### PR TITLE
s110 : examples of setting up GCP as terraform state backend

### DIFF
--- a/.github/workflows/ci-terraform.yaml
+++ b/.github/workflows/ci-terraform.yaml
@@ -1,7 +1,11 @@
 name: CI - infra (terraform)
 
 on:
-  [push]
+  push:
+    branches:
+      - '**' # should match all branches
+    tags-ignore:
+      - '**' # all tags; actually, believe this is default behavior when you specify filter for branches but not tags
 
 jobs:
   validate:

--- a/.github/workflows/ci-terraform.yaml
+++ b/.github/workflows/ci-terraform.yaml
@@ -23,3 +23,21 @@ jobs:
         run: |
           terraform init
           terraform validate
+
+      - name: 'Terraform - validate example-google-workspace'
+        working-directory: infra/example-google-workspace
+        run: |
+          terraform init
+          terraform validate
+
+     - name: 'Terraform - validate example-gcp-simple'
+       working-directory: infra/example-gcp-simple
+       run: |
+         terraform init
+         terraform validate
+
+     - name: 'Terraform - validate example-gcp-cft'
+       working-directory: infra/example-gcp-cft
+       run: |
+         terraform init
+         terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,15 @@ hs_err_pid*
 # Maven modules --> IntelliJ modules doesn't result in nice hierarchy (only shows leaves)
 
 
-# ignore terraform variables / state for developers' personal development environmenst
-infra/dev-personal/terraform.tfvars
-infra/dev-personal/.terraform**
-infra/dev-personal/terraform.tfstate**
+# ignore terraform variables / state for developers' personal development environments and other examples
+infra/*/terraform.tfvars
+infra/*/.terraform**
+infra/*/terraform.tfstate**
+infra/*/TODO*
+
+# ignore sa key file(s)
 infra/dev-personal/*connector-sa-key.json
-infra/dev-personal/TODO*
+
 
 java/target
 java/**/target

--- a/infra/example-bootstrap-gcp-cft/README.md
+++ b/infra/example-bootstrap-gcp-cft/README.md
@@ -1,0 +1,23 @@
+# example-bootstrap-gcp-cft
+
+This is an example configuration of [terraform-google-bootstrap](https://registry.terraform.io/modules/terraform-google-modules/bootstrap/google/latest)
+- the official, as sanction by Google + Hashicorp, toolkit for this purpose.
+
+Our example exposes a subset of variables to configure; you can edit `main.tf` to set more.
+
+
+Worklytics offers a somewhat simplified alternative in `modules/gcp-bootstrap` which may be
+sufficient for your purposes - as well as simpler to configure.
+
+We make no endorsement of either as being appropriate for your use-case. Please review both, the
+modules on which they depend, and decide what best meets your needs - if any. YMMV
+
+
+## Known Issues
+
+  - As of Nov 2021, this does NOT run on M1-based Macbooks (eg, `darwin-arm64`) - as has dependencies
+which are not available for that platform.
+
+
+
+

--- a/infra/example-bootstrap-gcp-cft/main.tf
+++ b/infra/example-bootstrap-gcp-cft/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    google = {
+      version = ">= 3.74, <= 4.0"
+    }
+  }
+
+  backend "local" {
+  }
+}
+
+# see: https://registry.terraform.io/modules/terraform-google-modules/bootstrap/google/latest
+module "bootstrap" {
+  source  = "terraform-google-modules/bootstrap/google"
+  version = "~> 4.0.0"
+
+  org_id                     = var.org_id
+  billing_account            = var.billing_account
+  group_org_admins           = var.group_org_admins
+  group_billing_admins       = var.group_billing_admins
+  default_region             = var.default_region
+  encrypt_gcs_bucket_tfstate = true # just recommended, but change if you want ...
+}
+
+resource "local_file" "todo" {
+  filename = "TODO - terraform backend.md"
+  content = <<EOT
+Ensure the `terraform` block at the top of your Terraform configuration is something like following:
+
+```terraform
+terraform {
+  required_providers {
+    google = {
+      version = "~> 4.0.0"
+    }
+  }
+  backend "gcs" {
+    bucket = "${module.bootstrap.gcs_bucket_tfstate.value}"
+    prefix = "terraform_state"
+    impersonate_service_account = "${module.bootstrap.terraform_sa_email.value}"
+  }
+}
+
+provider "google" {
+  project                     = "${module.bootstrap.seed_project_id.value}
+  impersonate_service_account = "${module.bootstrap.terraform_sa_email.value}"
+}
+```
+EOT
+}

