### PR TITLE
s132  msft client id / refresh endpoint as env vars, rather than SSm

### DIFF
--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -111,35 +111,6 @@ module "msft-connection-auth" {
   certificate_subject   = var.certificate_subject
 }
 
-resource "aws_ssm_parameter" "client_id" {
-  for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
-
-  name  = "PSOXY_${upper(replace(each.key, "-", "_"))}_CLIENT_ID"
-  type  = "String"
-  value = module.msft-connection[each.key].connector.application_id
-
-  lifecycle {
-    ignore_changes = [
-      value
-    ]
-  }
-}
-
-resource "aws_ssm_parameter" "refresh_endpoint" {
-  for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
-
-  name      = "PSOXY_${upper(replace(each.key, "-", "_"))}_REFRESH_ENDPOINT"
-  type      = "String"
-  overwrite = true
-  value     = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
-
-  lifecycle {
-    ignore_changes = [
-      value
-    ]
-  }
-}
-
 
 module "private-key-aws-parameters" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
@@ -168,8 +139,10 @@ module "psoxy-msft-connector" {
   aws_account_id        = var.aws_account_id
   path_to_repo_root     = var.psoxy_base_dir
   environment_variables = {
-    PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
     IS_DEVELOPMENT_MODE  = "true"
+    CLIENT_ID            = module.msft-connection[each.key].connector.application_id
+    REFRESH_ENDPOINT     = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+    PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
   }
 }
 

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -55,6 +55,8 @@ locals {
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
 
+  msft_tenant_id = var.msft_tenant_id
+
   enabled_connectors = [
     "asana",
     "azure-ad",
@@ -141,7 +143,7 @@ module "psoxy-msft-connector" {
   environment_variables = {
     IS_DEVELOPMENT_MODE  = "true"
     CLIENT_ID            = module.msft-connection[each.key].connector.application_id
-    REFRESH_ENDPOINT     = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+    REFRESH_ENDPOINT     = module.worklytics_connector_specs.msft_token_refresh_endpoint
     PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
   }
 }

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -77,6 +77,8 @@ module "worklytics_connector_specs" {
     "zoom",
   ]
 
+  msft_tenant_id = var.msft_tenant_id
+
   # this IS the correct ID for the user terraform is running as, which we assume is a user who's OK
   # to use the subject of examples. You can change it to any string you want.
   example_msft_user_guid = data.azuread_client_config.current.object_id
@@ -157,7 +159,7 @@ module "psoxy-msft-connector" {
   api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
   environment_variables = {
     CLIENT_ID            = module.msft-connection[each.key].connector.application_id
-    REFRESH_ENDPOINT     = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+    REFRESH_ENDPOINT     = module.worklytics_connector_specs.msft_365_refresh_endpoint
     PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
   }
 

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -126,37 +126,6 @@ module "msft-connection-auth" {
   certificate_subject   = var.certificate_subject
 }
 
-resource "aws_ssm_parameter" "client_id" {
-  for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
-
-  name  = "PSOXY_${upper(replace(each.key, "-", "_"))}_CLIENT_ID"
-  type  = "String"
-  value = module.msft-connection[each.key].connector.application_id
-
-  lifecycle {
-    ignore_changes = [
-      tags,
-      value
-    ]
-  }
-}
-
-resource "aws_ssm_parameter" "refresh_endpoint" {
-  for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
-
-  name      = "PSOXY_${upper(replace(each.key, "-", "_"))}_REFRESH_ENDPOINT"
-  type      = "String"
-  overwrite = true
-  value     = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
-
-  lifecycle {
-    ignore_changes = [
-      tags,
-      value
-    ]
-  }
-}
-
 
 module "private-key-aws-parameters" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
@@ -187,6 +156,8 @@ module "psoxy-msft-connector" {
   path_to_repo_root    = var.psoxy_base_dir
   api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
   environment_variables = {
+    CLIENT_ID            = module.msft-connection[each.key].connector.application_id
+    REFRESH_ENDPOINT     = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
     PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
   }
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -374,3 +374,7 @@ output "enabled_oauth_long_access_connectors_todos" {
 output "enabled_oauth_secrets_to_create" {
   value = local.enabled_oauth_secrets_to_create
 }
+
+output "msft_token_refresh_endpoint" {
+  value = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+}

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -9,6 +9,12 @@ variable "google_workspace_example_user" {
   default     = null
 }
 
+variable "msft_tenant_id" {
+  type        = string
+  default     = ""
+  description = "ID of Microsoft tenant to connect to (req'd only if config includes MSFT connectors)"
+}
+
 variable "example_msft_user_guid" {
   type        = string
   description = "example MSFT user guid (uuid) for test API calls (OPTIONAL)"


### PR DESCRIPTION
### Features
  - msft client id / refresh endpoint as env var, rather than ssm parameter

### Change implications

 - dependencies added/changed? **no**
 - customers will see destroy of SSM parameters; update to lambdas - but nothing they need to actually do on next apply


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203062039134020