### PR TITLE
S131 zoom connector server-to-server oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,14 @@ terraform apply
 
 ## Releases
 
-### [v0.4.3](https://github.com/Worklytics/psoxy/releases/tag/v0.4.3)
+### [v0.4.4](https://github.com/Worklytics/psoxy/releases/tag/v0.4.4)
 The `main` branch is current at 0.4.
+
+Features:
+- Zoom connector now is built against Server-to-server OAuth apps, removing the use of the JWT application (will be deprecated in June 2023).
+
+
+### [v0.4.3](https://github.com/Worklytics/psoxy/releases/tag/v0.4.3)
 
 Features:
   - **transiently reversible pseudonyms** - rules to support returning  'transiently' reversible

--- a/configs/zoom.yaml
+++ b/configs/zoom.yaml
@@ -3,5 +3,5 @@ SOURCE_AUTH_STRATEGY_IDENTIFIER: oauth2_refresh_token
 TARGET_HOST: api.zoom.us
 OAUTH_SCOPES:
 IDENTIFIER_SCOPE_ID: zoom
-GRANT_TYPE: application_credentials
+GRANT_TYPE: account_credentials
 REFRESH_ENDPOINT: https://zoom.us/oauth/token

--- a/configs/zoom.yaml
+++ b/configs/zoom.yaml
@@ -1,5 +1,7 @@
 SOURCE: zoom
-SOURCE_AUTH_STRATEGY_IDENTIFIER: oauth2_access_token
+SOURCE_AUTH_STRATEGY_IDENTIFIER: oauth2_refresh_token
 TARGET_HOST: api.zoom.us
 OAUTH_SCOPES:
 IDENTIFIER_SCOPE_ID: zoom
+GRANT_TYPE: application_credentials
+REFRESH_ENDPOINT: https://zoom.us/oauth/token

