### PR TITLE
s133 fix bad output var ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ versions of all of the following:
   - git
   - Java 11+ JDK variant
   - [Maven 3.6+](https://maven.apache.org/docs/history.html)
-  - [terraform](https://www.terraform.io/) optional; if you don't use this, you'll need to configure
+  - [terraform 1.3.x+](https://www.terraform.io/) optional; if you don't use this, you'll need to configure
     your GCP/AWS project via the web console/CLI tools. Writing your own terraform config that
     re-uses our modules will simplify things greatly.
 

--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -72,7 +72,6 @@ module "psoxy-gcp" {
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
   psoxy_base_dir    = var.psoxy_base_dir
-  psoxy_version     = "0.4.5-jrc"
   bucket_location   = var.gcp_region
 
   depends_on = [

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -159,7 +159,7 @@ module "psoxy-msft-connector" {
   api_caller_role_arn  = module.psoxy-aws.api_caller_role_arn
   environment_variables = {
     CLIENT_ID            = module.msft-connection[each.key].connector.application_id
-    REFRESH_ENDPOINT     = module.worklytics_connector_specs.msft_365_refresh_endpoint
+    REFRESH_ENDPOINT     = module.worklytics_connector_specs.msft_token_refresh_endpoint
     PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
   }
   global_parameter_arns = module.psoxy-aws.global_parameters_arns

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -90,7 +90,6 @@ module "psoxy-aws" {
 
   aws_account_id                 = var.aws_account_id
   psoxy_base_dir                 = var.psoxy_base_dir
-  psoxy_version                  = "0.4.5-jrc"
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
 

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -75,9 +75,7 @@ module "psoxy-gcp" {
   project_id        = google_project.psoxy-project.project_id
   invoker_sa_emails = var.worklytics_sa_emails
   psoxy_base_dir    = var.psoxy_base_dir
-  psoxy_version     = "0.4.5-jrc"
   bucket_location   = var.gcp_region
-
 
   depends_on = [
     google_project.psoxy-project
@@ -90,7 +88,6 @@ module "google-workspace-connection" {
 
   # source = "../../modules/google-workspace-dwd-connection"
   source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.5"
-
 
   project_id                   = google_project.psoxy-project.project_id
   connector_service_account_id = "psoxy-${each.key}-dwd"

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -48,7 +48,7 @@ variable "caller_aws_arns" {
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"
-  default     = "0.4.5-jrc"
+  default     = "0.4.5"
 }
 
 

--- a/infra/modules/gcp/variables.tf
+++ b/infra/modules/gcp/variables.tf
@@ -23,5 +23,5 @@ variable "psoxy_base_dir" {
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"
-  default     = "0.4.5-jrc"
+  default     = "0.4.5"
 }

--- a/infra/modules/psoxy-package/variable.tf
+++ b/infra/modules/psoxy-package/variable.tf
@@ -13,6 +13,6 @@ variable "implementation" {
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"
-  default     = "0.4.5-jrc"
+  default     = "0.4.5"
 }
 


### PR DESCRIPTION
### Fixes
 - one example had bad ref to output var
 - `endswith` use broke compatibility with terraform < 1.3
 - numerous `-jrc` refs reached main

### Change implications

 - dependencies added/changed? **no**
