### PR TITLE
TODOs only for enabled connectors

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -294,7 +294,7 @@ locals {
   }
   enabled_oauth_long_access_connectors = { for k, v in local.oauth_long_access_connectors : k => v if contains(var.enabled_connectors, k) }
 
-  enabled_oauth_long_access_connectors_todos = { for k, v in local.oauth_long_access_connectors : k => v if v.external_token_todo != null }
+  enabled_oauth_long_access_connectors_todos = { for k, v in local.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
   # list of pair of [(conn1, secret1), (conn1, secret2), ... (connN, secretM)]
   enabled_oauth_secrets_to_create = distinct(flatten([
     for k, v in local.enabled_oauth_long_access_connectors : [
@@ -325,4 +325,3 @@ output "enabled_oauth_long_access_connectors_todos" {
 output "enabled_oauth_secrets_to_create" {
   value = local.enabled_oauth_secrets_to_create
 }
-


### PR DESCRIPTION
Seen here -> https://github.com/Worklytics/psoxy/pull/150

TODOs will fail as they are providing all connectors instead of the enabled ones.

### Change implications

 - dependencies added/changed? **no**
