### PR TITLE
fix pseudonymization of 'null' properties

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerImpl.java
@@ -132,6 +132,11 @@ public class SanitizerImpl implements Sanitizer {
                     .delete(document, jsonConfiguration);
             }
 
+            //TODO: error handling within the map functions. any exceptions thrown within the map
+            //      function seem to be suppressed, and an empty [] left as the 'document'.
+            // ideas:
+            // jsonConfiguration.addEvaluationListeners(); -->
+
             for (JsonPath pseudonymization : pseudonymizationsToApply) {
                 document = pseudonymization
                     .map(document, this::pseudonymizeToJson, jsonConfiguration);
@@ -146,7 +151,6 @@ public class SanitizerImpl implements Sanitizer {
                 document = pseudonymization
                     .map(document, this::pseudonymizeWithOriginalToJson, jsonConfiguration);
             }
-
 
             return jsonConfiguration.jsonProvider().toJson(document);
         }
@@ -181,11 +185,15 @@ public class SanitizerImpl implements Sanitizer {
     }
 
 
-    public PseudonymizedIdentity pseudonymize(@NonNull Object value) {
+    public PseudonymizedIdentity pseudonymize(Object value) {
         return pseudonymize(value, false);
     }
 
-    public PseudonymizedIdentity pseudonymize(@NonNull Object value, boolean includeOriginal) {
+    public PseudonymizedIdentity pseudonymize(Object value, boolean includeOriginal) {
+        if (value == null) {
+            return null;
+        }
+
         Preconditions.checkArgument(value instanceof String || value instanceof Number,
             "Value must be some basic type (eg JSON leaf, not node)");
 
@@ -238,11 +246,11 @@ public class SanitizerImpl implements Sanitizer {
     }
 
     @VisibleForTesting
-    public String pseudonymizeToJson(@NonNull Object value, @NonNull Configuration configuration) {
+    public String pseudonymizeToJson(Object value, @NonNull Configuration configuration) {
         return configuration.jsonProvider().toJson(pseudonymize(value));
     }
 
-    public String pseudonymizeWithOriginalToJson(@NonNull Object value, @NonNull Configuration configuration) {
+    public String pseudonymizeWithOriginalToJson(Object value, @NonNull Configuration configuration) {
         return configuration.jsonProvider().toJson(pseudonymize(value, true));
     }
 

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
@@ -25,8 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * abstract test stuff for Rules implementations
@@ -45,6 +44,8 @@ abstract public class RulesBaseTestCase {
     protected ObjectMapper yamlMapper;
     @Inject
     protected SanitizerFactory sanitizerFactory;
+    @Inject
+    protected RulesUtils rulesUtils;
 
 
 
@@ -130,6 +131,11 @@ abstract public class RulesBaseTestCase {
     @SneakyThrows
     protected String sanitize(String endpoint, String jsonResponse) {
         return this.sanitizer.sanitize(new URL(endpoint), jsonResponse);
+    }
+
+    protected void assertSha(String expectedSha) {
+        assertNotNull(expectedSha);
+        assertEquals(expectedSha, rulesUtils.sha(sanitizer.getOptions().getRules()));
     }
 
     protected void assertNotSanitized(String content, Collection<String> shouldContain) {

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/DirectoryTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/DirectoryTests.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.rules.msft;
 import co.worklytics.psoxy.Rules;
 import co.worklytics.psoxy.rules.JavaRulesTestBaseCase;
 import lombok.Getter;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -21,6 +22,14 @@ public class DirectoryTests extends JavaRulesTestBaseCase {
 
     @Getter
     final String yamlSerializationFilepath = "microsoft-365/directory";
+
+    @Disabled // not reliable; seems to have different value via IntelliJ/AWS deployment and my
+    // laptop's maven, which doesn't make any sense, given that binary deployed to AWS was built via
+    // maven on my laptop - so something about Surefire/Junit runner used by maven??
+    @Test
+    void sha() {
+        this.assertSha("7869e465607b7a00b4bd75a832a9ed1f811ce7f2");
+    }
 
     @Test
     void user() {
@@ -58,15 +67,18 @@ public class DirectoryTests extends JavaRulesTestBaseCase {
 
         Collection<String> PII = Arrays.asList(
             "john@worklytics.onmicrosoft.com",
-            "Paul Allen"
+            "Paul Allen",
+            "no-mail-example@worklytics.onmicrosoft.com"
         );
         assertNotSanitized(jsonString, PII);
 
         String sanitized = this.sanitize(endpoint, jsonString);
 
         assertPseudonymized(sanitized, "john@worklytics.onmicrosoft.com");
+        assertPseudonymized(sanitized, "no-mail-example@worklytics.onmicrosoft.com");
         assertRedacted(sanitized, "Paul Allen");
     }
+
 
     // case that ACTUALLY looks like what we call ...
     @Test

--- a/java/core/src/test/resources/api-response-examples/microsoft-365/directory/users.json
+++ b/java/core/src/test/resources/api-response-examples/microsoft-365/directory/users.json
@@ -67,6 +67,15 @@
       "preferredLanguage": "en-US",
       "surname": "Allen",
       "userPrincipalName": "Paul@worklytics.onmicrosoft.com"
+    },
+    {
+      "businessPhones": [],
+      "jobTitle": null,
+      "mail": null,
+      "officeLocation": null,
+      "preferredLanguage": null,
+      "userPrincipalName": "no-mail-example@worklytics.onmicrosoft.com",
+      "id": "232442306-9942-4750-a708-4a1e4fe8a879"
     }
   ]
 }


### PR DESCRIPTION
### Fixes
 - [azure ad proxy returning empty JSON array for users endpoint ](https://app.asana.com/0/1201991831825945/1202014631790084/f). - it's actually that the JsonPath implementation seems to blow up when applying a `MapFunction` to a JSON structure, if that function throws an exception. Resulting document after the map is `[]` though, instead of either throwing the error up OR just knocking out (or leaving unchanged) the input to the `MapFunction`.  This affected our test MSFT org, which has users without email addresses - so rules were pseudonymizing `null`, which was unexpected.

### Change implications

 - dependencies added/changed? **no**
