### PR TITLE
s130. : reversibly pseudonymize zoom user ids

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/zoom/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/zoom/PrebuiltSanitizerRules.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.rules.zoom;
 import co.worklytics.psoxy.rules.RuleSet;
 import co.worklytics.psoxy.rules.Rules2;
 import co.worklytics.psoxy.rules.Transform;
+import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -128,8 +129,9 @@ public class PrebuiltSanitizerRules {
                 .build()
             )
             .transform(Transform.Pseudonymize.builder()
-                .includeOriginal(true)// the original id is needed to iterate meetings by user
+                .includeReversible(true) // need to reverse when requesting meetings by user to iterate
                 .jsonPath("$.users[*].id")
+                .encoding(PseudonymEncoder.Implementations.URL_SAFE_TOKEN)
                 .build()
             )
             .transform(Transform.Redact.builder()

--- a/java/core/src/main/resources/rules/zoom/zoom.yaml
+++ b/java/core/src/main/resources/rules/zoom/zoom.yaml
@@ -9,7 +9,8 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$.users[*].id"
-        includeOriginal: true
+        includeReversible: true
+        encoding: "URL_SAFE_TOKEN"
       - !<redact>
         jsonPaths:
           - "$.users[*]['first_name','last_name','pic_url','employee_unique_id']"

--- a/java/core/src/test/resources/api-response-examples/zoom/sanitized/list-users.json
+++ b/java/core/src/test/resources/api-response-examples/zoom/sanitized/list-users.json
@@ -5,7 +5,7 @@
   "total_records":1,
   "users":[
     {
-      "id":"{\"scope\":\"zoom\",\"hash\":\"ZOPLM4doMzcRkn5mKz63MrQApQc.e4CHTv5z8dPxYVk\",\"original\":\"z8yAAAAA8bbbQ\"}",
+      "id":"p~JzXCV2FA272NOeqHYQbR4PewwSZI9hznATn7Wse3j8GpsoD91NC0nDg1vNKrhPEc",
       "email":"{\"scope\":\"email\",\"domain\":\"example.com\",\"hash\":\"Oyl8_kWC39yrNSWNGUSM7xylJREQ62Dj6OynAkyY2Ro\"}",
       "type":2,
       "pmi":111111111,


### PR DESCRIPTION
### Features
  - use reversible pseudonyms for Zoom Ids through proxy, instead of including original

### Change implications

 - dependencies added/changed? **no**
