### PR TITLE
S122 aws versions consistency

### DIFF
--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.11"
+      version = "~> 4.12"
     }
 
     # for API connections to Microsoft 365

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.2.0-beta.1"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -41,7 +41,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.2.0-beta.1"
 
   implementation     = "aws"
   path_to_psoxy_java = "../../../java"
@@ -143,7 +143,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.2.0-beta.1"
 
   project_id                   = google_project.psoxy-google-connectors.project_id
   connector_service_account_id = "psoxy-${each.key}"
@@ -160,7 +160,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.2.0-beta.1"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
   secret_id          = "PSOXY_${replace(upper(each.key),"-","_")}_SERVICE_ACCOUNT_KEY"
@@ -169,7 +169,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.2.0-beta.1"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.key
@@ -191,7 +191,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection-google-workspace" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.2.0-beta.1"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.12"
     }
 
     # for the API connections to Google Workspace

--- a/infra/examples/aws-hris/main.tf
+++ b/infra/examples/aws-hris/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.11"
+      version = "~> 4.12"
     }
   }
 

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -37,7 +37,7 @@ provider "azuread" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.2.0-beta.1"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -49,7 +49,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.2.0-beta.1"
 
   implementation     = "aws"
   path_to_psoxy_java = "../../../java"
@@ -121,7 +121,7 @@ locals {
 module "msft-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.2.0-beta.1"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -132,7 +132,7 @@ module "msft-connection" {
 module "msft-connection-auth" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.2.0-beta.1"
 
   application_object_id = module.msft-connection[each.key].connector.id
   rotation_days         = 60
@@ -161,7 +161,7 @@ resource "aws_ssm_parameter" "refresh_endpoint" {
 module "private-key-aws-parameters" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.2.0-beta.1"
 
   instance_id = each.key
 
@@ -172,7 +172,7 @@ module "private-key-aws-parameters" {
 module "psoxy-msft-connector" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.2.0-beta.1"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -198,7 +198,7 @@ module "psoxy-msft-connector" {
 module "msft_365_grants" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.2.0-beta.1"
 
   application_id           = module.msft-connection[each.key].connector.application_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
@@ -210,7 +210,7 @@ module "msft_365_grants" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.2.0-beta.1"
 
   psoxy_endpoint_url = module.psoxy-msft-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.12"
     }
 
     # for API connections to Microsoft 365

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.2.0-beta.1"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -40,7 +40,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.2.0-beta.1"
 
   implementation     = "aws"
   path_to_psoxy_java = "../../../java"
@@ -85,7 +85,7 @@ resource "aws_ssm_parameter" "long-access-token-secret" {
 module "aws-psoxy-long-auth-connectors" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.2.0-beta.1"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -106,7 +106,7 @@ module "aws-psoxy-long-auth-connectors" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.2.0-beta.1"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.12"
     }
   }
 

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -24,7 +24,7 @@ resource "google_project" "psoxy-project" {
 }
 
 module "psoxy-gcp" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.2.0-beta.1"
 
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
@@ -122,7 +122,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.2.0-beta.1"
 
   project_id                   = google_project.psoxy-project.project_id
   connector_service_account_id = "psoxy-${each.key}-dwd"
@@ -138,7 +138,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.2.0-beta.1"
 
   secret_project     = google_project.psoxy-project.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
@@ -148,7 +148,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.2.0-beta.1"
 
   project_id            = google_project.psoxy-project.project_id
   function_name         = "psoxy-${each.key}"
@@ -170,7 +170,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.1.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.2.0-beta.1"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].cloud_function_url
   display_name       = "${each.value.display_name} via Psoxy"

--- a/infra/modules/aws-bulk/main.tf
+++ b/infra/modules/aws-bulk/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.11"
+      version = "~> 4.12"
     }
   }
 }

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.11"
+      version = "~> 4.12"
     }
   }
 }

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.11"
+      version = "~> 4.12"
     }
   }
 }


### PR DESCRIPTION
Unify aws provider versioning across modules. Put all at latests.
Created release v0.2.0-beta.1 to have all modules in 4.1x (at least)

### Change implications

 - dependencies added/changed? **yes**: upgraded terraform versions to match 4.12
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202219382641143