### PR TITLE
S113 aws test call

### DIFF
--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -162,6 +162,7 @@ module "psoxy-google-workspace-connector" {
   path_to_function_zip = "../../../java/impl/aws/target/psoxy-aws-1.0-SNAPSHOT.jar"
   path_to_config       = "../../../configs/${each.key}.yaml"
   api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
+  aws_assume_role_arn  = var.aws_assume_role_arn
 
   parameter_bindings   = {
     PSOXY_SALT          = module.psoxy-aws.salt_secret

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -172,7 +172,13 @@ TBD
 
 ## Testing
 
-If you want to test from your local machine: (WIP, YMMV)
+Requests to AWS API need to be [signed](https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html).
+One tool to do it easily is [awscurl](https://github.com/okigan/awscurl). Install it:
+
+```shell
+pip install awscurl
+```
+
 ```shell
 export PSOXY_HOST=${var.api_gateway.api_endpoint}/live/${var.function_name}
 aws sts assume-role --role-arn ${var.api_caller_role_arn} --role-session-name ${var.function_name}_local_test --output json > token.json
@@ -181,7 +187,10 @@ export AWS_SECRET_ACCESS_KEY=`cat token.json| jq -r '.Credentials.SecretAccessKe
 export AWS_SESSION_TOKEN=`cat token.json| jq -r '.Credentials.SessionToken'`
 # TODO: set meaningful paths per integration
 export PSOXY_PATH=/admin/directory/v1/customer/my_customer/domains
-curl --aws-sigv4 "aws:amz:us-east-1" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" $PSOXY_HOST/$PSOXY_PATH -v
+
+awscurl -v -i --service execute-api --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY --security_token $AWS_SESSION_TOKEN $PSOXY_HOST$PSOXY_PATH
+
+rm token.json
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 ```
 

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -165,8 +165,14 @@ TBD
 If you want to test from your local machine: (WIP, YMMV)
 ```shell
 export PSOXY_HOST=${var.api_gateway.api_endpoint}/live/${var.function_name}
-aws sts assume-role --role-arn ${var.api_caller_role_arn} --role-session-name ${var.function_name}_local_test --output json > token.jsonexport AWS_ACCESS_KEY=`cat token.json | jq -r .Credentials.AccessKeyId`:`cat token.json | jq -r .Credentials.SecretAccessKey`
-curl --aws-sigv4 "aws:amz:${var.region}:apigateway" --user $AWS_ACCESS_KEY $PSOXY_HOST/admin/directory/v1/customer/my_customer/domains
+aws sts assume-role --role-arn ${var.api_caller_role_arn} --role-session-name ${var.function_name}_local_test --output json > token.json
+export AWS_ACCESS_KEY_ID=`cat token.json| jq -r '.Credentials.AccessKeyId'`
+export AWS_SECRET_ACCESS_KEY=`cat token.json| jq -r '.Credentials.SecretAccessKey'`
+export AWS_SESSION_TOKEN=`cat token.json| jq -r '.Credentials.SessionToken'`
+# TODO: set meaningful paths per integration
+export PSOXY_PATH=/admin/directory/v1/customer/my_customer/domains
+curl --aws-sigv4 "aws:amz:us-east-1" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" $PSOXY_HOST/$PSOXY_PATH -v
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 ```
 
 NOTE: if you want to customize the rule set used by Psoxy for your source, you can add a

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -65,16 +65,6 @@ resource "aws_iam_role" "iam_for_lambda" {
       }
     ]
   })
-  /* needed?
-  {
-        "Action": "sts:AssumeRole",
-        "Principal": {
-          "Service": "apigateway.amazonaws.com"
-        },
-        "Effect": "Allow",
-        "Sid": ""
-      }
-      */
 }
 
 resource "aws_lambda_function" "psoxy-instance" {

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -142,7 +142,7 @@ mvn package
 Third, run the following deployment command from `java/impl/aws` folder within your checkout:
 
 ```shell
-aws sts assume-role --duration 180 --role-arn ${var.aws_assume_role_arn} --role-session-name deploy-lambda > temporal-credentials.json
+aws sts assume-role --duration 900 --role-arn ${var.aws_assume_role_arn} --role-session-name deploy-lambda > temporal-credentials.json
 export AWS_ACCESS_KEY_ID=`cat temporal-credentials.json| jq -r '.Credentials.AccessKeyId'`
 export AWS_SECRET_ACCESS_KEY=`cat temporal-credentials.json| jq -r '.Credentials.SecretAccessKey'`
 export AWS_SESSION_TOKEN=`cat temporal-credentials.json| jq -r '.Credentials.SessionToken'`

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -65,6 +65,16 @@ resource "aws_iam_role" "iam_for_lambda" {
       }
     ]
   })