--- a/infra/examples-dev/aws-google-workspace/.gitignore
+++ b/infra/examples-dev/aws-google-workspace/.gitignore
@@ -1,0 +1,17 @@
+# this .gitignore is to avoid committing various Terraform files to repo for examples/
+# when you copy example for actual use, you should delete this .gitignore file and
+# commit these to your repo
+
+# ignore terraform variables / state for examples
+# NOTE: for prod use, you likely want to remove this f
+terraform.tfvars
+
+# Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
+# terraform state - not storing state on local disk / repo
+terraform.tfstate**
+.terraform.tfstate.lock.info
+
+.terraform.lock.hcl
+.terraform/**
+TODO*
+test*

--- a/infra/examples-dev/aws-google-workspace/README.md
+++ b/infra/examples-dev/aws-google-workspace/README.md
@@ -1,0 +1,23 @@
+# AWS
+
+Example Terraform configuration for deploying psoxy in AWS and connecting to Google Workspace sources
+
+Example `terraform.tfvars`:
+```terraform
+aws_account_id                = "123456789" # your AWS account ID
+aws_assume_role_arn           = "arn:aws:iam::123456789:role/InfraAdmin" # sufficiently privileged role within your AWS account to provision necessary infra
+caller_aws_arns = [
+  "arn:aws:iam::914358739851:root" # for production use, this should be Worklytics' AWS account; for testing, it can be your own AWS account
+]
+caller_gcp_service_account_ids = [
+  "123456712345671234567" # 21-digit numeric string you should obtain from Worklytics
+]
+
+gcp_project_id                = "psoxy-dev-aws-example-12314332"
+gcp_org_id                    = "123456789" # your GCP organization ID; if existing project, you can leave as empty string and see the value from `terraform plan`
+gcp_folder_id                 = "111111111111" # folder ID for the project; if existing project, you can leave as empty string and see the value from `terraform plan`
+gcp_billing_account_id        = "123456-789ABC-DEF012" # GCP billing account ID for project; if existing project, you can leave as empty string and see the value from `terraform plan`
+psoxy_base_dir                = "~/psoxy/" # TODO: we suggest using absolute path here
+```
+
+

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -61,7 +61,7 @@ locals {
 
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.4"
 
   enabled_connectors = [
     "gdirectory",
@@ -79,7 +79,7 @@ module "worklytics_connector_specs" {
 
 module "psoxy-aws" {
   source = "../../modules/aws" # to bind with local
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.4"
 
   aws_account_id                 = var.aws_account_id
   psoxy_base_dir                 = var.psoxy_base_dir
@@ -111,7 +111,7 @@ module "google-workspace-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/google-workspace-dwd-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.4"
 
   project_id                   = google_project.psoxy-google-connectors.project_id
   connector_service_account_id = "psoxy-${each.key}"
@@ -129,7 +129,7 @@ module "google-workspace-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/gcp-sa-auth-key-aws-secret"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.4.4"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
   secret_id          = "PSOXY_${replace(upper(each.key), "-", "_")}_SERVICE_ACCOUNT_KEY"
@@ -139,7 +139,7 @@ module "psoxy-google-workspace-connector" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.4"
 
   function_name                         = "psoxy-${each.key}"
   source_kind                           = each.key
@@ -164,7 +164,7 @@ module "worklytics-psoxy-connection-google-workspace" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/worklytics-psoxy-connection-aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.4"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
@@ -210,7 +210,7 @@ module "source_token_external_todo" {
   for_each = local.enabled_oauth_long_access_connectors_todos
 
   source = "../../modules/source-token-external-todo"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.4"
 
   source_id                         = each.key
   host_cloud                        = "aws"
@@ -222,7 +222,7 @@ module "aws-psoxy-long-auth-connectors" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.4"
 
 
   function_name                  = "psoxy-${each.key}"
@@ -246,7 +246,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/worklytics-psoxy-connection-aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.4"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
@@ -261,7 +261,7 @@ module "psoxy-bulk" {
   for_each = local.bulk_sources
 
   source = "../../modules/aws-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.4"
 
   aws_account_id       = var.aws_account_id
   aws_assume_role_arn  = var.aws_assume_role_arn

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -1,0 +1,276 @@
+terraform {
+  required_providers {
+    # for the infra that will host Psoxy instances
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.12"
+    }
+
+    # for the API connections to Google Workspace
+    google = {
+      version = ">= 3.74, <= 5.0"
+    }
+  }
+
+  # if you leave this as local, you should backup/commit your TF state files
+  backend "local" {
+  }
+}
+
+# NOTE: you need to provide credentials. usual way to do this is to set env vars:
+#        AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+# see https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication for more
+# information as well as alternative auth approaches
+provider "aws" {
+  region = var.aws_region
+
+  assume_role {
+    role_arn = var.aws_assume_role_arn
+  }
+  allowed_account_ids = [
+    var.aws_account_id
+  ]
+}
+
+
+locals {
+  base_config_path = "${var.psoxy_base_dir}/configs/"
+  bulk_sources = {
+    "hris" = {
+      source_kind = "hris"
+      rules = {
+        columnsToRedact = []
+        columnsToPseudonymize = [
+          "email",
+          "employee_id"
+        ]
+      }
+    },
+    "qualtrics" = {
+      source_kind = "qualtrics"
+      rules = {
+        columnsToRedact = []
+        columnsToPseudonymize = [
+          "email",
+          "employee_id"
+        ]
+      }
+    }
+  }
+}
+
+module "worklytics_connector_specs" {
+  source = "../../modules/worklytics-connector-specs"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
+
+  enabled_connectors = [
+    "gdirectory",
+    "gcal",
+    "gmail",
+    "gdrive",
+    "google-chat",
+    "google-meet",
+    "asana",
+    "slack-discovery-api",
+    "zoom",
+  ]
+  google_workspace_example_user = var.google_workspace_example_user
+}
+
+module "psoxy-aws" {
+  source = "../../modules/aws" # to bind with local
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.3"
+
+  aws_account_id                 = var.aws_account_id
+  psoxy_base_dir                 = var.psoxy_base_dir
+  caller_aws_arns                = var.caller_aws_arns
+  caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
+}
+
+# holds SAs + keys needed to connect to Google Workspace APIs
+resource "google_project" "psoxy-google-connectors" {
+  name            = "Worklytics Connect%{if var.environment_name != ""} - ${var.environment_name}%{endif}"
+  project_id      = var.gcp_project_id
+  billing_account = var.gcp_billing_account_id
+  folder_id       = var.gcp_folder_id # if project is at top-level of your GCP organization, rather than in a folder, comment this line out
+  # org_id          = var.gcp_org_id # if project is in a GCP folder, this value is implicit and this line should be commented out
+
+  # NOTE: these are provide because OFTEN customers have pre-existing GCP project; if such, there's
+  # usually no need to specify folder_id/org_id/billing_account and have changes applied
+  lifecycle {
+    ignore_changes = [
+      org_id,
+      folder_id,
+      billing_account,
+    ]
+  }
+}
+
+
+module "google-workspace-connection" {
+  for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
+
+  source = "../../modules/google-workspace-dwd-connection"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.3"
+
+  project_id                   = google_project.psoxy-google-connectors.project_id
+  connector_service_account_id = "psoxy-${each.key}"
+  display_name                 = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
+  apis_consumed                = each.value.apis_consumed
+  oauth_scopes_needed          = each.value.oauth_scopes_needed
+
+  depends_on = [
+    module.psoxy-aws,
+    google_project.psoxy-google-connectors
+  ]
+}
+
+module "google-workspace-connection-auth" {
+  for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
+
+  source = "../../modules/gcp-sa-auth-key-aws-secret"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.4.3"
+
+  service_account_id = module.google-workspace-connection[each.key].service_account_id
+  secret_id          = "PSOXY_${replace(upper(each.key), "-", "_")}_SERVICE_ACCOUNT_KEY"
+}
+
+module "psoxy-google-workspace-connector" {
+  for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
+
+  source = "../../modules/aws-psoxy-rest"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+
+  function_name                         = "psoxy-${each.key}"
+  source_kind                           = each.key
+  path_to_function_zip                  = module.psoxy-aws.path_to_deployment_jar
+  function_zip_hash                     = module.psoxy-aws.deployment_package_hash
+  path_to_config                        = "${local.base_config_path}/${each.key}.yaml"
+  api_caller_role_arn                   = module.psoxy-aws.api_caller_role_arn
+  aws_assume_role_arn                   = var.aws_assume_role_arn
+  aws_account_id                        = var.aws_account_id
+  path_to_repo_root                     = var.psoxy_base_dir
+  example_api_calls                     = each.value.example_api_calls
+  example_api_calls_user_to_impersonate = each.value.example_api_calls_user_to_impersonate
+
+  parameters = [
+    module.psoxy-aws.salt_secret,
+    module.google-workspace-connection-auth[each.key].key_secret
+  ]
+}
+
+
+module "worklytics-psoxy-connection-google-workspace" {
+  for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
+
+  source = "../../modules/worklytics-psoxy-connection-aws"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+
+  psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
+  display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
+  aws_region         = var.aws_region
+  aws_role_arn       = module.psoxy-aws.api_caller_role_arn
+}
+
+
+# BEGIN LONG ACCESS AUTH CONNECTORS
+
+locals {
+  enabled_oauth_long_access_connectors_todos = { for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
+
+  secrets_to_create = distinct(flatten([
+    for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : [
+      for secret_name in v.secured_variables : {
+        connector_name = k
+        secret_name    = secret_name
+      }
+    ]
+  ]))
+}
+
+
+# Create secret (later filled by customer)
+resource "aws_ssm_parameter" "long-access-secrets" {
+  for_each = { for entry in local.secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
+
+  name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
+  type        = "SecureString"
+  description = "Stores the value of ${upper(each.value.secret_name)} for `psoxy-${each.value.connector_name}`"
+  value       = sensitive("TODO: fill me with the proper value for ${upper(each.value.secret_name)}!! (via AWS console)")
+
+  lifecycle {
+    ignore_changes = [
+      value # we expect this to be filled via Console, so don't want to overwrite it with the dummy value if changed
+    ]
+  }
+}
+
+module "source_token_external_todo" {
+  for_each = local.enabled_oauth_long_access_connectors_todos
+
+  source = "../../modules/source-token-external-todo"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.3"
+
+  source_id                         = each.key
+  host_cloud                        = "aws"
+  connector_specific_external_steps = each.value.external_token_todo
+  token_secret_id                   = aws_ssm_parameter.long-access-secrets["${each.key}.${each.value.secured_variables[0]}"].name
+}
+
+module "aws-psoxy-long-auth-connectors" {
+  for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
+
+  source = "../../modules/aws-psoxy-rest"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+
+
+  function_name        = "psoxy-${each.key}"
+  path_to_function_zip = module.psoxy-aws.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-aws.deployment_package_hash
+  path_to_config       = "${local.base_config_path}/${each.value.source_kind}.yaml"
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  aws_account_id       = var.aws_account_id
+  api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
+  source_kind          = each.value.source_kind
+  path_to_repo_root    = var.psoxy_base_dir
+  example_api_calls    = each.value.example_api_calls
+
+  parameters = [
+    module.psoxy-aws.salt_secret,
+    # aws_ssm_parameter.long-access-secrets[each.key]
+  ]
+}
+
+module "worklytics-psoxy-connection" {
+  for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
+
+  source = "../../modules/worklytics-psoxy-connection-aws"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+
+  psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
+  display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
+  aws_region         = var.aws_region
+  aws_role_arn       = module.psoxy-aws.api_caller_role_arn
+}
+
+# END LONG ACCESS AUTH CONNECTORS
+
+
+module "psoxy-bulk" {
+  for_each = local.bulk_sources
+
+  source = "../../modules/aws-psoxy-bulk"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.3"
+
+  aws_account_id       = var.aws_account_id
+  aws_assume_role_arn  = var.aws_assume_role_arn
+  instance_id          = each.key
+  source_kind          = each.value.source_kind
+  aws_region           = var.aws_region
+  path_to_function_zip = module.psoxy-aws.path_to_deployment_jar
+  function_zip_hash    = module.psoxy-aws.deployment_package_hash
+  api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
+  api_caller_role_name = module.psoxy-aws.api_caller_role_name
+  psoxy_base_dir       = var.psoxy_base_dir
+  rules                = each.value.rules
+}

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -1,0 +1,96 @@
+variable "aws_account_id" {
+  type        = string
+  description = "id of aws account in which to provision your AWS infra"
+  validation {
+    condition     = can(regex("^\\d{12}$", var.aws_account_id))
+    error_message = "The aws_account_id value should be 12-digit numeric string."
+  }
+}
+
+variable "aws_assume_role_arn" {
+  type        = string
+  description = "arn of role Terraform should assume when provisioning your infra"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "default region in which to provision your AWS infra"
+}
+
+variable "caller_gcp_service_account_ids" {
+  type        = list(string)
+  description = "ids of GCP service accounts allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for i in var.caller_gcp_service_account_ids : (length(regexall("^\\d{21}$", i)) > 0)
+    ])
+    error_message = "The values of caller_gcp_service_account_ids should be 21-digit numeric strings."
+  }
+}
+
+variable "caller_aws_arns" {
+  type        = list(string)
+  description = "ARNs of AWS accounts allowed to send requests to the proxy (eg, arn:aws:iam::914358739851:root)"
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+    ])
+    error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
+  }
+}
+
+variable "gcp_project_id" {
+  type        = string
+  description = "id of GCP project that will host psoxy instance"
+}
+
+variable "environment_name" {
+  type        = string
+  description = "qualifier to append to name of project that will host your psoxy instance"
+  default     = ""
+}
+
+variable "gcp_folder_id" {
+  type        = string
+  description = "optionally, a folder into which to provision it"
+  default     = null
+}
+
+variable "gcp_billing_account_id" {
+  type        = string
+  description = "billing account ID; needed to create the project"
+  default     = null
+}
+
+variable "gcp_org_id" {
+  type        = string
+  description = "your GCP organization ID"
+  default     = null
+}
+
+variable "connector_display_name_suffix" {
+  type        = string
+  description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"
+  default     = ""
+}
+
+variable "psoxy_base_dir" {
+  type        = string
+  description = "the path where your psoxy repo resides. Preferably a full path, /home/user/repos/, avoid tilde (~) shortcut to $HOME"
+  default     = "../../../"
+
+  validation {
+    condition     = can(regex(".*\\/$", var.psoxy_base_dir))
+    error_message = "The psoxy_base_dir value should end with a slash."
+  }
+}
+
+variable "google_workspace_example_user" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for none)"
+}

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -288,7 +288,7 @@ module "psoxy-bulk" {
   for_each = local.bulk_sources
 
   source = "../../modules/aws-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.4"
 
   aws_account_id       = var.aws_account_id
   aws_assume_role_arn  = var.aws_assume_role_arn

--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -72,7 +72,7 @@ module "psoxy-gcp" {
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
   psoxy_base_dir    = var.psoxy_base_dir
-  psoxy_version     = "0.4.3"
+  psoxy_version     = "0.4.4"
   bucket_location   = var.gcp_region
 
   depends_on = [
@@ -193,7 +193,7 @@ module "psoxy-gcp-bulk" {
   for_each = local.bulk_sources
 
   source = "../../modules/gcp-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.3"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.4"
 
   project_id                    = google_project.psoxy-project.project_id
   worklytics_sa_emails          = var.worklytics_sa_emails

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -61,7 +61,7 @@ locals {
 
 module "worklytics_connector_specs" {
   # source = "../../modules/worklytics-connector-specs"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.4"
 
   enabled_connectors = [
     "gdirectory",
@@ -79,7 +79,7 @@ module "worklytics_connector_specs" {
 
 module "psoxy-aws" {
   # source = "../../modules/aws" # to bind with local
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.4"
 
   aws_account_id                 = var.aws_account_id
   psoxy_base_dir                 = var.psoxy_base_dir
@@ -111,7 +111,7 @@ module "google-workspace-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/google-workspace-dwd-connection"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.4"
 
   project_id                   = google_project.psoxy-google-connectors.project_id
   connector_service_account_id = "psoxy-${each.key}"
@@ -129,7 +129,7 @@ module "google-workspace-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/gcp-sa-auth-key-aws-secret"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-aws-secret?ref=v0.4.4"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
   secret_id          = "PSOXY_${replace(upper(each.key), "-", "_")}_SERVICE_ACCOUNT_KEY"
@@ -139,7 +139,7 @@ module "psoxy-google-workspace-connector" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/aws-psoxy-rest"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.4"
 
   function_name                         = "psoxy-${each.key}"
   source_kind                           = each.key
@@ -164,7 +164,7 @@ module "worklytics-psoxy-connection-google-workspace" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/worklytics-psoxy-connection-aws"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.4"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
@@ -210,7 +210,7 @@ module "source_token_external_todo" {
   for_each = local.enabled_oauth_long_access_connectors_todos
 
   # source = "../../modules/source-token-external-todo"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.4"
 
   source_id                         = each.key
   host_cloud                        = "aws"
@@ -222,7 +222,7 @@ module "aws-psoxy-long-auth-connectors" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   # source = "../../modules/aws-psoxy-rest"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.4"
 
 
   function_name                  = "psoxy-${each.key}"
@@ -246,7 +246,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   # source = "../../modules/worklytics-psoxy-connection-aws"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.4"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
@@ -261,7 +261,7 @@ module "psoxy-bulk" {
   for_each = local.bulk_sources
 
   # source = "../../modules/aws-psoxy-bulk"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.4"
 
   aws_account_id       = var.aws_account_id
   aws_assume_role_arn  = var.aws_assume_role_arn

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -60,8 +60,8 @@ locals {
 }
 
 module "worklytics_connector_specs" {
-  source = "../../modules/worklytics-connector-specs"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
+  # source = "../../modules/worklytics-connector-specs"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
 
   enabled_connectors = [
     "gdirectory",
@@ -173,26 +173,49 @@ module "worklytics-psoxy-connection-google-workspace" {
 }
 
 
-# BEGIN LONG ACCESS AUTH CONNECTORS
+# BEGIN AUTH CONNECTORS
 
 locals {
   enabled_oauth_long_access_connectors_todos = { for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
+
+  secrets_to_create = distinct(flatten([
+    for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : [
+      for secret_name in v.secured_variables : {
+        connector_name = k
+        secret_name    = secret_name
+      }
+    ]
+  ]))
 }
 
-# Create secret (later filled by customer)
-resource "aws_ssm_parameter" "long-access-token-secret" {
-  for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
-  name        = "PSOXY_${upper(replace(each.key, "-", "_"))}_ACCESS_TOKEN"
+# Create secure parameters (later filled by customer)
+# Can be later passed on to a module and store in other vault if needed
+resource "aws_ssm_parameter" "long-access-secrets" {
+  for_each = { for entry in local.secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
+
+  name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"
-  description = "The long lived token for `psoxy-${each.key}`"
-  value       = sensitive("TODO: fill me with a real token!! (via AWS console)")
+  description = "Stores the value of ${upper(each.value.secret_name)} for `psoxy-${each.value.connector_name}`"
+  value       = sensitive("TODO: fill me with the proper value for ${upper(each.value.secret_name)}!! (via AWS console)")
 
   lifecycle {
     ignore_changes = [
       value # we expect this to be filled via Console, so don't want to overwrite it with the dummy value if changed
     ]
   }
+}
+
+module "source_token_external_todo" {
+  for_each = local.enabled_oauth_long_access_connectors_todos
+
+  # source = "../../modules/source-token-external-todo"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.3"
+
+  source_id                         = each.key
+  host_cloud                        = "aws"
+  connector_specific_external_steps = each.value.external_token_todo
+  token_secret_id                   = aws_ssm_parameter.long-access-secrets["${each.key}.${each.value.secured_variables[0]}"].name
 }
 
 module "aws-psoxy-long-auth-connectors" {
@@ -202,35 +225,21 @@ module "aws-psoxy-long-auth-connectors" {
   source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
 
 
-  function_name        = "psoxy-${each.key}"
-  path_to_function_zip = module.psoxy-aws.path_to_deployment_jar
-  function_zip_hash    = module.psoxy-aws.deployment_package_hash
-  path_to_config       = "${local.base_config_path}/${each.value.source_kind}.yaml"
-  aws_assume_role_arn  = var.aws_assume_role_arn
-  aws_account_id       = var.aws_account_id
-  api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
-  source_kind          = each.value.source_kind
-  path_to_repo_root    = var.psoxy_base_dir
-  example_api_calls    = each.value.example_api_calls
-
+  function_name                  = "psoxy-${each.key}"
+  path_to_function_zip           = module.psoxy-aws.path_to_deployment_jar
+  function_zip_hash              = module.psoxy-aws.deployment_package_hash
+  path_to_config                 = "${local.base_config_path}/${each.value.source_kind}.yaml"
+  aws_assume_role_arn            = var.aws_assume_role_arn
+  aws_account_id                 = var.aws_account_id
+  api_caller_role_arn            = module.psoxy-aws.api_caller_role_arn
+  source_kind                    = each.value.source_kind
+  path_to_repo_root              = var.psoxy_base_dir
+  example_api_calls              = each.value.example_api_calls
+  reserved_concurrent_executions = each.value.reserved_concurrent_executions
   parameters = [
     module.psoxy-aws.salt_secret,
-    aws_ssm_parameter.long-access-token-secret[each.key]
+    # aws_ssm_parameter.long-access-secrets[each.key]
   ]
-
-
-}
-
-module "source_token_external_todo" {
-  for_each = local.enabled_oauth_long_access_connectors_todos
-
-  #source = "../../modules/source-token-external-todo"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.3"
-
-  source_id                         = each.key
-  host_cloud                        = "aws"
-  connector_specific_external_steps = each.value.external_token_todo
-  token_secret_id                   = aws_ssm_parameter.long-access-token-secret[each.key].name
 }
 
 module "worklytics-psoxy-connection" {

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -175,24 +175,10 @@ module "worklytics-psoxy-connection-google-workspace" {
 
 # BEGIN AUTH CONNECTORS
 
-locals {
-  enabled_oauth_long_access_connectors_todos = { for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
-
-  secrets_to_create = distinct(flatten([
-    for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : [
-      for secret_name in v.secured_variables : {
-        connector_name = k
-        secret_name    = secret_name
-      }
-    ]
-  ]))
-}
-
-
 # Create secure parameters (later filled by customer)
 # Can be later passed on to a module and store in other vault if needed
 resource "aws_ssm_parameter" "long-access-secrets" {
-  for_each = { for entry in local.secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
+  for_each = { for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
 
   name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"
@@ -207,7 +193,7 @@ resource "aws_ssm_parameter" "long-access-secrets" {
 }
 
 module "source_token_external_todo" {
-  for_each = local.enabled_oauth_long_access_connectors_todos
+  for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors_todos
 
   # source = "../../modules/source-token-external-todo"
   source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.4"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -227,25 +227,10 @@ module "worklytics-psoxy-connection" {
 
 
 # BEGIN AUTH CONNECTORS
-
-locals {
-  enabled_oauth_long_access_connectors_todos = { for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
-
-  secrets_to_create = distinct(flatten([
-    for k, v in module.worklytics_connector_specs.enabled_oauth_long_access_connectors : [
-      for secret_name in v.secured_variables : {
-        connector_name = k
-        secret_name    = secret_name
-      }
-    ]
-  ]))
-}
-
-
 # Create secure parameters (later filled by customer)
 # Can be later passed on to a module and store in other vault if needed
 resource "aws_ssm_parameter" "long-access-secrets" {
-  for_each = { for entry in local.secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
+  for_each = { for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
 
   name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"
@@ -260,7 +245,7 @@ resource "aws_ssm_parameter" "long-access-secrets" {
 }
 
 module "source_token_external_todo" {
-  for_each = local.enabled_oauth_long_access_connectors_todos
+  for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors_todos
 
   # source = "../../modules/source-token-external-todo"
   source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.4"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -64,7 +64,7 @@ locals {
 
 module "worklytics_connector_specs" {
   # source = "../../modules/worklytics-connector-specs"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.4"
 
   enabled_connectors = [
     "azure-ad",
@@ -82,11 +82,11 @@ module "worklytics_connector_specs" {
 
 module "psoxy-aws" {
   # source = "../../modules/aws"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.4"
 
   aws_account_id                 = var.aws_account_id
   psoxy_base_dir                 = var.psoxy_base_dir
-  psoxy_version                  = "0.4.3"
+  psoxy_version                  = "0.4.4"
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
 
@@ -104,7 +104,7 @@ module "msft-connection" {
 
 
   #source = "../../modules/azuread-connection"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.4"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -116,7 +116,7 @@ module "msft-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-local-cert"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.4.4"
 
   application_object_id = module.msft-connection[each.key].connector.id
   rotation_days         = 60
@@ -160,7 +160,7 @@ module "private-key-aws-parameters" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/private-key-aws-parameter"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/private-key-aws-parameter?ref=v0.4.4"
 
   instance_id = each.key
 
@@ -172,7 +172,7 @@ module "psoxy-msft-connector" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/aws-psoxy-rest"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.4"
 
   function_name        = "psoxy-${each.key}"
   source_kind          = each.value.source_kind
@@ -204,7 +204,7 @@ module "msft_365_grants" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-grant-all-users"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.4"
 
   application_id           = module.msft-connection[each.key].connector.application_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
@@ -217,7 +217,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/worklytics-psoxy-connection-aws"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.4"
 
   psoxy_endpoint_url = module.psoxy-msft-connector[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
@@ -263,7 +263,7 @@ module "source_token_external_todo" {
   for_each = local.enabled_oauth_long_access_connectors_todos
 
   # source = "../../modules/source-token-external-todo"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.4"
 
   source_id                         = each.key
   host_cloud                        = "aws"
@@ -275,7 +275,7 @@ module "aws-psoxy-long-auth-connectors" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   # source = "../../modules/aws-psoxy-rest"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.4"
 
 
   function_name                  = "psoxy-${each.key}"
@@ -299,7 +299,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   # source = "../../modules/worklytics-psoxy-connection-aws"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.4"
 
   psoxy_endpoint_url = module.aws-psoxy-long-auth-connectors[each.key].endpoint_url
   display_name       = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
@@ -313,7 +313,7 @@ module "psoxy-bulk" {
   for_each = local.bulk_sources
 
   # source = "../../modules/aws-psoxy-bulk"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.4"
 
   aws_account_id       = var.aws_account_id
   aws_assume_role_arn  = var.aws_assume_role_arn

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -68,12 +68,12 @@ resource "google_project" "psoxy-project" {
 
 module "psoxy-gcp" {
   # source = "../../modules/gcp"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.4.4"
 
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
   psoxy_base_dir    = var.psoxy_base_dir
-  psoxy_version     = "0.4.3"
+  psoxy_version     = "0.4.4"
   bucket_location   = var.gcp_region
 
 
@@ -87,7 +87,7 @@ module "google-workspace-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/google-workspace-dwd-connection"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.4"
 
 
   project_id                   = google_project.psoxy-project.project_id
@@ -105,7 +105,7 @@ module "google-workspace-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/gcp-sa-auth-key-secret-manager"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key-secret-manager?ref=v0.4.4"
 
   secret_project     = google_project.psoxy-project.project_id
   service_account_id = module.google-workspace-connection[each.key].service_account_id
@@ -116,7 +116,7 @@ module "psoxy-google-workspace-connector" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/gcp-psoxy-rest"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.4"
 
   project_id                            = google_project.psoxy-project.project_id
   instance_id                           = "psoxy-${each.key}"
@@ -144,7 +144,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   # source = "../../modules/worklytics-psoxy-connection"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.4"
 
   psoxy_endpoint_url = module.psoxy-google-workspace-connector[each.key].cloud_function_url
   display_name       = "${title(each.key)}${var.connector_display_name_suffix} via Psoxy"
@@ -165,7 +165,7 @@ module "connector-long-auth-block" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   # source                  = "../../modules/gcp-oauth-long-access-strategy"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-oauth-long-access-strategy?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-oauth-long-access-strategy?ref=v0.4.4"
 
 
   project_id              = google_project.psoxy-project.project_id
@@ -177,7 +177,7 @@ module "connector-long-auth-create-function" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   # source = "../../modules/gcp-psoxy-rest"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.4"
 
 
   project_id                    = google_project.psoxy-project.project_id
@@ -207,7 +207,7 @@ module "psoxy-gcp-bulk" {
   for_each = local.bulk_sources
 
   # source = "../../modules/gcp-psoxy-bulk"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.4"
 
   project_id                    = google_project.psoxy-project.project_id
   worklytics_sa_emails          = var.worklytics_sa_emails

--- a/infra/examples/msft-365/main.tf
+++ b/infra/examples/msft-365/main.tf
@@ -21,7 +21,7 @@ data "azuread_client_config" "current" {}
 
 module "worklytics_connector_specs" {
   # source = "../../modules/worklytics-connector-specs"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.4"
 
   enabled_connectors = [
     "azure-ad",
@@ -46,7 +46,7 @@ module "msft-connection" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-connection"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.4"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -61,7 +61,7 @@ module "msft-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-local-cert"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.4.4"
 
   application_object_id = module.msft-connection[each.key].connector.id
   rotation_days         = 60
@@ -99,7 +99,7 @@ module "msft_365_grants" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-grant-all-users"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.3"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.4"
 
   application_id           = module.msft-connection[each.key].connector.application_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -9,15 +9,16 @@ terraform {
 }
 
 resource "aws_lambda_function" "psoxy-instance" {
-  function_name    = var.function_name
-  role             = aws_iam_role.iam_for_lambda.arn
-  architectures    = ["arm64"] # 20% cheaper per ms exec time than x86_64
-  runtime          = "java11"
-  filename         = var.path_to_function_zip
-  source_code_hash = var.function_zip_hash
-  handler          = var.handler_class
-  timeout          = var.timeout_seconds
-  memory_size      = var.memory_size_mb
+  function_name                  = var.function_name
+  role                           = aws_iam_role.iam_for_lambda.arn
+  architectures                  = ["arm64"] # 20% cheaper per ms exec time than x86_64
+  runtime                        = "java11"
+  filename                       = var.path_to_function_zip
+  source_code_hash               = var.function_zip_hash
+  handler                        = var.handler_class
+  timeout                        = var.timeout_seconds
+  memory_size                    = var.memory_size_mb
+  reserved_concurrent_executions = var.reserved_concurrent_executions
 
   environment {
     variables = merge(

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "psoxy-instance" {
   handler                        = var.handler_class
   timeout                        = var.timeout_seconds
   memory_size                    = var.memory_size_mb
-  reserved_concurrent_executions = var.reserved_concurrent_executions
+  reserved_concurrent_executions = coalesce(var.reserved_concurrent_executions, -1)
 
   environment {
     variables = merge(

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -22,6 +22,12 @@ variable "aws_assume_role_arn" {
   description = "role arn"
 }
 
+variable "reserved_concurrent_executions" {
+  type        = number
+  description = "Max number of concurrent instances for the function"
+  default     = -1
+}
+
 # NOTE: currently unused; but perhaps we'll have default rules by source_kind in the future,
 # so leaving it in
 variable "source_kind" {

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -11,17 +11,18 @@ terraform {
 module "psoxy_lambda" {
   source = "../aws-psoxy-lambda"
 
-  function_name         = var.function_name
-  handler_class         = "co.worklytics.psoxy.Handler"
-  path_to_function_zip  = var.path_to_function_zip
-  function_zip_hash     = var.function_zip_hash
-  memory_size_mb        = 512
-  timeout_seconds       = 55
-  aws_assume_role_arn   = var.aws_assume_role_arn
-  path_to_config        = var.path_to_config
-  source_kind           = var.source_kind
-  parameters            = []
-  environment_variables = var.environment_variables
+  function_name                  = var.function_name
+  handler_class                  = "co.worklytics.psoxy.Handler"
+  path_to_function_zip           = var.path_to_function_zip
+  function_zip_hash              = var.function_zip_hash
+  memory_size_mb                 = 512
+  timeout_seconds                = 55
+  reserved_concurrent_executions = coalesce(var.reserved_concurrent_executions, -1)
+  aws_assume_role_arn            = var.aws_assume_role_arn
+  path_to_config                 = var.path_to_config
+  source_kind                    = var.source_kind
+  parameters                     = []
+  environment_variables          = var.environment_variables
 }
 
 resource "aws_lambda_function_url" "lambda_url" {

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -17,7 +17,7 @@ module "psoxy_lambda" {
   function_zip_hash              = var.function_zip_hash
   memory_size_mb                 = 512
   timeout_seconds                = 55
-  reserved_concurrent_executions = coalesce(var.reserved_concurrent_executions, -1)
+  reserved_concurrent_executions = var.reserved_concurrent_executions
   aws_assume_role_arn            = var.aws_assume_role_arn
   path_to_config                 = var.path_to_config
   source_kind                    = var.source_kind

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -24,6 +24,12 @@ variable "handler_class" {
   default     = "co.worklytics.psoxy.Handler"
 }
 
+variable "reserved_concurrent_executions" {
+  type        = number
+  description = "Max number of concurrent instances for the function"
+  default     = null # meaning no reserved concurrency
+}
+
 variable "aws_assume_role_arn" {
   type        = string
   description = "role arn"

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -48,7 +48,7 @@ variable "caller_aws_arns" {
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"
-  default     = "0.4.3"
+  default     = "0.4.4"
 }
 
 

--- a/infra/modules/gcp/variables.tf
+++ b/infra/modules/gcp/variables.tf
@@ -23,5 +23,5 @@ variable "psoxy_base_dir" {
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"
-  default     = "0.4.3"
+  default     = "0.4.4"
 }

--- a/infra/modules/psoxy-package/variable.tf
+++ b/infra/modules/psoxy-package/variable.tf
@@ -13,6 +13,6 @@ variable "implementation" {
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"
-  default     = "0.4.3"
+  default     = "0.4.4"
 }
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -171,7 +171,8 @@ locals {
       ],
       secured_variables : [
         "ACCESS_TOKEN",
-      ]
+      ],
+      reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
   1. Create a [Service Account User + token](https://asana.com/guide/help/premium/service-accounts)
@@ -191,6 +192,7 @@ EOT
       secured_variables : [
         "ACCESS_TOKEN",
       ]
+      reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
 ## Slack Discovery Setup
@@ -249,6 +251,7 @@ EOT
         "CLIENT_ID",
         "ACCOUNT_ID"
       ],
+      reserved_concurrent_executions : 1
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
 ## Zoom Setup

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -168,6 +168,9 @@ locals {
         "/api/1.0/workspaces/{ANY_WORKSPACE_ID}/projects",
         "/api/1.0/projects/{ANY_PROJECT_ID}/tasks",
         "/api/1.0/tasks/{ANY_TASK_ID}/stories",
+      ],
+      secured_variables : [
+        "ACCESS_TOKEN",
       ]
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
@@ -184,6 +187,9 @@ EOT
         "/api/discovery.conversations.list",
         "/api/discovery.conversations.history?channel={CHANNEL_ID}&limit=10",
         "/api/discovery.users.list",
+      ],
+      secured_variables : [
+        "ACCESS_TOKEN",
       ]
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
@@ -237,7 +243,12 @@ EOT
         "/v2/report/users/{userId}/meetings",
         "/v2/report/meetings/{meetingId}",
         "/v2/report/meetings/{meetingId}/participants"
-      ]
+      ],
+      secured_variables : [
+        "CLIENT_SECRET",
+        "CLIENT_ID",
+        "ACCOUNT_ID"
+      ],
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
 ## Zoom Setup
@@ -245,13 +256,26 @@ EOT
 Zoom connector through Psoxy requires a custom managed app on the Zoom Marketplace (in development
 mode, no need to publish).
 
-1. Go to https://marketplace.zoom.us/develop/create and create an app of type JWT
+1. Go to https://marketplace.zoom.us/develop/create and create an app of type "Server to Server OAuth"
 
-2. Fill information and on App Credentials generate a token with a long expiration time, for example 00:00 01/01/2030
+2. After creation it will show the App Credentials. Share them with the AWS/GCP administrator, the
+following secret values must be filled in the Secret Manager for the Proxy with the appropriate values:
+- `PSOXY_ZOOM_CLIENT_ID`
+- `PSOXY_ZOOM_ACCOUNT_ID`
+- `PSOXY_ZOOM_CLIENT_SECRET`
+Anytime the *client secret* is regenerated it needs to be updated in the Proxy too.
 
-3. Copy the JWT Token, it will be used later when creating the Zoom cloud function.
+3. Fill the information section
 
-4. Activate the app
+4. Fill the scopes section, enabling the following:
+- Users / View all user information /user:read:admin
+  - To be able to gather information about the zoom users
+- Meetings / View all user meetings /meeting:read:admin
+  - Allows us to list all user meeting
+- Report / View report data /report:read:admin
+  - Last 6 months view for user meetings
+
+5. Activate the app
 EOT
     }
   }

--- a/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
@@ -6,11 +6,10 @@ import co.worklytics.psoxy.gateway.SourceAuthStrategy;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
 import co.worklytics.psoxy.storage.FileHandlerFactory;
 import co.worklytics.psoxy.storage.impl.FileHandlerFactoryImpl;
-
+import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
 import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
-import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -24,17 +23,9 @@ import dagger.Module;
 import dagger.Provides;
 import lombok.extern.java.Log;
 
-
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
-import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -146,7 +137,7 @@ public class PsoxyModule {
             .map(passkey -> AESReversibleTokenizationStrategy.aesKeyFromPassword(passkey, salt));
         //q: do we need to support actual fully AES keys?
 
-        if (!keyFromConfig.isPresent()) {
+        if (keyFromConfig.isEmpty()) {
             log.warning("No value for PSOXY_ENCRYPTION_KEY; any transforms depending on it will fail!");
         }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/SourceAuthModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/SourceAuthModule.java
@@ -2,12 +2,8 @@ package co.worklytics.psoxy;
 
 import co.worklytics.psoxy.gateway.SourceAuthStrategy;
 import co.worklytics.psoxy.gateway.impl.GoogleCloudPlatformServiceAccountKeyAuthStrategy;
-import co.worklytics.psoxy.gateway.impl.oauth.ClientCredentialsGrantTokenRequestPayloadBuilder;
-import co.worklytics.psoxy.gateway.impl.oauth.OAuthAccessTokenSourceAuthStrategy;
-import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
-import co.worklytics.psoxy.gateway.impl.oauth.RefreshTokenPayloadBuilder;
+import co.worklytics.psoxy.gateway.impl.oauth.*;
 import com.google.auth.oauth2.OAuth2CredentialsWithRefresh;
-import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
@@ -50,4 +46,10 @@ public class SourceAuthModule {
     OAuthRefreshTokenSourceAuthStrategy.TokenRequestPayloadBuilder clientCredentialsGrantTokenRequestPayloadBuilder(ClientCredentialsGrantTokenRequestPayloadBuilder refreshTokenPayloadBuilder) {
         return refreshTokenPayloadBuilder;
     }
+
+    @Provides @IntoSet
+    OAuthRefreshTokenSourceAuthStrategy.TokenRequestPayloadBuilder accountCredentialsGrantTokenRequestPayloadBuilder(AccountCredentialsGrantTokenRequestPayloadBuilder refreshTokenPayloadBuilder) {
+        return refreshTokenPayloadBuilder;
+    }
+
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilder.java
@@ -60,10 +60,9 @@ public class AccountCredentialsGrantTokenRequestPayloadBuilder implements OAuthR
     public void addHeaders(HttpHeaders httpHeaders) {
         String clientId = config.getConfigPropertyOrError(ConfigProperty.CLIENT_ID);
         String clientSecret = config.getConfigPropertyOrError(ConfigProperty.CLIENT_SECRET);
-        String bearerToken = Base64.getEncoder()
-            .withoutPadding()
+        String token = Base64.getEncoder()
             .encodeToString(String.join(":", clientId, clientSecret).getBytes(StandardCharsets.UTF_8));
-        httpHeaders.setAuthorization("Bearer " + bearerToken);
+        httpHeaders.setAuthorization("Basic " + token);
     }
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilder.java
@@ -32,7 +32,7 @@ public class AccountCredentialsGrantTokenRequestPayloadBuilder implements OAuthR
 
     @Override
     public Set<ConfigService.ConfigProperty> getRequiredConfigProperties() {
-        return Set.of(ConfigProperty.ACCOUNT_ID);
+        return Set.of(ConfigProperty.ACCOUNT_ID, ConfigProperty.CLIENT_ID, ConfigProperty.CLIENT_SECRET);
     }
 
     public enum ConfigProperty implements ConfigService.ConfigProperty {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilder.java
@@ -1,0 +1,69 @@
+package co.worklytics.psoxy.gateway.impl.oauth;
+
+import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.psoxy.gateway.RequiresConfiguration;
+import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.UrlEncodedContent;
+import lombok.NoArgsConstructor;
+
+import javax.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Implemented for Zoom use case
+ * {@link "https://marketplace.zoom.us/docs/guides/build/server-to-server-oauth-app/"}
+ * Server-to-server OAuth app
+ * {@link "https://marketplace.zoom.us/docs/guides/build/server-to-server-oauth-app/#use-account-credentials-to-get-an-access-token"}
+ */
+@NoArgsConstructor(onConstructor_ = @Inject)
+public class AccountCredentialsGrantTokenRequestPayloadBuilder implements OAuthRefreshTokenSourceAuthStrategy.TokenRequestPayloadBuilder, RequiresConfiguration {
+
+    @Inject
+    ConfigService config;
+
+    private static final String PARAM_ACCOUNT_ID = "account_id";
+
+    private static final String PARAM_GRANT_TYPE = "grant_type";
+
+    @Override
+    public Set<ConfigService.ConfigProperty> getRequiredConfigProperties() {
+        return Set.of(ConfigProperty.ACCOUNT_ID);
+    }
+
+    public enum ConfigProperty implements ConfigService.ConfigProperty {
+        ACCOUNT_ID, //NOTE: you should configure this as a secret in Secret Manager
+        CLIENT_ID,  //NOTE: you should configure this as a secret in Secret Manager
+        CLIENT_SECRET //NOTE: you should configure this as a secret in Secret Manager
+    }
+
+    @Override
+    public String getGrantType() {
+        return "account_credentials";
+    }
+
+    @Override
+    public HttpContent buildPayload() {
+        // The documentation doesn't say anything to use POST data, but passes everything in the URL
+        // Tested manually and, for the moment, it is accepted as POST data
+        Map<String, String> data = new TreeMap<>();
+        data.put(PARAM_GRANT_TYPE, getGrantType());
+        data.put(PARAM_ACCOUNT_ID, config.getConfigPropertyOrError(ConfigProperty.ACCOUNT_ID));
+        return new UrlEncodedContent(data);
+    }
+
+    @Override
+    public void addHeaders(HttpHeaders httpHeaders) {
+        String clientId = config.getConfigPropertyOrError(ConfigProperty.CLIENT_ID);
+        String clientSecret = config.getConfigPropertyOrError(ConfigProperty.CLIENT_SECRET);
+        String bearerToken = Base64.getEncoder()
+            .withoutPadding()
+            .encodeToString(String.join(":", clientId, clientSecret).getBytes(StandardCharsets.UTF_8));
+        httpHeaders.setAuthorization("Bearer " + bearerToken);
+    }
+
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -26,11 +26,11 @@ import java.util.stream.Stream;
  * source auth strategy to authenticate using a short-lived OAuth 2.0 access token which must be
  * periodically refreshed.
  *   Options for refresh method are configured by
- *
+ * <p>
  * A new access token will be retrieved for every psoxy instance that spins up; as well as when the
  * current one expires.  We'll endeavor to minimize the number of token requests by sharing this
  * states across API requests
- *
+ * <p>
  * If the source API you're connecting to offers long-lived access tokens (or does not offer refresh
  * tokens), you may opt for the access-token only strategy:
  * @see OAuthAccessTokenSourceAuthStrategy
