### PR TITLE
S123 fix calendar structure

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/Rules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/Rules.java
@@ -143,7 +143,7 @@ public class Rules implements Serializable {
         other.emailHeaderPseudonymizations.stream()
             .forEach(builder::emailHeaderPseudonymization);
         other.pseudonymizations.stream()
-            .forEach(builder::emailHeaderPseudonymization);
+            .forEach(builder::pseudonymization);
         other.pseudonymizationWithOriginals.stream()
             .forEach(builder::pseudonymizationWithOriginal);
         other.redactions.stream()

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerImpl.java
@@ -163,7 +163,7 @@ public class SanitizerImpl implements Sanitizer {
             return null;
         }
 
-        Preconditions.checkArgument(value instanceof String,"Value must be string");
+        Preconditions.checkArgument(value instanceof String, "Value must be string");
 
         if (StringUtils.isBlank((String) value)) {
             return new ArrayList<>();

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/PrebuiltSanitizerRules.java
@@ -10,7 +10,7 @@ public class PrebuiltSanitizerRules {
     static public final Map<String, Rules> DEFAULTS = ImmutableMap.<String, Rules>builder()
         .putAll(co.worklytics.psoxy.rules.google.PrebuiltSanitizerRules.GOOGLE_DEFAULT_RULES_MAP)
         .putAll(co.worklytics.psoxy.rules.slack.PrebuiltSanitizerRules.SLACK_DEFAULT_RULES_MAP)
-        .putAll(co.worklytics.psoxy.rules.msft.PrebuiltSanitzerRules.MSFT_DEFAULT_RULES_MAP)
+        .putAll(co.worklytics.psoxy.rules.msft.PrebuiltSanitizerRules.MSFT_DEFAULT_RULES_MAP)
         .putAll(co.worklytics.psoxy.rules.zoom.PrebuiltSanitizerRules.ZOOM_PREBUILT_RULES_MAP)
         .build();
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
-public class PrebuiltSanitzerRules {
+public class PrebuiltSanitizerRules {
 
     static final Rules DIRECTORY =  Rules.builder()
         //GENERAL stuff

--- a/java/core/src/main/resources/rules/microsoft-365/outlook-cal.yaml
+++ b/java/core/src/main/resources/rules/microsoft-365/outlook-cal.yaml
@@ -1,3 +1,4 @@
+---
 allowedEndpointRegexes:
   - "^/(v1.0|beta)/(groups|users)/?[^/]*"
   - "^/(v1.0|beta)/(groups|users)\\?.*"
@@ -5,13 +6,6 @@ allowedEndpointRegexes:
   - "^/(v1.0|beta)/users/[^/]*/(calendars/[^/]*/)?events.*"
   - "^/(v1.0|beta)/users/[^/]*/mailboxSettings"
   - "^/beta/users/[^/]*/calendar/calendarView(?)[^/]*"
-emailHeaderPseudonymizations:
-  - jsonPaths:
-      - "$..emailAddress.address"
-    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/calendar/calendarView(?)[^/]*"
-  - jsonPaths:
-      - "$..emailAddress.address"
-    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/(calendars/[^/]*/)?events.*"
 pseudonymizations:
   - jsonPaths:
       - "$..userPrincipalName"
@@ -25,6 +19,12 @@ pseudonymizations:
       - "$..mail"
       - "$..otherMails[*]"
     relativeUrlRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
+  - jsonPaths:
+      - "$..emailAddress.address"
+    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/calendar/calendarView(?)[^/]*"
+  - jsonPaths:
+      - "$..emailAddress.address"
+    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/(calendars/[^/]*/)?events.*"
 redactions:
   - jsonPaths:
       - "$..displayName"

--- a/java/core/src/main/resources/rules/microsoft-365/outlook-mail.yaml
+++ b/java/core/src/main/resources/rules/microsoft-365/outlook-mail.yaml
@@ -5,13 +5,6 @@ allowedEndpointRegexes:
   - "^/(v1.0|beta)/users/[^/]*/messages/[^/]*"
   - "^/(v1.0|beta)/users/[^/]*/mailFolders/SentItems/messages.*"
   - "^/(v1.0|beta)/users/[^/]*/mailboxSettings"
-emailHeaderPseudonymizations:
-  - jsonPaths:
-      - "$..emailAddress.address"
-    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/mailFolders/SentItems/messages.*"
-  - jsonPaths:
-      - "$..emailAddress.address"
-    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/messages/[^/]*"
 pseudonymizations:
   - jsonPaths:
       - "$..userPrincipalName"
@@ -25,6 +18,12 @@ pseudonymizations:
       - "$..mail"
       - "$..otherMails[*]"
     relativeUrlRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
+  - jsonPaths:
+      - "$..emailAddress.address"
+    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/mailFolders/SentItems/messages.*"
+  - jsonPaths:
+      - "$..emailAddress.address"
+    relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/messages/[^/]*"
 redactions:
   - jsonPaths:
       - "$..displayName"
@@ -81,4 +80,5 @@ redactions:
       - "$..singleValueExtendedProperties"
       - "$..internetMessageHeaders"
     relativeUrlRegex: "^/(v1.0|beta)/users/[^/]*/messages/[^/]*"
+
 

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/CalendarTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/CalendarTests.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class CalendarTests extends DirectoryTests {
 
     @Getter
-    final Rules rulesUnderTest = PrebuiltSanitzerRules.OUTLOOK_CALENDAR;
+    final Rules rulesUnderTest = PrebuiltSanitizerRules.OUTLOOK_CALENDAR;
 
     @Getter
     final String exampleDirectoryPath = "api-response-examples/microsoft-365/outlook-cal";

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/DirectoryTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/DirectoryTests.java
@@ -12,7 +12,7 @@ import java.util.Collection;
 public class DirectoryTests extends JavaRulesTestBaseCase {
 
     @Getter
-    final Rules rulesUnderTest = PrebuiltSanitzerRules.DIRECTORY;
+    final Rules rulesUnderTest = PrebuiltSanitizerRules.DIRECTORY;
 
     @Getter
     final String exampleDirectoryPath = "api-response-examples/microsoft-365/directory";

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/MailTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/MailTests.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class MailTests extends JavaRulesTestBaseCase {
 
     @Getter
-    final Rules rulesUnderTest = PrebuiltSanitzerRules.OUTLOOK_MAIL;
+    final Rules rulesUnderTest = PrebuiltSanitizerRules.OUTLOOK_MAIL;
 
     @Getter
     final String exampleDirectoryPath = "api-response-examples/microsoft-365/outlook-mail";


### PR DESCRIPTION
### Fixes
  - bug in rule composition was parsing some fields as if email headers (split on `,` before pseudonymization), causing results to be list of pseudonyms where only single value was expected

### Change implications

 - dependencies added/changed? **no**
