### PR TITLE
s111 - jdk8 compatible version of the psoxy core

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -11,9 +11,38 @@
     </parent>
 
     <groupId>co.worklytics.psoxy</groupId>
-    <artifactId>psoxy-core</artifactId>
+    <artifactId>psoxy-core${artifactSuffix}</artifactId>
     <packaging>jar</packaging>
     <description>Code that's core to both Psoxy clients and implementations</description>
+
+    <properties>
+        <!-- empty for java 11 builds -->
+        <artifactSuffix></artifactSuffix>
+    </properties>
+
+    <!-- generates a jdk8 compatible jar -->
+    <!-- mvn clean install -P dev -->
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <artifactSuffix>-jdk8</artifactSuffix>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.1</version>
+                        <configuration>
+                            <source>8</source>
+                            <target>8</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,8 +11,6 @@
 
     <properties>
         <revision>1.0-SNAPSHOT</revision>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
         <dependency.jackson.version>2.12.5</dependency.jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.lombok.version>1.18.20</dependency.lombok.version>
@@ -27,7 +25,15 @@
 
     <build>
         <plugins>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
Maven configuration to build a jdk8 compatible psoxy-core to use with our jdk8 projects

### Features
- [java8 maven build profile for psoxy-core artifact](Search.1201449695753355_search_1201460785569618)

### Change implications

 - dependencies added/changed? **no**