--- a/infra/example-bootstrap-gcp-cft/variables.tf
+++ b/infra/example-bootstrap-gcp-cft/variables.tf
@@ -1,0 +1,26 @@
+variable "org_id" {
+  type        = string
+}
+variable "billing_account" {
+  type        = string
+}
+
+variable "group_org_admins" {
+  type        = string
+  description = "Google group of org admins"
+}
+
+variable "group_billing_admins" {
+  type        = string
+  description = "Google group of billing admins"
+}
+
+variable "project_id" {
+  type        = string
+  description = "id of GCP project to hold Terraform state"
+}
+
+variable "default_region" {
+  type     = string
+  default = "us-central1"
+}

--- a/infra/example-bootstrap-gcp-simple/main.tf
+++ b/infra/example-bootstrap-gcp-simple/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    google = {
+      version = ">= 3.74, <= 4.0"
+    }
+  }
+
+  backend "local" {
+  }
+}
+
+# see: https://registry.terraform.io/modules/terraform-google-modules/bootstrap/google/latest
+module "bootstrap" {
+  source  = "../modules/gcp-bootstrap"
+
+  project_id            = var.project_id
+  project_name          = var.project_name
+  bucket_labels         = var.bucket_labels
+  project_labels        = var.project_labels
+  kms_resource_location = var.kms_resource_location
+  storage_location      = var.storage_location
+}

--- a/infra/example-bootstrap-gcp-simple/variables.tf
+++ b/infra/example-bootstrap-gcp-simple/variables.tf
@@ -1,0 +1,34 @@
+variable "project_name" {
+  type        = string
+  description = "name to give to GCP project"
+  default     = null
+}
+
+variable "project_id" {
+  type        = string
+  description = "id of GCP project to hold Terraform state"
+}
+
+variable "kms_resource_location" {
+  type        = string
+  description = "location in which Cloud KMS key rings (and keys) should reside (see https://cloud.google.com/kms/docs/locations)"
+  default     = "us" # recommended alternatives: global, europe
+}
+
+variable "storage_location" {
+  type        = string
+  description = "location in which Cloud Storage buckets should reside (see https://cloud.google.com/storage/docs/locations)"
+  default     = "US" # recommended alternatives : EU, ASIA
+}
+
+variable "project_labels" {
+  type        = map(string)
+  description = "labels to assign to project"
+  default     = {}
+}
+
+variable "bucket_labels" {
+  type        = map(string)
+  description = "labels to assign to bucket"
+  default     = {}
+}

