### PR TITLE
S133 more concise param policy

### DIFF
--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -60,10 +60,11 @@ module "worklytics_connector_specs" {
   enabled_connectors = [
     "asana",
     "azure-ad",
+    "dropbox-business",
     "outlook-cal",
     "outlook-mail",
     "slack-discovery-api",
-    "dropbox-business"
+    "zoom"
   ]
 }
 

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -81,6 +81,7 @@ variable "global_parameter_arns" {
   description = "System Manager Parameters ARNS to expose to function, expected to contain global shared parameters, like salt or encryption keys"
 }
 
+# remove after v0.4.x
 variable "function_parameters" {
   type = list(object({
     name     = string

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -86,6 +86,6 @@ variable "function_parameters" {
     name     = string
     writable = bool
   }))
-  description = "Parameter names and expected grant to create for function"
+  description = "IGNORED; Parameter names and expected grant to create for function"
   default     = []
 }

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -90,6 +90,7 @@ variable "global_parameter_arns" {
   default     = []
 }
 
+# remove after v0.4.x
 variable "function_parameters" {
   type = list(object({
     name     = string

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -95,6 +95,6 @@ variable "function_parameters" {
     name     = string
     writable = bool
   }))
-  description = "Parameter names and expected grant to create for function"
+  description = "IGNORED; Parameter names and expected grant to create for function"
   default     = []
 }


### PR DESCRIPTION
### Fixes
 - ssm param policy known at plan time

### Features
 - more concise, single IAM policy for each lamba's SSM access

### Change implications

 - dependencies added/changed? **no**
