### PR TITLE
s110: Slack allow API method

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -13,6 +13,7 @@ import static co.worklytics.psoxy.Rules.Rule;
 public class PrebuiltSanitizerRules {
 
     static final Rules SLACK = Rules.builder()
+        .allowedEndpointRegex("^\\/api\\/discovery\\.enterprise\\.info(?:\\?.+)?")
         .allowedEndpointRegex("^\\/api\\/discovery\\.conversations\\.list(?:\\?.+)?")
         .allowedEndpointRegex("^\\/api\\/discovery\\.conversations\\.history(?:\\?.+)?")
         .allowedEndpointRegex("^\\/api\\/discovery\\.users\\.list(?:\\?.+)?")

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
@@ -28,6 +28,7 @@ public class SlackDiscoveryTests extends RulesBaseTestCase {
 
     @SneakyThrows
     @ValueSource(strings = {
+        "https://slack.com/api/discovery.enterprise.info",
         "https://slack.com/api/discovery.conversations.list#fragment", // fragments get discarded
         "https://slack.com/api/discovery.conversations.list",
         "https://slack.com/api/discovery.conversations.list?team=X&offset=Y&only_im=true",
@@ -49,7 +50,6 @@ public class SlackDiscoveryTests extends RulesBaseTestCase {
         "https://slack.com/api/discovery-conversations-history",
         "https://slack.com/api/discovery users list",
         // all the rest of the discovery methods
-        "https://slack.com/api/discovery.enterprise.info",
         "https://slack.com/api/discovery.user.info",
         "https://slack.com/api/discovery.user.conversations",
         "https://slack.com/api/discovery.conversations.recent",


### PR DESCRIPTION
Adds a new endpoint that must be reachable for org-wide installations to read all workspaces to later iterate on them.

### Features
- [slack ediscovery connector, extensible via proxy ](https://app.asana.com/0/1201290353665663/1201109001473054)

### Change implications

 - dependencies added/changed? **no**
