### PR TITLE
S122 fix max policies

### DIFF
--- a/.github/workflows/ci-terraform.yaml
+++ b/.github/workflows/ci-terraform.yaml
@@ -25,59 +25,59 @@ jobs:
       - name: 'Terraform - validate examples/aws-google-workspace'
         working-directory: infra/examples/aws-google-workspace
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/aws-hris'
         working-directory: infra/examples/aws-hris
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/aws-msft-365'
         working-directory: infra/examples/aws-msft-365
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/aws-zoom-slack'
         working-directory: infra/examples/aws-zoom-slack
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/gcp-bootstrap-cft'
         working-directory: infra/examples/gcp-bootstrap-cft
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/gcp-bootstrap-simple'
         working-directory: infra/examples/gcp-bootstrap-simple
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/gcp-google-workspace'
         working-directory: infra/examples/gcp-google-workspace
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples/gcp-hris'
         working-directory: infra/examples/gcp-hris
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
-          
+
       - name: 'Terraform - validate examples-dev/gcp-google-workspace'
         working-directory: infra/examples-dev/gcp-google-workspace
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate
 
       - name: 'Terraform - validate examples-dev/aws-msft-365'
         working-directory: infra/examples-dev/aws-msft-365
         run: |
-          terraform init
+          terraform init -reconfigure
           terraform validate

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -52,7 +52,7 @@ module "psoxy-package" {
   source = "../../modules/psoxy-package"
 
   implementation     = "aws"
-  path_to_psoxy_java = "${var.psoxy_basedir}/java"
+  path_to_psoxy_java = "${var.psoxy_base_dir}/java"
 }
 
 data "azuread_client_config" "current" {}

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -52,7 +52,7 @@ module "psoxy-package" {
   source = "../../modules/psoxy-package"
 
   implementation     = "aws"
-  path_to_psoxy_java = "../../../java"
+  path_to_psoxy_java = "${var.psoxy_basedir}/java"
 }
 
 data "azuread_client_config" "current" {}
