### PR TITLE
s130 : ignore tags + labels

### DIFF
--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -133,6 +133,7 @@ resource "aws_ssm_parameter" "client_id" {
 
   lifecycle {
     ignore_changes = [
+      tags,
       value
     ]
   }
@@ -148,6 +149,7 @@ resource "aws_ssm_parameter" "refresh_endpoint" {
 
   lifecycle {
     ignore_changes = [
+      tags,
       value
     ]
   }

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -37,6 +37,12 @@ module "psoxy_lambda" {
 
 resource "aws_s3_bucket" "input" {
   bucket = "psoxy-${var.instance_id}-${random_string.bucket_suffix.id}-input"
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "input" {
@@ -60,6 +66,12 @@ resource "aws_s3_bucket_public_access_block" "input-block-public-access" {
 
 resource "aws_s3_bucket" "output" {
   bucket = "psoxy-${var.instance_id}-${random_string.bucket_suffix.id}-output"
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "output" {
@@ -119,6 +131,12 @@ resource "aws_iam_policy" "input_bucket_getObject_policy" {
         }
       ]
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "read_policy_for_import_bucket" {
@@ -144,6 +162,12 @@ resource "aws_iam_policy" "output_bucket_write_policy" {
         }
       ]
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "write_policy_for_output_bucket" {
@@ -173,6 +197,12 @@ resource "aws_iam_policy" "output_bucket_read" {
         }
       ]
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "caller_bucket_access_policy" {
@@ -186,4 +216,10 @@ resource "aws_ssm_parameter" "rules" {
   type           = "String"
   description    = "Rules for transformation of files. NOTE: any 'RULES' env var will override this value"
   insecure_value = yamlencode(var.rules) # NOTE: insecure_value just means shown in Terraform output
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -25,12 +25,24 @@ resource "aws_lambda_function" "psoxy-instance" {
       var.environment_variables
     )
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 # cloudwatch group per lambda function
 resource "aws_cloudwatch_log_group" "lambda-log" {
   name              = "/aws/lambda/${aws_lambda_function.psoxy-instance.function_name}"
   retention_in_days = var.log_retention_in_days
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -49,6 +61,12 @@ resource "aws_iam_role" "iam_for_lambda" {
       }
     ]
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_policy" "policy" {
@@ -71,6 +89,11 @@ resource "aws_iam_policy" "policy" {
       ]
   })
 
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "basic" {

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -62,6 +62,12 @@ resource "aws_iam_role" "api-caller" {
       local.gcp_service_account_caller_statements
     )
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 # Allow caller to read parameters required by lambdas
@@ -82,6 +88,12 @@ resource "aws_iam_policy" "read_parameters_policy" {
         }
       ]
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "read_parameters_policy_attach" {
@@ -105,6 +117,12 @@ resource "aws_iam_policy" "execution_lambda_to_caller" {
         }
       ]
   })
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "invoker_lambda_execution" {
@@ -139,6 +157,7 @@ resource "aws_ssm_parameter" "salt" {
 
   lifecycle {
     ignore_changes = [
+      tags,
       value
     ]
   }
@@ -160,6 +179,7 @@ resource "aws_ssm_parameter" "encryption_key" {
 
   lifecycle {
     ignore_changes = [
+      tags,
       value
     ]
   }

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -13,6 +13,12 @@ resource "google_storage_bucket" "input-bucket" {
   location                    = var.region
   force_destroy               = true
   uniform_bucket_level_access = true
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
 }
 
 # data output from function
@@ -22,6 +28,12 @@ resource "google_storage_bucket" "output-bucket" {
   location                    = var.region
   force_destroy               = true
   uniform_bucket_level_access = true
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
 }
 
 resource "google_service_account" "service-account" {
@@ -29,6 +41,12 @@ resource "google_service_account" "service-account" {
   display_name = "Psoxy ${var.source_kind} service account for cloud function"
   description  = "Service account where the function is running and have permissions to read secrets"
   project      = var.project_id
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
 }
 
 resource "google_secret_manager_secret_iam_member" "salt-secret-access-for-service-account" {
@@ -58,6 +76,12 @@ resource "google_project_iam_custom_role" "bucket-write" {
   title       = "Access for writing and update objects in bucket"
   description = "Write and update support, because storage.objectCreator role only support creation -not update"
   permissions = ["storage.objects.create", "storage.objects.delete"]
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
 }
 
 resource "google_storage_bucket_iam_member" "access_for_processed_bucket" {
@@ -96,6 +120,13 @@ resource "google_cloudfunctions_function" "function" {
   event_trigger {
     event_type = "google.storage.object.finalize"
     resource   = google_storage_bucket.input-bucket.name
+  }
+
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
   }
 
   depends_on = [

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -60,6 +60,12 @@ resource "google_cloudfunctions_function" "function" {
   }
 
   trigger_http = true
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
 }
 
 locals {

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -27,6 +27,12 @@ resource "google_secret_manager_secret" "pseudonymization-salt" {
     automatic = true
   }
 
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
+
   depends_on = [
     google_project_service.gcp-infra-api
   ]
@@ -64,6 +70,12 @@ resource "google_secret_manager_secret" "pseudonymization-key" {
 
   replication {
     automatic = true
+  }
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
   }
 
   depends_on = [
@@ -122,6 +134,12 @@ resource "google_storage_bucket" "artifacts" {
   name          = "${var.project_id}-psoxy-artifacts-bucket"
   location      = var.bucket_location
   force_destroy = true
+
+  lifecycle {
+    ignore_changes = [
+      labels
+    ]
+  }
 }
 
 # Add source code zip to bucket

--- a/infra/modules/private-key-aws-parameter-user-managed/main.tf
+++ b/infra/modules/private-key-aws-parameter-user-managed/main.tf
@@ -10,6 +10,7 @@ resource "aws_ssm_parameter" "private-key" {
 
   lifecycle {
     ignore_changes = [
+      tags,
       value
     ]
   }
@@ -23,6 +24,7 @@ resource "aws_ssm_parameter" "private-key-id" {
 
   lifecycle {
     ignore_changes = [
+      tags,
       value
     ]
   }

--- a/infra/modules/private-key-aws-parameter/main.tf
+++ b/infra/modules/private-key-aws-parameter/main.tf
@@ -7,6 +7,12 @@ resource "aws_ssm_parameter" "private-key" {
   type        = "SecureString"
   description = "Value of private key"
   value       = var.private_key
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_ssm_parameter" "private-key-id" {
@@ -14,6 +20,12 @@ resource "aws_ssm_parameter" "private-key-id" {
   type        = "SecureString" # probably not necessary
   description = "ID of private key"
   value       = var.private_key_id
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 output "parameters" {


### PR DESCRIPTION
### Features
 - customers use tags/labels on aws/gcp infra; proxy doesn't depend on them. Simplest is to not try to manage them, but simply `ignore_changes` in all cases

### Change implications

 - dependencies added/changed? **no**