@@ -87,6 +87,12 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
         String getGrantType();
 
         HttpContent buildPayload();
+
+        /**
+         * Add any headers to the request if needed, by default, does nothing
+         * @param httpHeaders the request headers to modify
+         */
+        default void addHeaders(HttpHeaders httpHeaders) {}
     }
 
     @NoArgsConstructor(onConstructor_ = @Inject)
@@ -125,6 +131,9 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
 
             HttpRequest tokenRequest = httpRequestFactory
                 .buildPostRequest(new GenericUrl(refreshEndpoint), payloadBuilder.buildPayload());
+
+            // modify any header if needed
+            payloadBuilder.addHeaders(tokenRequest.getHeaders());
 
             HttpResponse response = tokenRequest.execute();
 

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilderTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestPayloadBuilderTest.java
@@ -1,0 +1,53 @@
+package co.worklytics.psoxy.gateway.impl.oauth;
+
+import co.worklytics.psoxy.PsoxyModule;
+import co.worklytics.psoxy.SourceAuthModule;
+import co.worklytics.test.MockModules;
+import com.google.api.client.http.HttpHeaders;
+import dagger.Component;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class AccountCredentialsGrantTokenRequestPayloadBuilderTest {
+
+    @Inject
+    AccountCredentialsGrantTokenRequestPayloadBuilder payloadBuilder;
+
+    @Singleton
+    @Component(modules = {
+        PsoxyModule.class,
+        SourceAuthModule.class,
+        MockModules.ForConfigService.class,
+    })
+    public interface Container {
+        void inject(AccountCredentialsGrantTokenRequestPayloadBuilderTest test);
+    }
+
+    @BeforeEach
+    public void setup() {
+        AccountCredentialsGrantTokenRequestPayloadBuilderTest.Container container =
+            DaggerAccountCredentialsGrantTokenRequestPayloadBuilderTest_Container.create();
+        container.inject(this);
+    }
+
+    @Test
+    void addHeaders() {
+        when(payloadBuilder.config
+            .getConfigPropertyOrError(AccountCredentialsGrantTokenRequestPayloadBuilder.ConfigProperty.CLIENT_ID))
+            .thenReturn("client");
+        when(payloadBuilder.config
+            .getConfigPropertyOrError(AccountCredentialsGrantTokenRequestPayloadBuilder.ConfigProperty.CLIENT_SECRET))
+            .thenReturn("secret");
+
+        HttpHeaders headers = new HttpHeaders();
+        payloadBuilder.addHeaders(headers);
+
+        assertEquals("Basic Y2xpZW50OnNlY3JldA==", headers.getAuthorization());
+    }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.4.3-SNAPSHOT</revision>
+        <revision>0.4.4-SNAPSHOT</revision>
         <dependency.jackson.version>2.12.5</dependency.jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.lombok.version>1.18.22</dependency.lombok.version>


### PR DESCRIPTION
Only AWS support for now, need to check how to limit instances in GCP

This PR deprecates the JWT connector in favor of Zoom's new server-to-server oauth connector [^1]

### Features
[zoom psoxy auth via something other than JWT ](https://app.asana.com/0/1201039336231823/1202908236800093)

### Change implications

 - dependencies added/changed? **no**

[^1]: https://marketplace.zoom.us/docs/guides/build/server-to-server