### PR TITLE
Match function parameters namespace

### DIFF
--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -139,7 +139,7 @@ module "google-workspace-connection-auth" {
 
   secret_project     = var.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
-  secret_id          = "PSOXY_${each.key}_SERVICE_ACCOUNT_KEY"
+  secret_id          = "PSOXY_${replace(upper(each.key),"-","_")}_SERVICE_ACCOUNT_KEY"
 }
 module "psoxy-google-workspace-connector" {
   for_each = {

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -162,7 +162,7 @@ module "google-workspace-connection-auth" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.1.0-beta.1"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
-  secret_id          = "PSOXY_${upper(each.key)}_SERVICE_ACCOUNT_KEY"
+  secret_id          = "PSOXY_${replace(upper(each.key),"-","_")}_SERVICE_ACCOUNT_KEY"
 }
 
 module "psoxy-google-workspace-connector" {

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -141,7 +141,7 @@ module "google-workspace-connection-auth" {
 
   secret_project     = var.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
-  secret_id          = "PSOXY_${each.key}_SERVICE_ACCOUNT_KEY"
+  secret_id          = "PSOXY_${replace(upper(each.key),"-","_")}_SERVICE_ACCOUNT_KEY"
 }
 
 module "psoxy-google-workspace-connector" {


### PR DESCRIPTION
PSOXY_(function)_SERVICE_ACCOUNT_KEY parameters did not match with code, as namespace there transformed dashes into underscores. Apply same transformation in terraform files when creating the secrets.

### Fixes
- [PSOXY_*_SERVICE_ACCOUNT_KEY secrets do not match](https://app.asana.com/0/1202204100399673/1202221297340240)

### Change implications

 - dependencies added/changed? **no**
