### PR TITLE
s115 : terraform module to make grant; example invocation

### DIFF
--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -144,3 +144,16 @@ module "psoxy-msft-connector" {
     ]
   )
 }
+
+# grant required permissions to connectors via Azure AD
+# (requires terraform configuration being applied by an Azure User with privelleges to do this; it
+#  usually requires a 'Global Administrator' for your tenant)
+module "msft_365_grants" {
+  for_each = local.msft_sources
+
+  source = "../../modules/azuread-grant-all-users"
+
+  application_id           = module.msft-connection[each.key].connector.application_id
+  oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
+  app_roles                = each.value.required_app_roles
+}

--- a/infra/modules/azuread-grant-all-users/main.tf
+++ b/infra/modules/azuread-grant-all-users/main.tf
@@ -19,10 +19,16 @@ resource "azuread_service_principal" "msgraph" {
 
 resource "azuread_service_principal" "connector" {
   application_id = var.application_id
+  use_existing   = true
 }
 
-resource "azuread_service_principal_delegated_permission_grant" "example" {
+locals {
+  oauth2_permission_scope_ids = [for name in var.oauth2_permission_scopes : azuread_service_principal.msgraph.oauth2_permission_scope_ids[name]]
+  app_role_ids                = [for name in var.app_roles : azuread_service_principal.msgraph.app_role_ids[name]]
+}
+
+resource "azuread_service_principal_delegated_permission_grant" "grant" {
   service_principal_object_id          = azuread_service_principal.connector.object_id
   resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
-  claim_values                         = [for permission in var.required_resource_access : permission.id ]
+  claim_values                         = concat(local.app_role_ids, local.oauth2_permission_scope_ids)
 }

--- a/infra/modules/azuread-grant-all-users/variables.tf
+++ b/infra/modules/azuread-grant-all-users/variables.tf
@@ -1,14 +1,14 @@
-
-variable "required_resource_access" {
-  type        = list(object({
-    id   = string,
-    type = string # usually 'Role', but possibly 'Scope'
-  }))
-
-  description  = "list of Azure AD OAuth2 permissions that connector requires"
-}
-
 variable "application_id" {
   type        = string
   description = "object ID of the Azure AD application to authorize"
+}
+
+variable "oauth2_permission_scopes" {
+  type        = list(string)
+  description = "names of OAuth2 Permission Scopes to grant to application for Microsoft Graph"
+}
+
+variable "app_roles" {
+  type        = list(string)
+  description = "names of Application Roles to grant to application for Microsoft Graph"
 }


### PR DESCRIPTION
### Features
  - use terraform to make the necessary permission grant via Azure AD for connectors

### Change implications
 - dependencies added/changed? **no**
