### PR TITLE
s124 - Zoom rules update

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/zoom/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/zoom/PrebuiltSanitizerRules.java
@@ -78,7 +78,7 @@ public class PrebuiltSanitizerRules {
         // List meetings
         // https://marketplace.zoom.us/docs/api-reference/zoom-api/methods#operation/reportMeetings
         .endpoint(Rules2.Endpoint.builder()
-            .pathRegex("^/v2/report/users/(?:.*)/meetings")
+            .pathRegex("^/v2/report/users/(?:.*)/meetings(?:\\?.+)?")
             .transform(Transform.Pseudonymize.builder()
                 .jsonPath("$.meetings[*]['host_id','user_email','host_email']")
                 .build()

--- a/java/core/src/main/resources/rules/zoom/zoom.yaml
+++ b/java/core/src/main/resources/rules/zoom/zoom.yaml
@@ -47,7 +47,7 @@ endpoints:
       - !<redact>
         jsonPaths:
           - "$.participants[*].['name','registrant_id']"
-  - pathRegex: "^/v2/report/users/(?:.*)/meetings"
+  - pathRegex: "^/v2/report/users/(?:.*)/meetings(?:\\?.+)?"
     transforms:
       - !<pseudonymize>
         jsonPaths:

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/zoom/ZoomRulesTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/zoom/ZoomRulesTests.java
@@ -45,6 +45,7 @@ public class ZoomRulesTests extends JavaRulesTestBaseCase {
         "https://api.zoom.us/v2/meetings/MEETING_ID",
         "https://api.zoom.us/v2/meetings/MEETING_ID?occurence_id=OCCURRENCE_ID&show_previous_occurrences=false",
         "https://api.zoom.us/v2/report/users/{userId}/meetings",
+        "https://api.zoom.us/v2/report/users/myuserid/meetings?from=2022-05-16&to=2022-05-31&type=pastJoined&page_size=1",
         "https://api.zoom.us/v2/report/meetings/{meetingId}",
         "https://api.zoom.us/v2/report/meetings/{meetingId}/participants",
 


### PR DESCRIPTION
### Fixes
- Allow query string parameters in zoom reports meetings call.

### Change implications

 - dependencies added/changed? **no**
