### PR TITLE
S110 deploy improvements

### DIFF
--- a/infra/dev-personal/main.tf
+++ b/infra/dev-personal/main.tf
@@ -42,6 +42,9 @@ module "gmail-connector" {
   apis_consumed                = [
     "gmail.googleapis.com"
   ]
+  oauth_scopes_needed          = [
+    "https://www.googleapis.com/auth/gmail.metadata"
+  ]
 
   depends_on = [
     module.psoxy-gcp
@@ -94,7 +97,9 @@ module "google-chat-connector" {
   apis_consumed                = [
     "admin.googleapis.com"
   ]
-
+  oauth_scopes_needed          = [
+    "https://www.googleapis.com/auth/admin.reports.audit.readonly"
+  ]
   depends_on = [
     module.psoxy-gcp
   ]

--- a/infra/dev-personal/main.tf
+++ b/infra/dev-personal/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      version = "~> 4.0.0"
+      version = ">= 3.74, <= 4.0"
     }
   }
 

--- a/infra/example-google-workspace/main.tf
+++ b/infra/example-google-workspace/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      version = "~> 3.74.0"
+      version = ">= 3.74, <= 4.0"
     }
   }
 

--- a/infra/example-google-workspace/main.tf
+++ b/infra/example-google-workspace/main.tf
@@ -46,11 +46,24 @@ locals {
       apis_consumed: [
         "admin.googleapis.com"
       ]
+      oauth_scopes_needed: [
+        "https://www.googleapis.com/auth/admin.directory.user.readonly",
+        "https://www.googleapis.com/auth/admin.directory.user.alias.readonly",
+        "https://www.googleapis.com/auth/admin.directory.domain.readonly",
+        "https://www.googleapis.com/auth/admin.directory.group.readonly",
+        "https://www.googleapis.com/auth/admin.directory.group.member.readonly",
+        "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
+        "https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"
+      ]
     }
     "gcal": {
       display_name: "Google Calendar"
       apis_consumed: [
         "calendar-json.googleapis.com"
+      ]
+      oauth_scopes_needed: [
+        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/calendar.settings.readonly"
       ]
     }
     "gmail": {
@@ -58,11 +71,17 @@ locals {
       apis_consumed: [
         "gmail.googleapis.com"
       ]
+      oauth_scopes_needed: [
+        "https://www.googleapis.com/auth/gmail.metadata"
+      ]
     }
     "google-chat": {
       display_name: "Google Chat"
       apis_consumed: [
         "admin.googleapis.com"
+      ]
+      oauth_scopes_needed: [
+        "https://www.googleapis.com/auth/admin.reports.audit.readonly"
       ]
     }
     "gdrive": {
@@ -70,11 +89,17 @@ locals {
       apis_consumed: [
         "drive.googleapis.com"
       ]
+      oauth_scopes_needed: [
+        "https://www.googleapis.com/auth/drive.metadata.readonly"
+      ]
     }
     "google-meet": {
       display_name: "Google Meet"
       apis_consumed: [
         "admin.googleapis.com"
+      ]
+      oauth_scopes_needed: [
+        "https://www.googleapis.com/auth/admin.reports.audit.readonly"
       ]
     }
   }

--- a/infra/modules/gcp-psoxy-cloud-function/main.tf
+++ b/infra/modules/gcp-psoxy-cloud-function/main.tf
@@ -29,6 +29,7 @@ gcloud beta functions deploy ${var.function_name} \
     --runtime=java11 \
     --entry-point=co.worklytics.psoxy.Route \
     --trigger-http \
+    --security-level=secure-always \
     --source=target/deployment \
     --service-account=${var.service_account_email} \
     --env-vars-file=configs/${var.source_kind}.yaml \

--- a/infra/modules/gcp-psoxy-cloud-function/main.tf
+++ b/infra/modules/gcp-psoxy-cloud-function/main.tf
@@ -16,16 +16,27 @@ locals {
 resource "local_file" "todo" {
   filename = "TODO - deploy ${var.function_name}.md"
   content  = <<EOT
-First, run `mvn package install` from `java/core/` within a checkout of the Psoxy repo.
+First, from `java/core/` within a checkout of the Psoxy repo, package the core proxy library:
 
-Second, package the GCP implementation: run `mvn package` from `java/impl/gcp` within a checkout of
-the psoxy repo).
+```shell
+cd ../../java/core
+mvn package install
+```
+
+Second, from `java/impl/gcp` within a checkout of the Psoxy repo, package an executable JAR for the
+cloud function with the following command:
+
+```shell
+cd ../../java/impl/gcp
+mvn package
+```
 
 Third, run the following deployment command from `java/impl/gcp` folder within your checkout:
 
 ```shell
-gcloud functions deploy ${var.function_name} \
+gcloud beta functions deploy ${var.function_name} \
     --project=${var.project_id} \
+    --region=${var.region} \
     --runtime=java11 \
     --entry-point=co.worklytics.psoxy.Route \
     --trigger-http \
@@ -36,11 +47,19 @@ gcloud functions deploy ${var.function_name} \
     --set-secrets '${join(",", local.secret_clauses)}'
 ```
 
-and if you want to test from your local machine:
+Finally, review the deployed Cloud function in GCP console:
+
+https://console.cloud.google.com/functions/details/${var.region}/${var.function_name}?project=${var.project_id}
+
+## Testing
+
+If you want to test from your local machine:
 ```shell
 export PSOXY_GCP_PROJECT=${var.project_id}
-export PSOXY_GCP_REGION=us-central1
+export PSOXY_GCP_REGION=${var.region}
 ```
+
+
 
 EOT
 }

--- a/infra/modules/gcp-psoxy-cloud-function/main.tf
+++ b/infra/modules/gcp-psoxy-cloud-function/main.tf
@@ -24,7 +24,7 @@ the psoxy repo).
 Third, run the following deployment command from `java/impl/gcp` folder within your checkout:
 
 ```shell
-gcloud beta functions deploy ${var.function_name} \
+gcloud functions deploy ${var.function_name} \
     --project=${var.project_id} \
     --runtime=java11 \
     --entry-point=co.worklytics.psoxy.Route \

--- a/infra/modules/gcp-psoxy-cloud-function/variables.tf
+++ b/infra/modules/gcp-psoxy-cloud-function/variables.tf
@@ -3,6 +3,12 @@ variable "project_id" {
   description = "name of the gcp project"
 }
 
+variable "region" {
+  type        = string
+  description = "region into which to deploy function"
+  default     = "us-central1"
+}
+
 variable "function_name" {
   type        = string
   description = "name of cloud function"

--- a/infra/modules/google-workspace-dwd-connection/main.tf
+++ b/infra/modules/google-workspace-dwd-connection/main.tf
@@ -21,25 +21,18 @@ resource "google_project_service" "apis_needed" {
 }
 
 
-# enable domain-wide-delegation via GCP console
-# NOTE: side effect of enabling domain-wide-delegation is that an "OAuth 2.0 Client ID" will be
-# created for the service account and listed in GCP Console
-# TODO: specify the following step in in terraform once https://github.com/hashicorp/terraform-provider-google/issues/1959 solved
-resource "local_file" "todo" {
+# enable domain-wide-delegation via Google Workspace Admin console
+resource "local_file" "todo-google-workspace-admin-console" {
   filename = "TODO - ${var.display_name} setup.md"
   content  = <<EOT
-Complete the following steps via GCP console:
-  1. Visit https://console.cloud.google.com/apis/credentials?project=${var.project_id}
-  2. Find the `${var.connector_service_account_id}` service account.
-  3. Enable 'Domain-wide Delegation' and 'Save'. This provisions an 'Oauth 2.0 client' for the
-     service account. Copy the Client ID of that client.
-
 Complete the following steps via the Google Workspace Admin console:
    1. Visit https://admin.google.com/ and navigate to Security --> API Controls, then find "Manage
       Domain Wide Delegation". Click "Add new"
-   2. Copy and paste the client ID from the prior section into the "Client ID" input in the popup.
-   3. Copy and paste the scopes for your data source (see `java/configs/`, and find the `SCOPE`
-      variable in the yaml file that matches your source) into the "Scopes" input.
+   2. Copy and paste client ID `${google_service_account.connector-sa.unique_id}` into the "Client ID" input in the popup.
+   3. Copy and paste the following OAuth 2.0 scope string into the "Scopes" input:
+```
+${join(",", var.oauth_scopes_needed)}
+```
    4. Authorize it.
 
 With this, your psoxy instance should be able to authenticate with Google as `${var.connector_service_account_id}`

--- a/infra/modules/google-workspace-dwd-connection/variables.tf
+++ b/infra/modules/google-workspace-dwd-connection/variables.tf
@@ -24,4 +24,9 @@ variable "apis_consumed" {
   description = "APIs to be used for this connection (Eg, 'gmail.googleapis.com')"
 }
 
+variable "oauth_scopes_needed" {
+  type        = list(string)
+  description = "oauth scopes that connector SA must be granted"
+  default     = []
+}
 


### PR DESCRIPTION
some improvements after this AM's customer setup

### Features
  - only allow https calls to proxy function - just seems like a good idea
  - parameterize region
  - [better Google Workspace Connector TODOs for proxy](https://app.asana.com/0/1201039336231823/1201383732183828/f)
  

### Change implications

 - dependencies added/changed? **yes** - go to Google 4.0.0+ by default