--- a/infra/modules/gcp-bootstrap/README.md
+++ b/infra/modules/gcp-bootstrap/README.md
@@ -1,0 +1,55 @@
+# gcp-bootstrap
+
+This bootstraps infra needed to use Terraform using a GCS bucket as the backend, including:
+  - encryption key for the bucket
+  - the bucket itself
+
+This is a simplified alternative to [terraform-google-bootstrap](https://registry.terraform.io/modules/terraform-google-modules/bootstrap/google/latest),
+which provides more functionality and produces a setup more aligned to GCP best practices - at the
+expense of more complexity.
+
+This should be executed by a sufficiently privileged GCP user.  Alternatively, you can use the
+Terraform code as a guide to create the resources directly via GCP console.
+
+NOTE: as this is intended to bootstrap GCP infra for storing Terrafrom state, its own state will
+be written to your local file system. You could commit this state to a code repository if you wish,
+or, given its simplicity, discard it and re-import in the future if needed.
+
+If you execute this Terraform module again with the same variables as the same user, it should NOT
+overwrite or cause any disruptions to the previously existing infrastructure - it will simply error
+as the project, bucket, keys, etc already exist (and GCP does not allow names of these to be
+re-used). It should be simple enough to use the error messages as guide to `terraform import` all
+the pre-existing stuff, and thus reconstitute a state from a prior execution.
+
+
+## Usage
+
+Create a variables file named `terraform.tfvars` with the following content, customized for your
+needs (review `variables.tf` for optional variables that you might find useful to define):
+
+```terraform
+project_id=your-project-id
+```
+
+Initialize your configuration:
+```shell
+terraform init
+```
+
+If the project you intend to use already exists, import it:
+```shell
+terraform import google_project.project {{your-project-id}}
+```
+
+Apply your Terraform config:
+```shell
+terraform apply
+```
+
+Look for a TODO file which should have been created; this will include the necessary Terraform code
+which you should add to the `main.tf` file of your Psoxy terraform config (which will be a different
+root module than this one).
+
+You'll need to run another `terraform init` again at the root of your Psoxy terraform config. If you
+previously used that config with a backend *other* than this GCS one, that init command should
+prompt you to confirm that you wish to move it.

--- a/infra/modules/gcp-bootstrap/main.tf
+++ b/infra/modules/gcp-bootstrap/main.tf
@@ -1,0 +1,55 @@
+
+resource "google_project" "project" {
+  name       = coalesce(var.project_name, var.project_id)
+  project_id = var.project_id
+  labels     = var.project_labels
+}
+
+resource "google_kms_key_ring" "ring" {
+  project  = var.project_id
+  location = var.kms_resource_location
+  name     = "keys"
+}
+
+resource "google_kms_crypto_key" "terraform-state" {
+  key_ring = google_kms_key_ring.ring.id
+  location = var.kms_resource_location
+  name     = "terraform-state-key"
+}
+
+resource "google_storage_bucket" "state_bucket" {
+  name                        = "psoxy-terraform-state"
+  uniform_bucket_level_access = true  # good practice
+  labels                      = var.bucket_labels
+  location                    = var.storage_location
+
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.terraform-state.name
+  }
+}
+
+resource "local_file" "todo" {
+  filename = "TODO - terraform backend.md"
+  content = <<EOT
+Ensure the `terraform` block at the top of your Terraform configuration is something like following:
+```terraform
+terraform {
+  required_providers {
+    google = {
+      version = "~> 4.0.0"
+    }
+  }
+  backend "gcs" {
+    bucket = "${google_storage_bucket.state_bucket.name}"
+    prefix = "terraform_state"
+  }
+}
+```
+EOT
+}
+
+
+# NOTE: outputs aligned to https://registry.terraform.io/modules/terraform-google-modules/bootstrap/google/latest
+output "gcs_bucket_tfstate" {
+  value = google_storage_bucket.state_bucket.name
+}

--- a/infra/modules/gcp-bootstrap/variables.tf
+++ b/infra/modules/gcp-bootstrap/variables.tf
@@ -1,0 +1,35 @@
+variable "project_name" {
+  type        = string
+  description = "name to give to GCP project"
+  default     = null
+}
+
+variable "project_id" {
+  type        = string
+  description = "id of GCP project to hold Terraform state"
+}
+
+variable "kms_resource_location" {
+  type        = string
+  description = "location in which Cloud KMS key rings (and keys) should reside (see https://cloud.google.com/kms/docs/locations)"
+  default     = "us" # recommended alternatives: global, europe
+}
+
+variable "storage_location" {
+  type        = string
+  description = "location in which Cloud Storage buckets should reside (see https://cloud.google.com/storage/docs/locations)"
+  default     = "US" # recommended alternatives : EU, ASIA
+}
+
+
+variable "project_labels" {
+  type        = map(string)
+  description = "labels to assign to project"
+  default     = {}
+}
+
+variable "bucket_labels" {
+  type        = map(string)
+  description = "labels to assign to bucket"
+  default     = {}
+}


### PR DESCRIPTION
### Features
 - [example of using a GCS bucket, with CMEK, to store your state](https://app.asana.com/0/1201039336231823/1201367423324936/f)

### Change implications

 - dependencies added/changed? **yes** -- various terraform modules, most critically google/hashicorp bootstrap  : https://registry.terraform.io/modules/terraform-google-modules/bootstrap/google/latest