@@ -175,15 +175,15 @@ module "psoxy-msft-connector" {
 
   source = "../../modules/aws-psoxy-instance"
 
-  function_name        = "psoxy-${each.key}"
-  source_kind          = each.value.source_kind
-  path_to_function_zip = module.psoxy-package.path_to_deployment_jar
-  function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "../../../configs/${each.value.source_kind}.yaml"
-  api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
+  function_name            = "psoxy-${each.key}"
+  source_kind              = each.value.source_kind
+  path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
+  function_zip_hash        = module.psoxy-package.deployment_package_hash
+  path_to_config           = "../../../configs/${each.value.source_kind}.yaml"
+  api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
   api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
-  aws_assume_role_arn  = var.aws_assume_role_arn
-  example_api_calls    = each.value.example_calls
+  aws_assume_role_arn      = var.aws_assume_role_arn
+  example_api_calls        = each.value.example_calls
 
   parameters = concat(
     module.private-key-aws-parameters[each.key].parameters,

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -175,15 +175,14 @@ module "psoxy-msft-connector" {
 
   source = "../../modules/aws-psoxy-instance"
 
-  function_name            = "psoxy-${each.key}"
-  source_kind              = each.value.source_kind
-  path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
-  function_zip_hash        = module.psoxy-package.deployment_package_hash
-  path_to_config           = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
-  api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
-  api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
-  aws_assume_role_arn      = var.aws_assume_role_arn
-  example_api_calls        = each.value.example_calls
+  function_name        = "psoxy-${each.key}"
+  source_kind          = each.value.source_kind
+  path_to_function_zip = module.psoxy-package.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-package.deployment_package_hash
+  path_to_config       = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  example_api_calls    = each.value.example_calls
+  aws_account_id       = var.aws_account_id
 
   parameters = concat(
     module.private-key-aws-parameters[each.key].parameters,

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -179,7 +179,7 @@ module "psoxy-msft-connector" {
   source_kind              = each.value.source_kind
   path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
   function_zip_hash        = module.psoxy-package.deployment_package_hash
-  path_to_config           = "../../../configs/${each.value.source_kind}.yaml"
+  path_to_config           = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
   api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
   api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
   aws_assume_role_arn      = var.aws_assume_role_arn

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -55,7 +55,8 @@ variable "certificate_subject" {
   description = "value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -54,3 +54,8 @@ variable "certificate_subject" {
   type        = string
   description = "value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -44,7 +44,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
 
   implementation     = "aws"
-  path_to_psoxy_java = "../../../java"
+  path_to_psoxy_java = "${var.psoxy_basedir}/java"
 }
 
 # holds SAs + keys needed to connect to Google Workspace APIs

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -41,7 +41,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -143,7 +143,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.3"
 
   project_id                   = google_project.psoxy-google-connectors.project_id
   connector_service_account_id = "psoxy-${each.key}"
@@ -160,7 +160,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.3.0-beta.3"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
   secret_id          = "PSOXY_${replace(upper(each.key), "-", "_")}_SERVICE_ACCOUNT_KEY"
@@ -169,7 +169,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.key
@@ -190,7 +190,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection-google-workspace" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.3"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -171,14 +171,13 @@ module "psoxy-google-workspace-connector" {
 
   source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
-  function_name            = "psoxy-${each.key}"
-  source_kind              = each.key
-  path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
-  function_zip_hash        = module.psoxy-package.deployment_package_hash
-  path_to_config           = "../../../configs/${each.key}.yaml"
-  api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
-  api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
-  aws_assume_role_arn      = var.aws_assume_role_arn
+  function_name        = "psoxy-${each.key}"
+  source_kind          = each.key
+  path_to_function_zip = module.psoxy-package.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-package.deployment_package_hash
+  path_to_config       = "../../../configs/${each.key}.yaml"
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  aws_account_id       = var.aws_account_id
 
   parameters = [
     module.psoxy-aws.salt_secret,

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -44,7 +44,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
-  path_to_psoxy_java = "${var.psoxy_basedir}/java"
+  path_to_psoxy_java = "${var.psoxy_base_dir}/java"
 }
 
 # holds SAs + keys needed to connect to Google Workspace APIs
@@ -175,7 +175,7 @@ module "psoxy-google-workspace-connector" {
   source_kind          = each.key
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_basedir}/configs/${each.key}.yaml"
+  path_to_config       = "${var.psoxy_base_dir}/configs/${each.key}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   aws_account_id       = var.aws_account_id
 

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.4"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -41,7 +41,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.4"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_base_dir}/java"
@@ -144,7 +144,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.4"
 
   project_id                   = google_project.psoxy-google-connectors.project_id
   connector_service_account_id = "psoxy-${each.key}"
@@ -161,7 +161,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.3.0-beta.4"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
   secret_id          = "PSOXY_${replace(upper(each.key), "-", "_")}_SERVICE_ACCOUNT_KEY"
@@ -170,7 +170,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.4"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.key
@@ -191,7 +191,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection-google-workspace" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.4"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -41,7 +41,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -143,7 +143,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.2"
 
   project_id                   = google_project.psoxy-google-connectors.project_id
   connector_service_account_id = "psoxy-${each.key}"
@@ -160,7 +160,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.3.0-beta.2"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
   secret_id          = "PSOXY_${replace(upper(each.key), "-", "_")}_SERVICE_ACCOUNT_KEY"
@@ -169,7 +169,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
   function_name            = "psoxy-${each.key}"
   source_kind              = each.key
@@ -191,7 +191,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection-google-workspace" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.2"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -138,6 +138,7 @@ locals {
     }
   }
   enabled_google_workspace_sources = { for id, spec in local.google_workspace_sources : id => spec if spec.enabled }
+  base_config_path                 = "${var.psoxy_base_dir}/configs/"
 }
 
 module "google-workspace-connection" {
@@ -175,7 +176,7 @@ module "psoxy-google-workspace-connector" {
   source_kind          = each.key
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_base_dir}/configs/${each.key}.yaml"
+  path_to_config       = "${local.base_config_path}/${each.key}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   aws_account_id       = var.aws_account_id
 

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -175,7 +175,7 @@ module "psoxy-google-workspace-connector" {
   source_kind          = each.key
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "../../../configs/${each.key}.yaml"
+  path_to_config       = "${var.psoxy_basedir}/configs/${each.key}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   aws_account_id       = var.aws_account_id
 

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -67,3 +67,8 @@ variable "connector_display_name_suffix" {
   description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"
   default     = ""
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -68,7 +68,8 @@ variable "connector_display_name_suffix" {
   default     = ""
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/examples/aws-hris/main.tf
+++ b/infra/examples/aws-hris/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-bulk?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-bulk?ref=v0.3.0-beta.3"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id

--- a/infra/examples/aws-hris/main.tf
+++ b/infra/examples/aws-hris/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-bulk?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-bulk?ref=v0.3.0-beta.4"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id

--- a/infra/examples/aws-hris/main.tf
+++ b/infra/examples/aws-hris/main.tf
@@ -37,5 +37,5 @@ module "psoxy-aws" {
   instance_id             = var.instance_id
   source_kind             = var.source_kind
   aws_region              = var.aws_region
-  psoxy_basedir           = var.psoxy_basedir
+  psoxy_base_dir          = var.psoxy_base_dir
 }

--- a/infra/examples/aws-hris/main.tf
+++ b/infra/examples/aws-hris/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "../../modules/aws-bulk"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-bulk?ref=v0.3.0-beta.2"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -37,4 +37,5 @@ module "psoxy-aws" {
   instance_id             = var.instance_id
   source_kind             = var.source_kind
   aws_region              = var.aws_region
+  psoxy_basedir           = var.psoxy_basedir
 }

--- a/infra/examples/aws-hris/variables.tf
+++ b/infra/examples/aws-hris/variables.tf
@@ -47,3 +47,8 @@ variable "source_kind" {
   default     = "hris"
   description = "Kind of the content to process"
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/examples/aws-hris/variables.tf
+++ b/infra/examples/aws-hris/variables.tf
@@ -48,7 +48,8 @@ variable "source_kind" {
   description = "Kind of the content to process"
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -37,7 +37,7 @@ provider "azuread" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -49,7 +49,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -121,7 +121,7 @@ locals {
 module "msft-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.3.0-beta.2"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -132,7 +132,7 @@ module "msft-connection" {
 module "msft-connection-auth" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.3.0-beta.2"
 
   application_object_id = module.msft-connection[each.key].connector.id
   rotation_days         = 60
@@ -161,7 +161,7 @@ resource "aws_ssm_parameter" "refresh_endpoint" {
 module "private-key-aws-parameters" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.3.0-beta.2"
 
   instance_id = each.key
 
@@ -172,7 +172,7 @@ module "private-key-aws-parameters" {
 module "psoxy-msft-connector" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
   function_name            = "psoxy-${each.key}"
   source_kind              = each.value.source_kind
@@ -198,7 +198,7 @@ module "psoxy-msft-connector" {
 module "msft_365_grants" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.3.0-beta.2"
 
   application_id           = module.msft-connection[each.key].connector.application_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
@@ -210,7 +210,7 @@ module "msft_365_grants" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.2"
 
   psoxy_endpoint_url = module.psoxy-msft-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -178,7 +178,7 @@ module "psoxy-msft-connector" {
   source_kind          = each.value.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "../../../configs/${each.value.source_kind}.yaml"
+  path_to_config       = "${var.psoxy_basedir}/configs/${each.value.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   example_api_calls    = each.value.example_calls
   aws_account_id       = var.aws_account_id

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -52,7 +52,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
 
   implementation     = "aws"
-  path_to_psoxy_java = "../../../java"
+  path_to_psoxy_java = "${var.psoxy_basedir}/java"
 }
 
 data "azuread_client_config" "current" {}

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -174,15 +174,14 @@ module "psoxy-msft-connector" {
 
   source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
-  function_name            = "psoxy-${each.key}"
-  source_kind              = each.value.source_kind
-  path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
-  function_zip_hash        = module.psoxy-package.deployment_package_hash
-  path_to_config           = "../../../configs/${each.value.source_kind}.yaml"
-  api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
-  api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
-  aws_assume_role_arn      = var.aws_assume_role_arn
-  example_api_calls        = each.value.example_calls
+  function_name        = "psoxy-${each.key}"
+  source_kind          = each.value.source_kind
+  path_to_function_zip = module.psoxy-package.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-package.deployment_package_hash
+  path_to_config       = "../../../configs/${each.value.source_kind}.yaml"
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  example_api_calls    = each.value.example_calls
+  aws_account_id       = var.aws_account_id
 
   parameters = concat(
     module.private-key-aws-parameters[each.key].parameters,

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -37,7 +37,7 @@ provider "azuread" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.4"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -49,7 +49,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.4"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_base_dir}/java"
@@ -122,7 +122,7 @@ locals {
 module "msft-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.3.0-beta.4"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -133,7 +133,7 @@ module "msft-connection" {
 module "msft-connection-auth" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.3.0-beta.4"
 
   application_object_id = module.msft-connection[each.key].connector.id
   rotation_days         = 60
@@ -162,7 +162,7 @@ resource "aws_ssm_parameter" "refresh_endpoint" {
 module "private-key-aws-parameters" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.3.0-beta.4"
 
   instance_id = each.key
 
@@ -173,7 +173,7 @@ module "private-key-aws-parameters" {
 module "psoxy-msft-connector" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.4"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -198,7 +198,7 @@ module "psoxy-msft-connector" {
 module "msft_365_grants" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.3.0-beta.4"
 
   application_id           = module.msft-connection[each.key].connector.application_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
@@ -210,7 +210,7 @@ module "msft_365_grants" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.4"
 
   psoxy_endpoint_url = module.psoxy-msft-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -37,7 +37,7 @@ provider "azuread" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -49,7 +49,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -121,7 +121,7 @@ locals {
 module "msft-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.3.0-beta.3"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -132,7 +132,7 @@ module "msft-connection" {
 module "msft-connection-auth" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.3.0-beta.3"
 
   application_object_id = module.msft-connection[each.key].connector.id
   rotation_days         = 60
@@ -161,7 +161,7 @@ resource "aws_ssm_parameter" "refresh_endpoint" {
 module "private-key-aws-parameters" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.3.0-beta.3"
 
   instance_id = each.key
 
@@ -172,7 +172,7 @@ module "private-key-aws-parameters" {
 module "psoxy-msft-connector" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -197,7 +197,7 @@ module "psoxy-msft-connector" {
 module "msft_365_grants" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.3.0-beta.3"
 
   application_id           = module.msft-connection[each.key].connector.application_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
@@ -209,7 +209,7 @@ module "msft_365_grants" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_msft_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.3"
 
   psoxy_endpoint_url = module.psoxy-msft-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -116,6 +116,7 @@ locals {
     }
   }
   enabled_msft_sources = { for id, spec in local.msft_sources : id => spec if spec.enabled }
+  base_config_path     = "${var.psoxy_base_dir}/configs/"
 }
 
 module "msft-connection" {
@@ -178,7 +179,7 @@ module "psoxy-msft-connector" {
   source_kind          = each.value.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
+  path_to_config       = "${local.base_config_path}/${each.value.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   example_api_calls    = each.value.example_calls
   aws_account_id       = var.aws_account_id

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -52,7 +52,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
-  path_to_psoxy_java = "${var.psoxy_basedir}/java"
+  path_to_psoxy_java = "${var.psoxy_base_dir}/java"
 }
 
 data "azuread_client_config" "current" {}
@@ -178,7 +178,7 @@ module "psoxy-msft-connector" {
   source_kind          = each.value.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_basedir}/configs/${each.value.source_kind}.yaml"
+  path_to_config       = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   example_api_calls    = each.value.example_calls
   aws_account_id       = var.aws_account_id

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -49,3 +49,8 @@ variable "certificate_subject" {
   type        = string
   description = "value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -50,7 +50,8 @@ variable "certificate_subject" {
   description = "value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -64,6 +64,7 @@ locals {
     }
   }
   enabled_oauth_long_access_connectors = { for k, v in local.oauth_long_access_connectors : k => v if v.enabled }
+  base_config_path                     = "${var.psoxy_base_dir}/configs/"
 }
 
 # Create secret (later filled by customer)
@@ -91,7 +92,7 @@ module "aws-psoxy-long-auth-connectors" {
   source_kind          = each.value.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
+  path_to_config       = "${local.base_config_path}/${each.value.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   aws_account_id       = var.aws_account_id
 

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.4"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -40,7 +40,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.4"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_base_dir}/java"
@@ -86,7 +86,7 @@ resource "aws_ssm_parameter" "long-access-token-secret" {
 module "aws-psoxy-long-auth-connectors" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.4"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -106,7 +106,7 @@ module "aws-psoxy-long-auth-connectors" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.4"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -91,7 +91,7 @@ module "aws-psoxy-long-auth-connectors" {
   source_kind          = each.value.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "../../../configs/${each.value.source_kind}.yaml"
+  path_to_config       = "${var.psoxy_basedir}/configs/${each.value.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   aws_account_id       = var.aws_account_id
 

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -43,7 +43,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
-  path_to_psoxy_java = "${var.psoxy_basedir}/java"
+  path_to_psoxy_java = "${var.psoxy_base_dir}/java"
 }
 
 # BEGIN LONG ACCESS AUTH CONNECTORS
@@ -91,7 +91,7 @@ module "aws-psoxy-long-auth-connectors" {
   source_kind          = each.value.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_basedir}/configs/${each.value.source_kind}.yaml"
+  path_to_config       = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   aws_account_id       = var.aws_account_id
 

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -87,14 +87,13 @@ module "aws-psoxy-long-auth-connectors" {
 
   source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
-  function_name            = "psoxy-${each.key}"
-  source_kind              = each.value.source_kind
-  path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
-  function_zip_hash        = module.psoxy-package.deployment_package_hash
-  path_to_config           = "../../../configs/${each.value.source_kind}.yaml"
-  api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
-  api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
-  aws_assume_role_arn      = var.aws_assume_role_arn
+  function_name        = "psoxy-${each.key}"
+  source_kind          = each.value.source_kind
+  path_to_function_zip = module.psoxy-package.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-package.deployment_package_hash
+  path_to_config       = "../../../configs/${each.value.source_kind}.yaml"
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  aws_account_id       = var.aws_account_id
 
   parameters = [
     module.psoxy-aws.salt_secret,

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -40,7 +40,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -85,7 +85,7 @@ resource "aws_ssm_parameter" "long-access-token-secret" {
 module "aws-psoxy-long-auth-connectors" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -105,7 +105,7 @@ module "aws-psoxy-long-auth-connectors" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.3"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -43,7 +43,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
 
   implementation     = "aws"
-  path_to_psoxy_java = "../../../java"
+  path_to_psoxy_java = "${var.psoxy_basedir}/java"
 }
 
 # BEGIN LONG ACCESS AUTH CONNECTORS

--- a/infra/examples/aws-zoom-slack/main.tf
+++ b/infra/examples/aws-zoom-slack/main.tf
@@ -28,7 +28,7 @@ provider "aws" {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -40,7 +40,7 @@ module "psoxy-aws" {
 }
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -85,7 +85,7 @@ resource "aws_ssm_parameter" "long-access-token-secret" {
 module "aws-psoxy-long-auth-connectors" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
   function_name            = "psoxy-${each.key}"
   source_kind              = each.value.source_kind
@@ -106,7 +106,7 @@ module "aws-psoxy-long-auth-connectors" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_oauth_long_access_connectors
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.3.0-beta.2"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"

--- a/infra/examples/aws-zoom-slack/variables.tf
+++ b/infra/examples/aws-zoom-slack/variables.tf
@@ -38,3 +38,8 @@ variable "connector_display_name_suffix" {
   description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"
   default     = ""
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/examples/aws-zoom-slack/variables.tf
+++ b/infra/examples/aws-zoom-slack/variables.tf
@@ -39,7 +39,8 @@ variable "connector_display_name_suffix" {
   default     = ""
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -24,7 +24,7 @@ resource "google_project" "psoxy-project" {
 }
 
 module "psoxy-gcp" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.3.0-beta.2"
 
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
@@ -122,7 +122,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.2"
 
   project_id                   = google_project.psoxy-project.project_id
   connector_service_account_id = "psoxy-${each.key}-dwd"
@@ -138,7 +138,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.3.0-beta.2"
 
   secret_project     = google_project.psoxy-project.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
@@ -148,7 +148,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.3.0-beta.2"
 
   project_id            = google_project.psoxy-project.project_id
   function_name         = "psoxy-${each.key}"
@@ -170,7 +170,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.3.0-beta.2"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].cloud_function_url
   display_name       = "${each.value.display_name} via Psoxy"

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -24,7 +24,7 @@ resource "google_project" "psoxy-project" {
 }
 
 module "psoxy-gcp" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.3.0-beta.4"
 
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
@@ -122,7 +122,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.4"
 
   project_id                   = google_project.psoxy-project.project_id
   connector_service_account_id = "psoxy-${each.key}-dwd"
@@ -138,7 +138,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.3.0-beta.4"
 
   secret_project     = google_project.psoxy-project.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
@@ -148,7 +148,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.3.0-beta.4"
 
   project_id            = google_project.psoxy-project.project_id
   function_name         = "psoxy-${each.key}"
@@ -170,7 +170,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.3.0-beta.4"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].cloud_function_url
   display_name       = "${each.value.display_name} via Psoxy"

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -24,7 +24,7 @@ resource "google_project" "psoxy-project" {
 }
 
 module "psoxy-gcp" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.3.0-beta.3"
 
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
@@ -122,7 +122,7 @@ locals {
 module "google-workspace-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.3.0-beta.3"
 
   project_id                   = google_project.psoxy-project.project_id
   connector_service_account_id = "psoxy-${each.key}-dwd"
@@ -138,7 +138,7 @@ module "google-workspace-connection" {
 module "google-workspace-connection-auth" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.3.0-beta.3"
 
   secret_project     = google_project.psoxy-project.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
@@ -148,7 +148,7 @@ module "google-workspace-connection-auth" {
 module "psoxy-google-workspace-connector" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-cloud-function?ref=v0.3.0-beta.3"
 
   project_id            = google_project.psoxy-project.project_id
   function_name         = "psoxy-${each.key}"
@@ -170,7 +170,7 @@ module "psoxy-google-workspace-connector" {
 module "worklytics-psoxy-connection" {
   for_each = local.enabled_google_workspace_sources
 
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.3.0-beta.3"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].cloud_function_url
   display_name       = "${each.value.display_name} via Psoxy"

--- a/infra/examples/gcp-hris/main.tf
+++ b/infra/examples/gcp-hris/main.tf
@@ -39,7 +39,7 @@ module "psoxy-gcp-bulk" {
   bucket_prefix        = var.bucket_prefix
   bucket_location      = var.bucket_location
   source_kind          = var.source_kind
-  psoxy_basedir        = var.psoxy_basedir
+  psoxy_base_dir       = var.psoxy_base_dir
 
   depends_on = [
     google_project.psoxy-project,

--- a/infra/examples/gcp-hris/main.tf
+++ b/infra/examples/gcp-hris/main.tf
@@ -31,7 +31,7 @@ resource "google_project" "psoxy-project" {
 
 
 module "psoxy-gcp-bulk" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-bulk?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-bulk?ref=v0.3.0-beta.3"
 
   project_id           = google_project.psoxy-project.project_id
   worklytics_sa_emails = var.worklytics_sa_emails

--- a/infra/examples/gcp-hris/main.tf
+++ b/infra/examples/gcp-hris/main.tf
@@ -31,7 +31,7 @@ resource "google_project" "psoxy-project" {
 
 
 module "psoxy-gcp-bulk" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-bulk?ref=v0.3.0-beta.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-bulk?ref=v0.3.0-beta.4"
 
   project_id           = google_project.psoxy-project.project_id
   worklytics_sa_emails = var.worklytics_sa_emails

--- a/infra/examples/gcp-hris/main.tf
+++ b/infra/examples/gcp-hris/main.tf
@@ -22,7 +22,7 @@ terraform {
 # either way, we recommend the project be used exclusively to host psoxy instances corresponding to
 # a single worklytics account
 resource "google_project" "psoxy-project" {
-  name            = "Worklytics Psoxy%{ if var.environment_name != "" } - ${var.environment_name}%{ endif }"
+  name            = "Worklytics Psoxy%{if var.environment_name != ""} - ${var.environment_name}%{endif}"
   project_id      = var.gcp_project_id
   billing_account = var.gcp_billing_account_id
   folder_id       = var.gcp_folder_id # if project is at top-level of your GCP organization, rather than in a folder, comment this line out
@@ -31,7 +31,7 @@ resource "google_project" "psoxy-project" {
 
 
 module "psoxy-gcp-bulk" {
-  source = "../../modules/gcp-bulk"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-bulk?ref=v0.3.0-beta.2"
 
   project_id           = google_project.psoxy-project.project_id
   worklytics_sa_emails = var.worklytics_sa_emails
@@ -39,6 +39,7 @@ module "psoxy-gcp-bulk" {
   bucket_prefix        = var.bucket_prefix
   bucket_location      = var.bucket_location
   source_kind          = var.source_kind
+  psoxy_basedir        = var.psoxy_basedir
 
   depends_on = [
     google_project.psoxy-project,

--- a/infra/examples/gcp-hris/variables.tf
+++ b/infra/examples/gcp-hris/variables.tf
@@ -54,3 +54,8 @@ variable "source_kind" {
   default     = "hris"
   description = "Kind of the content to process"
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/examples/gcp-hris/variables.tf
+++ b/infra/examples/gcp-hris/variables.tf
@@ -55,7 +55,8 @@ variable "source_kind" {
   description = "Kind of the content to process"
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/infra.iml
+++ b/infra/infra.iml
@@ -2,7 +2,9 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/_test-local-aws/.terraform" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/infra/modules/aws-bulk/main.tf
+++ b/infra/modules/aws-bulk/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -18,7 +18,7 @@ module "psoxy-aws" {
 
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "output" {
 }
 
 module "psoxy-file-handler" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
 
   function_name        = "psoxy-${var.instance_id}"
   handler_class        = "co.worklytics.psoxy.S3Handler"

--- a/infra/modules/aws-bulk/main.tf
+++ b/infra/modules/aws-bulk/main.tf
@@ -21,7 +21,7 @@ module "psoxy-package" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
 
   implementation     = "aws"
-  path_to_psoxy_java = "${var.psoxy_basedir}/java"
+  path_to_psoxy_java = "${var.psoxy_base_dir}/java"
 }
 
 ## START HRIS MODULE - COPY TO YOUR MASTER main.tf
@@ -42,7 +42,7 @@ module "psoxy-file-handler" {
   source_kind          = var.source_kind
   path_to_function_zip = module.psoxy-package.path_to_deployment_jar
   function_zip_hash    = module.psoxy-package.deployment_package_hash
-  path_to_config       = "${var.psoxy_basedir}/configs/${var.source_kind}.yaml"
+  path_to_config       = "${var.psoxy_base_dir}/configs/${var.source_kind}.yaml"
   aws_assume_role_arn  = var.aws_assume_role_arn
   example_api_calls    = [] #None, as this function is called through the S3 event
   aws_account_id       = var.aws_account_id

--- a/infra/modules/aws-bulk/main.tf
+++ b/infra/modules/aws-bulk/main.tf
@@ -24,7 +24,7 @@ module "psoxy-package" {
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
 }
 
-## START HRIS MODULE
+## START HRIS MODULE - COPY TO YOUR MASTER main.tf
 
 resource "aws_s3_bucket" "input" {
   bucket = "psoxy-${var.instance_id}-input"
@@ -37,16 +37,15 @@ resource "aws_s3_bucket" "output" {
 module "psoxy-file-handler" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
-  function_name            = "psoxy-${var.instance_id}"
-  handler_class            = "co.worklytics.psoxy.S3Handler"
-  source_kind              = var.source_kind
-  path_to_function_zip     = module.psoxy-package.path_to_deployment_jar
-  function_zip_hash        = module.psoxy-package.deployment_package_hash
-  path_to_config           = "${var.psoxy_basedir}/configs/${var.source_kind}.yaml"
-  api_caller_role_arn      = module.psoxy-aws.api_caller_role_arn
-  api_caller_role_arn_name = module.psoxy-aws.api_caller_role_name
-  aws_assume_role_arn      = var.aws_assume_role_arn
-  example_api_calls        = [] #None, as this function is called through the S3 event
+  function_name        = "psoxy-${var.instance_id}"
+  handler_class        = "co.worklytics.psoxy.S3Handler"
+  source_kind          = var.source_kind
+  path_to_function_zip = module.psoxy-package.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-package.deployment_package_hash
+  path_to_config       = "${var.psoxy_basedir}/configs/${var.source_kind}.yaml"
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  example_api_calls    = [] #None, as this function is called through the S3 event
+  aws_account_id       = var.aws_account_id
 
   parameters = []
 

--- a/infra/modules/aws-bulk/main.tf
+++ b/infra/modules/aws-bulk/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.3"
+  source = "../aws"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -18,7 +18,7 @@ module "psoxy-aws" {
 
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.3"
+  source = "../psoxy-package"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_base_dir}/java"
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "output" {
 }
 
 module "psoxy-file-handler" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.3"
+  source = "../aws-psoxy-instance"
 
   function_name        = "psoxy-${var.instance_id}"
   handler_class        = "co.worklytics.psoxy.S3Handler"

--- a/infra/modules/aws-bulk/main.tf
+++ b/infra/modules/aws-bulk/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "psoxy-aws" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.3.0-beta.2"
 
   caller_aws_account_id   = var.caller_aws_account_id
   caller_external_user_id = var.caller_external_user_id
@@ -18,7 +18,7 @@ module "psoxy-aws" {
 
 
 module "psoxy-package" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/psoxy-package?ref=v0.3.0-beta.2"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_basedir}/java"
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "output" {
 }
 
 module "psoxy-file-handler" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.1"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-instance?ref=v0.3.0-beta.2"
 
   function_name            = "psoxy-${var.instance_id}"
   handler_class            = "co.worklytics.psoxy.S3Handler"

--- a/infra/modules/aws-bulk/variables.tf
+++ b/infra/modules/aws-bulk/variables.tf
@@ -43,7 +43,8 @@ variable "source_kind" {
   description = "Kind of the content to process"
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/modules/aws-bulk/variables.tf
+++ b/infra/modules/aws-bulk/variables.tf
@@ -42,3 +42,8 @@ variable "source_kind" {
   default     = "hris"
   description = "Kind of the content to process"
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}

--- a/infra/modules/aws-psoxy-instance/main.tf
+++ b/infra/modules/aws-psoxy-instance/main.tf
@@ -74,13 +74,10 @@ resource "aws_iam_policy" "policy" {
             "ssm:GetParameter*"
           ],
           "Effect" : "Allow",
-          "Resource" : "*"
-          # TODO: limit to SSM parameters in question
-          # "Resource": "arn:aws:ssm:us-east-2:123456789012:parameter/prod-*"
+          "Resource" : "arn:aws:ssm:${var.region}:${var.aws_account_id}:parameter/*"
         }
       ]
   })
-
 }
 
 
@@ -92,33 +89,6 @@ resource "aws_iam_role_policy_attachment" "basic" {
 resource "aws_iam_role_policy_attachment" "policy" {
   role       = aws_iam_role.iam_for_lambda.name
   policy_arn = aws_iam_policy.policy.arn
-}
-
-resource "aws_iam_role_policy_attachment" "read_lambda_ssm_to_caller" {
-  role       = var.api_caller_role_arn_name
-  policy_arn = aws_iam_policy.policy.arn
-}
-
-resource "aws_iam_policy" "execution_lambda_to_caller" {
-  name        = "${var.function_name}_invoker"
-  description = "Allow caller role to execute the lambda url directly"
-
-  policy = jsonencode(
-    {
-      "Version" : "2012-10-17",
-      "Statement" : [
-        {
-          "Action" : ["lambda:InvokeFunctionUrl"],
-          "Effect" : "Allow",
-          "Resource" : aws_lambda_function.psoxy-instance.arn
-        }
-      ]
-    })
-}
-
-resource "aws_iam_role_policy_attachment" "execution_lambda_to_caller" {
-  role       = var.api_caller_role_arn_name
-  policy_arn = aws_iam_policy.execution_lambda_to_caller.arn
 }
 
 locals {

--- a/infra/modules/aws-psoxy-instance/variables.tf
+++ b/infra/modules/aws-psoxy-instance/variables.tf
@@ -1,4 +1,11 @@
-
+variable "aws_account_id" {
+  type        = string
+  description = "id of aws account in which to provision your AWS infra"
+  validation {
+    condition     = can(regex("^\\d{12}$", var.aws_account_id))
+    error_message = "The aws_account_id value should be 12-digit numeric string."
+  }
+}
 
 variable "region" {
   type        = string
@@ -50,16 +57,6 @@ variable "function_zip_hash" {
 variable "path_to_config" {
   type        = string
   description = "path to config file (usually someting in ../../configs/, eg configs/gdirectory.yaml"
-}
-
-variable "api_caller_role_arn" {
-  type        = string
-  description = "arn of role which can be assumed to call API"
-}
-
-variable "api_caller_role_arn_name" {
-  type        = string
-  description = "name of arn of role which can be assumed to call API"
 }
 
 variable "example_api_calls" {

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -7,6 +7,12 @@ variable "aws_account_id" {
   }
 }
 
+variable "region" {
+  type        = string
+  description = "region into which to deploy function"
+  default     = "us-east-1"
+}
+
 variable "caller_aws_account_id" {
   type        = string
   description = "id of worklytics sa"

--- a/infra/modules/gcp-bulk/main.tf
+++ b/infra/modules/gcp-bulk/main.tf
@@ -18,7 +18,7 @@ module "psoxy-package" {
   source = "../psoxy-package"
 
   implementation     = "gcp"
-  path_to_psoxy_java = "${var.psoxy_basedir}/java"
+  path_to_psoxy_java = "${var.psoxy_base_dir}/java"
 }
 
 data "archive_file" "source" {

--- a/infra/modules/gcp-bulk/main.tf
+++ b/infra/modules/gcp-bulk/main.tf
@@ -18,7 +18,7 @@ module "psoxy-package" {
   source = "../psoxy-package"
 
   implementation     = "gcp"
-  path_to_psoxy_java = "../../../java"
+  path_to_psoxy_java = "${var.psoxy_basedir}/java"
 }
 
 data "archive_file" "source" {

--- a/infra/modules/gcp-bulk/variables.tf
+++ b/infra/modules/gcp-bulk/variables.tf
@@ -30,7 +30,8 @@ variable "source_kind" {
   description = "Kind of the content to process"
 }
 
-variable "psoxy_basedir" {
+variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"
+  default     = "../../.."
 }

--- a/infra/modules/gcp-bulk/variables.tf
+++ b/infra/modules/gcp-bulk/variables.tf
@@ -29,3 +29,8 @@ variable "source_kind" {
   type        = string
   description = "Kind of the content to process"
 }
+
+variable "psoxy_basedir" {
+  type        = string
+  description = "the path where your psoxy repo resides"
+}


### PR DESCRIPTION
Rework infra modules 
- pass basedir variable to get rid of relative paths
- use git references whenever possible
- rework aws lambdas, so they don't grant one policy to the caller to avoid reaching the max limit of 10
  - grant access to all parameters & lambdas in the project instead in aws module

- latest commit holds a temporary tag called ~~`v0.3.0-beta.3`~~ `v0.3.0-beta.4` to test all the references, upon approval will change to next version.

### Change implications

 - dependencies added/changed? **no**
