### PR TITLE
Fix main / aws-msft-365 example

### DIFF
--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -213,7 +213,7 @@ module "msft_365_grants" {
 }
 
 
-module "worklytics-psoxy-connection" {
+module "worklytics-psoxy-connection-msft-365" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/worklytics-psoxy-connection-aws"


### PR DESCRIPTION
Duplicated module was preventing to init aws-msft365 example and for that, the build is broken.

### Change implications

 - dependencies added/changed? **no**
