### PR TITLE
S130 Node.js testing tool

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,9 @@ indent_style = space
 indent_size = tab
 tab_width = 2
 
+[*.js]
+quote_type = single
+
 # https://google.github.io/styleguide/htmlcssguide.xml#Indentation
 [*.{html,htm,hbs,css,scss,sql}]
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Log files
 *.log
+
+tools/psoxy-test/node_modules
+tools/psoxy-test/package-lock.json

--- a/README.md
+++ b/README.md
@@ -43,14 +43,11 @@ versions of all of the following:
   - [terraform](https://www.terraform.io/) optional; if you don't use this, you'll need to configure
     your GCP/AWS project via the web console/CLI tools. Writing your own terraform config that
     re-uses our modules will simplify things greatly.
-  - [jq](https://stedolan.github.io/jq/) optional, used for testing.
 
 And, depending on your scenario, you may also need:
   - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) is
-    required to deploy your psoxy instances in AWS; and for testing AWS deployments locally:
-    - [python 3.6+](https://www.python.org/)
-    - [pip](https://pypi.org/project/pip/) - usually included with Python
-    - [awscurl](https://github.com/okigan/awscurl) - installed via pip
+    required to deploy your psoxy instances in AWS; Node.js v16+ and npm v8+, to be able to
+    test your proxy instances locally.
   - [Google Cloud Command Line tool](https://cloud.google.com/sdk/docs/install) Required to host
     your psoxy instances in GCP *OR* if you plan to connect Google Workspace as a data source. It
     should be configured for the GCP project that will host your psoxy instance(s) and/or your
@@ -118,7 +115,7 @@ recreate them (for example, to use GCP project that already exists).
 terraform apply
 ```
 
-  9. follow any `TODO` instructions produced by Terraform, such as:
+  10. follow any `TODO` instructions produced by Terraform, such as:
      - build and deploy JAR (built from this repo) into your environment
      - provision API keys / make OAuth grants needed by each Data Connection
      - create the Data Connection from Worklytics to your psoxy instance (Terraform can provide

--- a/docs/example-api-calls/google-workspace.md
+++ b/docs/example-api-calls/google-workspace.md
@@ -1,235 +1,209 @@
 # API Call Examples for Google Workspace
 
-Example commands that you can use to validate proxy behavior against the Google Workspace APIs.
+Example commands (*) that you can use to validate proxy behavior against the Google Workspace APIs.
 Follow the steps and change the values to match your configuration when needed.
 
-To use, ensure you've set env variables on your machine:
+You can use the `-i` flag to impersonate the desired user identity option when running the testing tool. Example:
+
 ```shell
-# no slash at the end, and no function or lambda, just the base url of the deployment
-export PSOXY_BASE=https://YOUR_PSOXY_HOST
-export PSOXY_USER_TO_IMPERSONATE=you@acme.com
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/calendars/primary -i you@acme.com
 ```
 
-For GCP, use
+For AWS, change the role to assume with one with sufficient permissions to call the proxy (`-r` flag). Example:
+
 ```shell
-export OPTIONS="-g -i $PSOXY_USER_TO_IMPERSONATE"
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/calendars/primary -r arn:aws:iam::PROJECT_ID:role/ROLE_NAME
 ```
 
-For AWS, change the role to impersonate with one with sufficient permissions to call the proxy
-```shell
-export AWS_ROLE_ARN="arn:aws:iam::PROJECT_ID:role/ROLE_NAME"
-export OPTIONS="-a -r $AWS_ROLE_ARN -i $PSOXY_USER_TO_IMPERSONATE"
-```
+If any call appears to fail, repeat it using the `-v` flag.
 
-If any call appears to fail, repeat it without the pipe to jq (eg, remove `| jq ...` portion from
-the end of the command) and "-v" flag.
-
-## Calendar
+(*) All commands assume that you are at the root path of the Psoxy project.
 
 ### Calendar
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gcal/calendar/v3/calendars/primary | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/calendars/primary
 ```
 
 ### Settings
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gcal/calendar/v3/users/me/settings | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/users/me/settings
 ```
 
 ### Events
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gcal/calendar/v3/calendars/primary/events | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/calendars/primary/events
 ```
 
 ### Event
+1. Get the calendar event ID (accessor path in response `.items[0].id`):
 ```shell
-export CALENDAR_EVENT_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gcal/calendar/v3/calendars/primary/events | jq -r '.items[0].id'`
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/calendars/primary/events
+```
 
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gcal/calendar/v3/calendars/primary/events/$CALENDAR_EVENT_ID | jq .
+2. Get event information (replace `calendar_event_id` with the corresponding value):
+```
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gcal/calendar/v3/calendars/primary/events/[calendar_event_id]
 ```
 
 ## Directory
 
 ### Domains
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/customer/my_customer/domains | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/customer/my_customer/domains
 ```
 
 ### Groups
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/groups\?customer=my_customer | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/groups?customer=my_customer
 ```
 
 ### Group
-```shell
-export GOOGLE_GROUP_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/groups\?customer=my_customer | jq -r '.groups[0].id'`
 
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/groups/$GOOGLE_GROUP_ID | jq .
+1. Get the group ID (accessor path in response `.groups[0].id`):
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/groups?customer=my_customer
+```
+
+2. Get group information (replace `google_group_id` with the corresponding value):
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/groups/[google_group_id]
 ```
 
 ### Group Members
 ```shell
-export GOOGLE_GROUP_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/groups\?customer=my_customer | jq -r '.groups[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/groups/$GOOGLE_GROUP_ID/members | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/groups/[google_group_id]/members
 ```
 
 ### Users
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/users\?customer=my_customer | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/users?customer=my_customer
+```
+1. Get the user ID (accessor path in response `.users[0].id`):
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/users?customer=my_customer
 ```
 
+2. Get user information (replace [google_user_id] with the corresponding value):
 ```shell
-export GOOGLE_USER_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/users\?customer=my_customer | jq -r '.users[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/users/$GOOGLE_USER_ID | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/users/[google_user_id]
 ```
 
-Thumbnail (expect have its contents redacted)
+3. Thumbnail (expect have its contents redacted; replace [google_user_id] with the corresponding value):
 ```shell
-export GOOGLE_USER_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/users\?customer=my_customer | jq -r '.users[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/users/$GOOGLE_USER_ID/photos/thumbnail | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/users/[google_user_id]/photos/thumbnail
 ```
 
 ### Roles
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/customer/my_customer/roles | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/customer/my_customer/roles
 ```
 
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdirectory/admin/directory/v1/customer/my_customer/roleassignments | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdirectory/admin/directory/v1/customer/my_customer/roleassignments
 ```
 
 ## Drive
 
 ### Files
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files
 ```
 
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v3/files
 ```
 
 ### File
+1. Get the file ID (accessor path in response `.files[0].id`:
 ```shell
-export DRIVE_FILE_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq -r '.items[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/$DRIVE_FILE_ID | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files
 ```
 
+2. Get file details (replace [drive_file_id] with the corresponding value): 
 ```shell
-export DRIVE_FILE_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files | jq -r '.files[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files/$DRIVE_FILE_ID\?fields=\* | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v3/files/[drive_file_id]?fields=*
 ```
 
 ### File Revisions
 YMMV, as file at index `0` must actually be a type that supports revisions for this to return
-anything. You can play with that value until you find something that does.
+anything. You can play with different file IDs until you find something that does.
 ```shell
-export DRIVE_FILE_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq -r '.items[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/$DRIVE_FILE_ID/revisions | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/revisions
 ```
 
 ```shell
-export DRIVE_FILE_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files\?pageSize=2\&fields=\* | jq -r '.files[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files/$DRIVE_FILE_ID/revisions\?pageSize=2\&fields=\* | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/revisions?pageSize=2&fields=*
 ```
 
 ### Permissions
 
 ```shell
-export DRIVE_FILE_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq -r '.items[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/$DRIVE_FILE_ID/permissions | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/permissions
 ```
 
 ```shell
-export DRIVE_FILE_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files | jq -r '.files[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files/$DRIVE_FILE_ID/permissions\?fields=\* | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/permissions?fields=*
 ```
 
 ### Comments
 YMMV, as file at index `0` must actually be a type that has comments for this to return
-anything. You can play with that value until you find something that does.
+anything. You can play with different file IDs until you find something that does.
 
 **NOTE probably blocked by OAuth metadata only scope!!**
 ```shell
-export DRIVE_FILE_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq -r '.items[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/$DRIVE_FILE_ID/comments | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/comments
 ```
-
 
 ```shell
-export DRIVE_FILE_ID=`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files | jq -r '.files[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v3/files/$DRIVE_FILE_ID/comments\?fields=\* | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/comments?fields=*
 ```
-
 
 ### Comment
 
 **NOTE probably blocked by OAuth metadata only scope!!**
 
+1. Get file comment ID (accessor path in response `.items[0].id`):
 ```shell
-export DRIVE_FILE_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq -r '.items[0].id'`
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/comments
+```
 
-export DRIVE_COMMENT_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/\`echo $DRIVE_FILE_ID\`/comments  | jq -r '.items[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/$DRIVE_FILE_ID/comments/`echo $DRIVE_COMMENT_ID` | jq .
+2. Get file comment details (replace `file_comment_id` with the corresponding value):
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/comments/[file_comment_id]
 ```
 
 ### Replies
 **NOTE probably blocked by OAuth metadata only scope!!**
 
-YMMV, as above, play with the index values until you find a file with comments, and a comment that
+YMMV, as above, play with the file comment ID value until you find a file with comments, and a comment that
 has replies.
+
 ```shell
-export DRIVE_FILE_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files | jq -r '.items[0].id'`
-
-export DRIVE_COMMENT_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/\`echo $DRIVE_FILE_ID\`/comments  | jq -r '.items[0].id'`
-
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gdrive/drive/v2/files/$DRIVE_FILE_ID/comments/`echo $DRIVE_COMMENT_ID`/replies | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gdrive/drive/v2/files/[drive_file_id]/comments/[file_comment_id]/replies
 ```
 
 ## GMail
 
 ### Messages
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gmail/gmail/v1/users/me/messages | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gmail/gmail/v1/users/me/messages
 ```
 
 ### Message
 ```shell
-export GMAIL_MESSAGE_ID=`./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gmail/gmail/v1/users/me/messages | jq -r '.messages[0].id'`
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-gmail/gmail/v1/users/me/messages/`echo $GMAIL_MESSAGE_ID`\?format=metadata | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-gmail/gmail/v1/users/me/messages/[gmail_message_id]?format=metadata
 ```
 
 ## Google Chat
 
 NOTE: limited to 10 results, to keep it readable.
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-google-chat/admin/reports/v1/activity/users/all/applications/chat\?maxResults=10 | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-google-chat/admin/reports/v1/activity/users/all/applications/chat?maxResults=10
 ```
 
 ## Google Meet
 
 NOTE: limited to 10 results, to keep it readable.
 ```shell
-./test-psoxy.sh $OPTIONS -u $PSOXY_BASE/psoxy-google-meet/admin/reports/v1/activity/users/all/applications/meet\?maxResults=10 | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/psoxy-google-chat/admin/reports/v1/activity/users/all/applications/meet?maxResults=10
 ```

--- a/docs/example-api-calls/slack-discovery.md
+++ b/docs/example-api-calls/slack-discovery.md
@@ -1,71 +1,68 @@
 # API Call Examples for Slack Discovery
 
-Example commands that you can use to validate proxy behavior against the Slack Discovery APIs.
+Example commands (*) that you can use to validate proxy behavior against the Slack Discovery APIs.
 Follow the steps and change the values to match your configuration when needed.
 
+For AWS, change the role to assume with one with sufficient permissions to call the proxy (`-r` flag). Example:
+
 ```shell
-export PROXY_SLACK_URL=https://YOUR_PSOXY_HOST/psoxy-slack-discovery-api
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.enterprise.info -r arn:aws:iam::PROJECT_ID:role/ROLE_NAME
 ```
 
-For GCP, use
-```shell
-export OPTIONS="-g"
-```
+If any call appears to fail, repeat it using the `-v` flag.
 
-For AWS, change the role to impersonate with one with sufficient permissions to call the proxy
-```shell
-export AWS_ROLE_ARN="arn:aws:iam::PROJECT_ID:role/ROLE_NAME"
-export OPTIONS="-a -r $AWS_ROLE_ARN"
-```
-
-If any call appears to fail, repeat it without the pipe to jq (eg, remove `| jq ...` portion from
-the end of the command) and "-v" flag.
+(*) All commands assume that you are at the root path of the Psoxy project.
 
 ### Read workspaces
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.enterprise.info | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.enterprise.info
 ```
 
 ### Read Users in Grid
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.users.list?include_deleted=true | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.users.list?include_deleted=true
 ```
 
 ### Read Conversations in Workspace (any kind, public and private)
 
-Next calls operate on a workspace so get an arbitrary workspace in variable
+1. Get a workspace ID (accessor path in response `.enterprise.teams[0].id`):
 ```shell
-export WORKSPACE_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.enterprise.info?limit=1 | jq -r '.enterprise.teams[0].id'`
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.enterprise.info?limit=1
 ```
-
+2. Get conversation details of that workspace (replace `workspace_id` with the corresponding value):
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.list?team=$WORKSPACE_ID\&limit=10 | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.list?team=[workspace_id]&limit=10
 ```
 
 ### Read Messages in Workspace Channel
 
-Next call operate on channels belonging to a workspace. Get an arbitrary channel in variable
+1. Get a channel ID (accessor path in response `.channels[0].id`):
 ```shell
-# get a workspace channel
-export CHANNEL_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.list?team=$WORKSPACE_ID\&limit=10 | jq -r '.channels[0].id'`
-# or for a DM (no workspace)
-export CHANNEL_ID=`./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.list?limit=10 | jq -r '.channels[0].id'`
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.list?team=[workspace_id]&limit=10
 ```
-
+2. Get DM information (no workspace):
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.history?team=$WORKSPACE_ID\&channel=$CHANNEL_ID\&limit=10 | jq .
-# omit the workspace id if channel is a DM
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.history?channel=$CHANNEL_ID\&limit=10 | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.list?limit=10
+```
+3. Read messages for workspace channel:1
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.history?team=[workspace_id]&channel=[channel_id]&limit=10
+```
+4. Omit the workspace ID if channel is a DM
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.history?channel=[channel_id]&limit=10
 ```
 
 ### Workspace Channel Info
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.info?team=$WORKSPACE_ID\&channel=$CHANNEL_ID\&limit=1 | jq .
-# omit the workspace id if channel is a DM
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.info?channel=$CHANNEL_ID\&limit=1 | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.info?team=[workspace_id]&channel=[channel_id]&limit=1
+```
+Omit the workspace ID if channel is a DM
+```shell
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.info?channel=[channel_id]&limit=1
 ```
 
 ### Recent Workspace Conversations
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_SLACK_URL/api/discovery.conversations.recent | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/api/discovery.conversations.recent
 ```

--- a/docs/example-api-calls/zoom.md
+++ b/docs/example-api-calls/zoom.md
@@ -1,63 +1,46 @@
 # API Call Examples for Zoom
 
-Example commands that you can use to validate proxy behavior against the Zoom APIs.
+Example commands (*) that you can use to validate proxy behavior against the Zoom APIs.
 Follow the steps and change the values to match your configuration when needed.
 
+For AWS, change the role to assume with one with sufficient permissions to call the proxy (`-r` flag). Example:
+
 ```shell
-export PROXY_ZOOM_URL=https://YOUR_PSOXY_HOST/psoxy-zoom
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/users -r arn:aws:iam::PROJECT_ID:role/ROLE_NAME
 ```
 
-For GCP, use
-```shell
-export OPTIONS="-g"
-```
+If any call appears to fail, repeat it using the `-v` flag.
 
-For AWS, change the role to impersonate with one with sufficient permissions to call the proxy
-```shell
-export AWS_ROLE_ARN="arn:aws:iam::PROJECT_ID:role/ROLE_NAME"
-export OPTIONS="-a -r $AWS_ROLE_ARN"
-```
-
-If any call appears to fail, repeat it without the pipe to jq (eg, remove `| jq ...` portion from
-the end of the command) and "-v" flag.
+(*) All commands assume that you are at the root path of the Psoxy project.
 
 ### List users
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/users | jq .
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/users
 ```
-Now pull out a user id, and add it as env variable. Next calls are bound to a single user.
-```shell
-export ZOOM_USER_ID=$(./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/users | jq -r .users[0].id | jq -r .original)
-```
-
+Now pull out a user id (`[zoom_user_id]`). Next call is bound to a single user:
 ### List user meetings
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/users/$ZOOM_USER_ID/meetings
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/users/[zoom_user_id]/meetings
 ```
 
 ## Meetings
-First pull out a meeting id, and add it as env variable
-
-```shell
-export MEETING_ID=$(./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/users/$ZOOM_USER_ID/meetings | jq -r .meetings[0].id)
-```
-
+First pull out a meeting id (`[zoom_meeting_id]`):
 ### List past meeting details
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/past_meetings/$MEETING_ID
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/past_meetings/[zoom_meeting_id]
 ```
 
 ### List past meeting instances
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/past_meetings/$MEETING_ID/instances
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/past_meetings/[zoom_meeting_id]/instances
 ```
 
 ### List past meeting participants
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/past_meetings/$MEETING_ID/participants
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/past_meetings/[zoom_meeting_id]/participants
 ```
 
 ### Get meeting details
 ```shell
-./test-psoxy.sh $OPTIONS -u $PROXY_ZOOM_URL/v2/meetings/$MEETING_ID
+node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/meetings/[zoom_meeting_id]
 ```

--- a/docs/example-api-calls/zoom.md
+++ b/docs/example-api-calls/zoom.md
@@ -17,14 +17,14 @@ If any call appears to fail, repeat it using the `-v` flag.
 ```shell
 node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/users
 ```
-Now pull out a user id (`[zoom_user_id]`). Next call is bound to a single user:
+Now pull out a user id (`[zoom_user_id]`, accessor path in response `.users[0].id`). Next call is bound to a single user:
 ### List user meetings
 ```shell
 node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/users/[zoom_user_id]/meetings
 ```
 
 ## Meetings
-First pull out a meeting id (`[zoom_meeting_id]`):
+First pull out a meeting id (`[zoom_meeting_id]`, accessor path in response `.meetings[0].id`):
 ### List past meeting details
 ```shell
 node tools/psoxy-test/cli.js -u [your_psoxy_url]/v2/past_meetings/[zoom_meeting_id]

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -47,7 +47,7 @@ locals {
   proxy_endpoint_url  = substr(aws_lambda_function_url.lambda_url.function_url, 0, length(aws_lambda_function_url.lambda_url.function_url) - 1)
   impersonation_param = var.example_api_calls_user_to_impersonate == null ? "" : " -i \"${var.example_api_calls_user_to_impersonate}\""
   test_commands = [for path in var.example_api_calls :
-    "${var.path_to_repo_root}tools/test-psoxy.sh -a -r \"${var.aws_assume_role_arn}\" -u \"${local.proxy_endpoint_url}${path}\"${local.impersonation_param}"
+    "node ${var.path_to_repo_root}tools/psoxy-test/cli.js -r \"${var.aws_assume_role_arn}\" -u \"${local.proxy_endpoint_url}${path}\"${local.impersonation_param}"
   ]
 }
 
@@ -63,23 +63,12 @@ Review the deployed function in AWS console:
 
 ### Prereqs
 Requests to AWS API need to be [signed](https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html).
-One tool to do it easily is [awscurl](https://github.com/okigan/awscurl). Install it:
+Our Node.js based testing tool does it, but the machine running the testing script must have
+the appropriate AWS credentials (you can use [aws-mfa](https://github.com/broamski/aws-mfa) or any
+similar tool).
 
-On MacOS via Homebrew:
-```shell
-brew install awscurl
-```
-
-Alternatively, via `pip` (python package manager):
-```shell
-pip install awscurl
-# Installs in $HOME/.local/bin
-# Make it available in your path
-# Add the following line to ~/.bashrc
-export PATH="$HOME/.local/bin:$PATH"
-# Then reload the config
-source ~/.bashrc
-```
+- [Node.js] >= v16
+- [npm] >= v8
 
 ### From Terminal
 

--- a/tools/psoxy-test/README.md
+++ b/tools/psoxy-test/README.md
@@ -1,0 +1,13 @@
+# Psoxy testing tool
+
+Node.js based testing tool for Worklytics Psoxy, AWS and CGP deploys.
+
+## Requirements
+
+[Node.js](version >=16) and [npm] (version >=8).
+
+1. `npm i` 
+2. `node tools/psoxy-test/cli.js -h`
+
+[Node.js]: https://nodejs.org/en/
+[npm]: https://www.npmjs.com

--- a/tools/psoxy-test/cli.js
+++ b/tools/psoxy-test/cli.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { createRequire } from 'module';
+import { Command } from 'commander';
+import chalk from 'chalk';
+import psoxyTest from './index.js';
+
+const require = createRequire(import.meta.url);
+const { name, version, description } = require('./package.json');
+
+const theme = {
+  error: chalk.bold.red,
+  success: chalk.green,
+};
+
+(async function () {
+  const program = new Command();
+
+  program
+    .name(name)
+    .version(version)
+    .description(description)
+    .requiredOption('-u, --url <url>', 'URL to call')
+    .option('-f, --force <type>', 'Force deploy type: AWS or GCP')
+    .option('-i, --impersonate <user>', 'User to impersonate, needed for certain connectors')
+    .option('-r, --role <arn>', 'AWS role to assume, use its ARN')
+    .option(
+      '-s, --skip',
+      'Skip sanitization rules, only works if function deployed in development mode',
+      false
+    )
+    .option('-t, --token <token>', 'Authorization token for GCP')
+    .option('-v, --verbose', 'Verbose output', false)
+    .option('-z, --gzip', 'Add gzip compression header', false)
+    .configureOutput({
+      wirteOut: undefined,
+      writeErr: undefined,
+    });
+
+  program.addHelpText(
+    'after',
+    `Example call: ${name} -u https://url-to-psoxy-function/path-to-api`
+  );
+
+  program.parse(process.argv);
+  const options = program.opts();
+
+  const result = await psoxyTest(options);
+
+  if (result.error) {
+    console.error(`${theme.error(result.error)}`);
+  } else {
+    console.log(`${theme.success('OK')}`);
+    console.log(JSON.stringify(result.response.data, undefined, 4));
+  }
+})();

--- a/tools/psoxy-test/cli.js
+++ b/tools/psoxy-test/cli.js
@@ -32,8 +32,7 @@ const theme = {
     .option('-v, --verbose', 'Verbose output', false)
     .option('-z, --gzip', 'Add gzip compression header', false)
     .configureOutput({
-      wirteOut: undefined,
-      writeErr: undefined,
+      outputError: (str, write) => write(theme.error(str)),
     });
 
   program.addHelpText(

--- a/tools/psoxy-test/index.js
+++ b/tools/psoxy-test/index.js
@@ -1,0 +1,85 @@
+import aws from './lib/aws.js';
+import gcp from './lib/gcp.js';
+
+/**
+ * @typedef {Object} PsoxyResponse
+ * @property {string} error - Error message if any
+ * @property {number} status - HTTP request status code
+ * @property {Object} data - HTTP request body (JSON)
+ */
+
+/**
+ * Psoxy test call
+ *
+ * @param {Object} options
+ * @param {string} options.url - Psoxy URL to call
+ * @param {string} options.force - Force URL as AWS or GCP deploy
+ * @param {string} options.impersonate - User to impersonate (Google Workspace API)
+ * @param {string} options.token - Authorization token for GCP deploys
+ * @param {string} options.role - AWS role to assume when calling the Psoxy (ARN format)
+ * @param {boolean} options.skip - Whether to skip or not sanitization rules (only in DEV mode)
+ * @param {boolean} options.gzip - Add Gzip compression headers
+ * @param {boolean} options.verbose - Verbose ouput (default to console)
+ * @return {PsoxyResponse}
+ */
+export default async function (options = {}) {
+  const result = {};
+  let url;
+
+  try {
+    url = new URL(options.url);
+  } catch (err) {
+    result.error = `"${options.url}" is not a valid URL`;
+    return result;
+  }
+
+  const isAWS = aws.isAWS(url);
+  const isGCP = gcp.isGCP(url);
+  let test;
+
+  if (options.force && ['aws', 'gcp'].includes(options.force.toLowerCase())) {
+    test = options.force === 'aws' ? aws.test : gcp.test;
+  } else if (!isAWS && !isGCP) {
+    result.error = `"${options.url}" doesn't seem to be a valid endpoint: AWS or GCP`;
+    return result;
+  } else {
+    test = isAWS ? aws.test : gcp.test;
+  }
+
+  try {
+    const response = await test(options);
+    if (response.status === 200) {
+      const data = await response.json();
+
+      result.response = {
+        status: response.status,
+        data: data,
+      };
+    } else {
+      const psoxyError = response.headers.get('x-psoxy-error');
+
+      if (psoxyError) {
+        switch (psoxyError) {
+          case 'BLOCKED_BY_RULES':
+            result.error = 'Blocked by rules error: make sure URL path is correct';
+            break;
+          case 'CONNECTION_SETUP':
+            result.error =
+              'Connection setup error: make sure the data source is properly configured';
+            break;
+          case 'API_ERROR':
+            result.error = 'API error: call to data source failed';
+            break;
+          default:
+            result.error = psoxyError;
+        }
+      } else {
+        result.error = response.statusText;
+      }
+    }
+  } catch (err) {
+    result.error = err.message;
+  }
+
+  return result;
+}

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -49,15 +49,15 @@ async function fetchAWS(options = {}, credentials = {}) {
     }
   );
 
-  if (options.impersonate) {
-    headers['X-Psoxy-User-To-Impersonate'] = options.impersonate;
-  }
-
   const headers = {
     ...signed.headers,
     'Accept-encoding': options.gzip ? 'gzip' : 'none',
     'X-Psoxy-Skip-Sanitizer': options.skip.toString(),
   };
+  if (options.impersonate) {
+    headers['X-Psoxy-User-To-Impersonate'] = options.impersonate;
+  }
+
   console.log('Waiting response...');
 
   if (options.verbose) {

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -1,0 +1,103 @@
+import { execSync } from 'child_process';
+import aws4 from 'aws4';
+import fetch from 'node-fetch';
+
+/**
+ * Call AWS cli to get temporary security credentials.
+ *
+ * Refs:
+ * - https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html
+ * - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns
+ *
+ * @param {String} role AWS IAM ARN format
+ * @returns {Object} AWS credentials for role
+ */
+function assumeRole(role) {
+  console.log(`Assuming role ${role}`);
+  // one-liner for simplicity
+  const command = `aws sts assume-role --role-arn ${role} --duration 900 --role-session-name lambda_test`;
+  const result = execSync(command).toString();
+  return JSON.parse(result);
+}
+
+/**
+ * Fetch AWS endpoint
+ *
+ * @param {Object} options - see `../index.js`
+ * @param {Object} credentials
+ * @returns {Promise}
+ */
+async function fetchAWS(options = {}, credentials = {}) {
+  const awsURL = new URL(options.url);
+  console.log('Calling psoxy...');
+  console.log(`Request: ${options.url}`);
+
+  // aws4 is not able to parse a full URL:
+  // https://[id].lambda-url.us-east-1.on.aws/
+  // the result is missing `service` and `region` which are mandatory
+  const signed = aws4.sign(
+    {
+      host: awsURL.host,
+      path: awsURL.pathname,
+      service: 'lambda',
+      region: awsURL.host.split('.')[2],
+    },
+    {
+      accessKeyId: credentials?.Credentials.AccessKeyId,
+      secretAccessKey: credentials?.Credentials.SecretAccessKey,
+      sessionToken: credentials?.Credentials.SessionToken,
+    }
+  );
+
+  if (options.impersonate) {
+    headers['X-Psoxy-User-To-Impersonate'] = options.impersonate;
+  }
+
+  const headers = {
+    ...signed.headers,
+    'Accept-encoding': options.gzip ? 'gzip' : 'none',
+    'X-Psoxy-Skip-Sanitizer': options.skip.toString(),
+  };
+  console.log('Waiting response...');
+
+  if (options.verbose) {
+    console.log('Options:');
+    console.log(options);
+    console.log('Request headers:');
+    console.log(headers);
+  }
+
+  return await fetch(options.url, { headers: headers });
+}
+
+/**
+ * Helper: check url deploy type
+ *
+ * @param {String|URL} url
+ * @return {boolean}
+ */
+function isAWS(url) {
+  if (typeof url === 'string') {
+    url = new URL(url);
+  }
+  return url.hostname.endsWith('.on.aws');
+}
+
+/**
+ * Psoxy test
+ *
+ * @param {Object} options
+ * @returns {Promise}
+ */
+async function test(options = {}) {
+  if (!options.role) {
+    throw new Error('Role is a required option for AWS');
+  }
+  const credentials = assumeRole(options.role);
+  return await fetchAWS(options, credentials);
+}
+
+export default {
+  isAWS: isAWS,
+  test: test,
+};

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -1,0 +1,54 @@
+import fetch from 'node-fetch';
+
+/**
+ * Helper: check url deploy type
+ *
+ * @param {String|URL} url
+ * @return {boolean}
+ */
+function isGCP(url) {
+  if (typeof url === 'string') {
+    url = new URL(url);
+  }
+  return url.hostname.endsWith('cloudfunctions.net');
+}
+
+/**
+ * Psoxy test
+ *
+ * @param {Object} options - see `../index.js`
+ * @returns {Promise}
+ */
+async function test(options = {}) {
+  if (!options.token) {
+    throw new Error('Authorization token is required for GCP endpoints');
+  }
+
+  const headers = {
+    'Accept-encoding': options.gzip ? 'gzip' : 'none',
+    'X-Psoxy-Skip-Sanitizer': options.skip.toString(),
+    Authorization: `Bearer ${options.token}`,
+  };
+
+  if (options.impersonate) {
+    headers['X-Psoxy-User-To-Impersonate'] = options.impersonate;
+  }
+
+  console.log('Calling psoxy...');
+  console.log(`Request: ${options.url}`);
+  console.log('Waiting response...');
+
+  if (options.verbose) {
+    console.log('Options:');
+    console.log(options);
+    console.log('Request headers:');
+    console.log(headers);
+  }
+
+  return await fetch(options.url, { headers: headers });
+}
+
+export default {
+  isGCP: isGCP,
+  test: test,
+};

--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "psoxy-test",
+  "version": "0.4.1",
+  "private": "true",
+  "type": "module",
+  "description": "Worklytics Psoxy testing tool",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Worklytics/psoxy.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Worklytics/psoxy/issues"
+  },
+  "homepage": "https://github.com/Worklytics/psoxy#readme",
+  "dependencies": {
+    "aws4": "^1.11.0",
+    "chalk": "^5.0.1",
+    "commander": "^9.4.0",
+    "node-fetch": "^3.2.10"
+  }
+}

--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psoxy-test",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "private": "true",
   "type": "module",
   "description": "Worklytics Psoxy testing tool",


### PR DESCRIPTION
Replaces: https://github.com/Worklytics/psoxy/pull/135
Initial version of the testing tool, `v0.4.3` (same as Psoxy).

### Fixes
.

### Features
 - [replace proxy test script with node alternative](https://app.asana.com/0/1201039336231823/1202818447690962/f)

### Change implications

 - dependencies added/changed? **no**
