### PR TITLE
S121 more redactions

### DIFF
--- a/docs/example-api-calls/slack-discovery.md
+++ b/docs/example-api-calls/slack-discovery.md
@@ -46,9 +46,26 @@ export WORKSPACE_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.
 
 Next call operate on channels belonging to a workspace. Get an arbitrary channel in variable
 ```shell
-export CHANNEL_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.list?team=$WORKSPACE_ID\&limit=1 | jq -r '.channels[0].id'`
+# get a workspace channel
+export CHANNEL_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.list?team=$WORKSPACE_ID\&limit=10 | jq -r '.channels[0].id'`
+# or for a DM (no workspace)
+export CHANNEL_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.list?limit=10 | jq -r '.channels[0].id'`
 ```
 
 ```shell
 ./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.history?team=$WORKSPACE_ID\&channel=$CHANNEL_ID\&limit=10 | jq .
+# omit the workspace id if channel is a DM
+./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.history?channel=$CHANNEL_ID\&limit=10 | jq .
+```
+
+### Workspace Channel Info
+```shell
+./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.info?team=$WORKSPACE_ID\&channel=$CHANNEL_ID\&limit=1 | jq .
+# omit the workspace id if channel is a DM
+./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.info?channel=$CHANNEL_ID\&limit=1 | jq .
+```
+
+### Recent Workspace Conversations
+```shell
+./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.recent | jq .
 ```

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -73,13 +73,13 @@ public class CommonRequestHandler {
         URL targetUrl = buildTarget(request);
         String relativeURL = URLUtils.relativeURL(targetUrl);
 
-        boolean skipSanitizer = skipSanitization(request);
+        boolean skipSanitization = skipSanitization(request);
 
         HttpEventResponse.HttpEventResponseBuilder builder = HttpEventResponse.builder();
 
         this.sanitizer = loadSanitizerRules();
 
-        if (skipSanitization(request)) {
+        if (skipSanitization) {
             log.info(String.format("Proxy invoked with target %s. Skipping sanitization.", relativeURL));
         } else if (sanitizer.isAllowed(targetUrl)) {
             log.info(String.format("Proxy invoked with target %s. Rules allowed call.", relativeURL));
@@ -134,7 +134,7 @@ public class CommonRequestHandler {
 
         String proxyResponseContent;
         if (isSuccessFamily(sourceApiResponse.getStatusCode())) {
-            if (skipSanitizer) {
+            if (skipSanitization) {
                 proxyResponseContent = responseContent;
             }  else {
                 proxyResponseContent = sanitizer.sanitize(targetUrl, responseContent);

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -23,7 +23,8 @@ public class PrebuiltSanitizerRules {
         .redaction(Rule.builder()
             .relativeUrlRegex("\\/api\\/discovery\\.enterprise\\.info(?:\\?.+)?")
             // we don't care about names
-            .jsonPath("$.teams[*]['name','description','icon']")
+            .jsonPath("$.enterprise.teams[*]['name','description','icon','enterprise_name']")
+            .jsonPath("$.enterprise['icon','name']")
             .build()
         )
         // users

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -19,6 +19,13 @@ public class PrebuiltSanitizerRules {
         .allowedEndpointRegex("^\\/api\\/discovery\\.conversations\\.recent(?:\\?.+)?")
         .allowedEndpointRegex("^\\/api\\/discovery\\.conversations\\.info(?:\\?.+)?")
         .allowedEndpointRegex("^\\/api\\/discovery\\.users\\.list(?:\\?.+)?")
+        // enterprise info
+        .redaction(Rule.builder()
+            .relativeUrlRegex("\\/api\\/discovery\\.enterprise\\.info(?:\\?.+)?")
+            // we don't care about names
+            .jsonPath("$.teams[*]['name','description','icon']")
+            .build()
+        )
         // users
         .pseudonymization(Rule.builder()
             .relativeUrlRegex("\\/api\\/discovery\\.users\\.list(?:\\?.+)?")
@@ -78,6 +85,7 @@ public class PrebuiltSanitizerRules {
             // username is a variation of user, so just skip it to avoid references
             .jsonPath("$.messages[*]['text','username']")
             .jsonPath("$.messages[*]..['text']")
+            .jsonPath("$.messages[*].user_profile")
             .jsonPath("$.messages[*].attachments[*]['fallback','service_name']")
             .build()
         )

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/zoom/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/zoom/PrebuiltSanitizerRules.java
@@ -44,6 +44,7 @@ public class PrebuiltSanitizerRules {
         .redaction(Rule.builder()
             .relativeUrlRegex("\\/v2\\/users\\/(?:[^\\/]*)\\/meetings(?:\\?.+)?")
             .jsonPath("$.meetings[*].topic")
+            .jsonPath("$.meetings[*].join_url")
             .build()
         )
         // Meeting details

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
@@ -179,4 +179,21 @@ public class SlackDiscoveryTests extends RulesBaseTestCase {
             "project-y");
 
     }
+
+    @SneakyThrows
+    @Test
+    void discovery_enterprise_info() {
+        String jsonString = asJson("discovery-enterprise-info.json");
+
+        String sanitized =
+            sanitizer.sanitize(new URL("https://slack.com/api/discovery.enterprise.info"), jsonString);
+
+        assertRedacted(sanitized, "icon", "image",
+            "DevGrid - W1",
+            "1st Workspace under Test Grid",
+            "DevGrid - W2",
+            "2nd Workspace under Test Grid",
+            "Test Grid");
+
+    }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
@@ -138,6 +138,9 @@ public class SlackDiscoveryTests extends RulesBaseTestCase {
         assertRedacted(sanitized, "Test message!",
             "<@U06CA4EAC|bjin>",
             "text with rich block",
+            "Some new text",
+            "Jose (ENT)",
+            "Jose",
             "This is likely a pun about the weather.",
             "We're withholding a pun from you",
             "Leg end nary a laugh, Ink.");

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/zoom/ZoomRulesTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/zoom/ZoomRulesTests.java
@@ -104,10 +104,9 @@ public class ZoomRulesTests extends RulesBaseTestCase {
         String sanitized =
             sanitizer.sanitize(new URL("https://api.zoom.us/v2/users/ANY_USER_ID/meetings"), jsonString);
 
-        // nothing to pseudonymize
         assertPseudonymized(sanitized, PII);
-        // topics gone
-        assertRedacted(sanitized, "Zoom Meeting", "TestMeeting", "My Meeting", "MyTestPollMeeting");
+        // topics & join_urls gone
+        assertRedacted(sanitized, "https://zoom.us", "Zoom Meeting", "TestMeeting", "My Meeting", "MyTestPollMeeting");
     }
 
     @SneakyThrows

--- a/java/core/src/test/resources/api-response-examples/slack/discovery-conversations-history.json
+++ b/java/core/src/test/resources/api-response-examples/slack/discovery-conversations-history.json
@@ -74,6 +74,43 @@
           "id": 1
         }
       ]
+    },
+    {
+      "client_msg_id": "314a746d-82c0-4a05-a081-429e4c096c3f",
+      "type": "message",
+      "user": "W000000",
+      "ts": "1651249518.059679",
+      "team": "T02MT9XBJL9",
+      "user_team": "T02MT9XBJL9",
+      "source_team": "T02MT9XBJL9",
+      "user_profile": {
+        "avatar_hash": "g08564a648b3",
+        "image_72": "https://secure.gravatar.com/avatar/08564a648b3575b6be2b6ea1e2ab4370.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0017-72.png",
+        "first_name": "Jose",
+        "real_name": "Jose (ENT)",
+        "display_name": "Jose (ENT)",
+        "team": "T02MT9XBJL9",
+        "name": "jose",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+      },
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "qWw",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "Some new text"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "offset": "1463084600.000000"

--- a/java/core/src/test/resources/api-response-examples/slack/discovery-enterprise-info.json
+++ b/java/core/src/test/resources/api-response-examples/slack/discovery-enterprise-info.json
@@ -1,0 +1,80 @@
+{
+  "ok": true,
+  "enterprise": {
+    "id": "E02DW6UCECM",
+    "name": "Test Grid",
+    "url": "https://test-grid.enterprise.slack.com/",
+    "domain": "test-grid",
+    "email_domain": "",
+    "icon": {
+      "image_102": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-102.png",
+      "image_132": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-132.png",
+      "image_230": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-230.png",
+      "image_34": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-34.png",
+      "image_44": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-44.png",
+      "image_68": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-68.png",
+      "image_88": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0015-88.png",
+      "image_default": true
+    },
+    "avatar_base_url": "https://ca.slack-edge.com/",
+    "is_verified": false,
+    "teams": [
+      {
+        "id": "T02DZ7JEGBE",
+        "name": "DevGrid - W1",
+        "url": "https://testdevgrid-w1.slack.com/",
+        "domain": "testdevgrid-w1",
+        "email_domain": "",
+        "icon": {
+          "image_34": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_34.png",
+          "image_44": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_44.png",
+          "image_68": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_68.png",
+          "image_88": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_88.png",
+          "image_102": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_102.png",
+          "image_132": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_132.png",
+          "image_230": "https://avatars.slack-edge.com/2022-04-29/3454441179510_63fb7156cdaf2f6ca865_230.png"
+        },
+        "is_verified": false,
+        "archived": false,
+        "deleted": false,
+        "discoverable": "open",
+        "enterprise_id": "E02DW6UCECM",
+        "enterprise_domain": "test-grid",
+        "enterprise_name": "Test Grid",
+        "is_enterprise": 0,
+        "created": 1631224594,
+        "description": "1st Workspace under Test Grid"
+      },
+      {
+        "id": "T02MT9XBJL2",
+        "name": "DevGrid - W2",
+        "url": "https://testdevgridw2.slack.com/",
+        "domain": "testdevgridw2",
+        "email_domain": "",
+        "icon": {
+          "image_34": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-34.png",
+          "image_44": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-44.png",
+          "image_68": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-68.png",
+          "image_88": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-88.png",
+          "image_102": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-102.png",
+          "image_132": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-132.png",
+          "image_230": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0001-230.png",
+          "image_default": true
+        },
+        "is_verified": false,
+        "archived": false,
+        "deleted": false,
+        "discoverable": "open",
+        "enterprise_id": "E02DW6UCECM",
+        "enterprise_domain": "test-grid",
+        "enterprise_name": "Test Grid",
+        "is_enterprise": 0,
+        "created": 1637016788,
+        "description": "2nd Workspace under Test Grid"
+      }
+    ]
+  },
+  "response_metadata": {
+    "next_cursor": ""
+  }
+}


### PR DESCRIPTION
Add missing calls. 
Changes in the test-proxy.sh to pass a skip sanitization call, so easier to compare (if deployed in dev mode)

### Features

- [slack messages user_profile ](https://app.asana.com/0/0/1202204100399659)
- [slack workspaces name/description/icon ](https://app.asana.com/0/0/1202204100399668)
- [zoom list meetings.joinUrl](https://app.asana.com/0/0/1202204100399665)

### Change implications

 - dependencies added/changed? **no**