+  /* needed?
+  {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+          "Service": "apigateway.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+      }
+      */
 }
 
 resource "aws_lambda_function" "psoxy-instance" {

--- a/infra/modules/aws-psoxy-instance/variables.tf
+++ b/infra/modules/aws-psoxy-instance/variables.tf
@@ -10,6 +10,11 @@ variable "function_name" {
   description = "name of function"
 }
 
+variable "aws_assume_role_arn" {
+  type        = string
+  description = "role arn"
+}
+
 variable "source_kind" {
   type        = string
   description = "kind of source (eg, 'gmail', 'google-chat', etc)"

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -49,15 +49,6 @@ resource "aws_iam_role" "api-caller" {
         #    "sts:ExternalId" : var.caller_aws_user_id
         #  }
         #}
-      },
-      # https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html
-      {
-        "Sid": "",
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "apigateway.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
       }
     ]
   })
@@ -71,53 +62,11 @@ resource "aws_iam_role" "api-caller" {
         {
           "Effect": "Allow",
           "Action": "execute-api:Invoke",
-          # "Resource": "arn:aws:execute-api:*:${var.aws_account_id}:*/*/GET/*",
-          "Resource": "arn:aws:execute-api:*:${var.aws_account_id}:*",
+          "Resource": "arn:aws:execute-api:*:${var.aws_account_id}:*/*/GET/*",
         }
       ]
     })
   }
-  managed_policy_arns = [
-    # I think this was created when creating the role from
-    # https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html
-    "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
-  ]
-  # not sure about this one
-  inline_policy {
-    name = "read-gateway"
-    policy = jsonencode({
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "apigateway:GET"
-          ],
-          "Resource": [
-            "arn:aws:apigateway:us-east-1::/apis/${var.aws_account_id}/*"
-          ]
-        }
-      ]
-    })
-  }
-  inline_policy {
-    name = "sns-list-topics"
-    policy = jsonencode({
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Resource": [
-            "*"
-          ],
-          "Action": [
-            "sns:ListTopics"
-          ]
-        }
-      ]
-    })
-  }
-
 }
 
 # pseudo secret

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -29,11 +29,6 @@ resource "aws_apigatewayv2_stage" "live" {
   }
 }
 
-resource "aws_iam_role_policy" "" {
-  policy = ""
-  role   = aws_iam_role.api-caller.id
-}
-
 # role that Worklytics user will use to call the API
 resource "aws_iam_role" "api-caller" {
   name = "PsoxyApiCaller"
@@ -54,24 +49,40 @@ resource "aws_iam_role" "api-caller" {
         #    "sts:ExternalId" : var.caller_aws_user_id
         #  }
         #}
+      },
+      # https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html
+      {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "apigateway.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
       }
     ]
   })
 
   # what this role can do (invoke anything in the API gateway )
   inline_policy {
-    name = "invoke"
+    name = "lambda-invoker"
     policy = jsonencode({
       "Version" : "2012-10-17",
       "Statement" : [
         {
           "Effect": "Allow",
           "Action": "execute-api:Invoke",
-          "Resource": "arn:aws:execute-api:*:${var.aws_account_id}:*/*/GET/*",
+          # "Resource": "arn:aws:execute-api:*:${var.aws_account_id}:*/*/GET/*",
+          "Resource": "arn:aws:execute-api:*:${var.aws_account_id}:*",
         }
       ]
     })
   }
+  managed_policy_arns = [
+    # I think this was created when creating the role from
+    # https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html
+    "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+  ]
+  # not sure about this one
   inline_policy {
     name = "read-gateway"
     policy = jsonencode({
@@ -84,6 +95,23 @@ resource "aws_iam_role" "api-caller" {
           ],
           "Resource": [
             "arn:aws:apigateway:us-east-1::/apis/${var.aws_account_id}/*"
+          ]
+        }
+      ]
+    })
+  }
+  inline_policy {
+    name = "sns-list-topics"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Resource": [
+            "*"
+          ],
+          "Action": [
+            "sns:ListTopics"
           ]
         }
       ]

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -9,3 +9,8 @@ variable "caller_aws_user_id" {
   type        = string
   description = "id of service account that will call proxy (eg, SA of your worklytics instance)"
 }
+
+variable "aws_account_id" {
+  type        = string
+  description = "account id of the organization"
+}


### PR DESCRIPTION
I believe `curl --aws-sigv4` doesn't work on asummed roles. Inspecting headers I found out it was not generating the signature properly. I found out this tool [awscurl](https://github.com/okigan/awscurl) that performs the signature in python and works. Some policies needed to be tweaked.

### Features
 - [Invoke from local via CURL](https://app.asana.com/0/1201637024614734/1201614440806034)

### Change implications

 - dependencies added/changed? **not to the project** (install awscurl if local tests wants to be performed)
