### PR TITLE
S133 testing tool improvements

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -166,7 +166,7 @@ locals {
       display_name : "Asana"
       example_api_calls : [
         "/api/1.0/workspaces",
-        "/api/1.0/users?workspaceId={ANY_WORKSPACE_ID}&limit=10",
+        "/api/1.0/users?workspace={ANY_WORKSPACE_ID}&limit=10",
         "/api/1.0/workspaces/{ANY_WORKSPACE_ID}/projects?limit=20",
         "/api/1.0/projects/{ANY_PROJECT_ID}/tasks?limit=20",
         "/api/1.0/tasks/{ANY_TASK_ID}/stories",

--- a/tools/psoxy-test/README.md
+++ b/tools/psoxy-test/README.md
@@ -24,7 +24,10 @@ As you can see, the differences are:
 (*) Requests to AWS API need to be [signed], so you must ensure that the machine running these scripts have the appropriate AWS credentials for the role you've selected.
 
 ## GCP
-For GCP, every call must include the `-t` option, which is the identity token used for authentication (*). 
+For GCP, every call needs an "identity token" (`-t, --token` option in the examples below) for the account 
+that has access to the Cloud Platform (*). If you omit the token, the script will try to get it automatically,
+so you must [authorize gcloud first].
+
 Google Calendar example:
 ```shell
 node cli.js -u https://us-central1-acme.cloudfunctions.net/calendar/v3/calendars/primary -t <IDENTITY_TOKEN> -i user@acme.com
@@ -33,8 +36,12 @@ Zoom example:
 ```shell
 node cli.js -u https://us-central1-acme.cloudfunctions.net/v2/users -t <IDENTITY_TOKEN>
 ```
+Outlook Calendar example (token option omitted):
+```shell
+node cli.js -u https://us-central1-acme.cloudfunctions.net/outlook-cal/v1.0/users
+```
 
-(*) You can obtain it by running `gcloud auth print-identity-token` (using Google Cloud SDK)
+(*) You can obtain it by running `gcloud auth print-identity-token` (using [Google Cloud SDK])
 
 ## Testing all endpoints for a given data source
 
@@ -42,16 +49,18 @@ The `-d, --data-source` option of our CLI script allows you to test all the endp
 The only difference with the previous examples is that the `-u, --url` option has to be the URL of the deploy **without** the corresponding API path of the data source:
 
 ```shell
-# Zoom example for AWS deploys, instead of:
+# Zoom example for AWS deploys, instead of running a single call:
 # node cli.js -u https://acme.lambda-url.us-east-1.on.aws/v2/users -r <role>
-# use:
+# use this command to run multiple calls:
 node cli.js -u https://acme.lambda-url.us-east-1.on.aws -r <ROLE> -d zoom
 ```
 ```shell
-# Zoom example for GCP deploys, instead of:
+# Zoom example for GCP deploys, instead of running a single call:
 # node cli.js -u https://us-central1-acme.cloudfunctions.net/v2/users -t <ROLE>
-# use:
-node cli.js -u https://acme.lambda-url.us-east-1.on.aws -t <IDENTITY_TOKEN> -d zoom
+# use this command to run multiple calls:
+node cli.js -u https://us-central1-acme.cloudfunctions.net -t <IDENTITY_TOKEN> -d zoom
+# or simply:
+node cli.js -u https://us-central1-acme.cloudfunctions.net -d zoom
 ```
 
 Notice how the URL changes, and any other option the Psoxy may need doesn't.
@@ -64,3 +73,5 @@ Notice how the URL changes, and any other option the Psoxy may need doesn't.
 [Google Calendar]: https://developers.google.com/calendar/api
 [Zoom]: https://zoom.us
 [Zoom API endpoint]: https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/users
+[Google Cloud SDK]: https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token
+[authorize gcloud first]: https://cloud.google.com/sdk/gcloud/reference/auth/login

--- a/tools/psoxy-test/cli.js
+++ b/tools/psoxy-test/cli.js
@@ -29,6 +29,7 @@ const { name, version, description } = require('./package.json');
     .option('-z, --gzip', 'Add gzip compression header', false)
     .addOption(new Option('-d, --data-source <name>', 
       'Data source to test all available endpoints').choices([
+        'asana',
         'gcal', 
         'gdrive', 
         'gdirectory',

--- a/tools/psoxy-test/cli.js
+++ b/tools/psoxy-test/cli.js
@@ -29,7 +29,12 @@ const { name, version, description } = require('./package.json');
     .option('-z, --gzip', 'Add gzip compression header', false)
     .addOption(new Option('-d, --data-source <name>', 
       'Data source to test all available endpoints').choices([
-        'gcal', 'gdrive', 'google-chat', 'google-meet', 'slack-discovery-api',
+        'gcal', 
+        'gdrive', 
+        'gdirectory',
+        'google-chat', 
+        'google-meet', 
+        'slack-discovery-api',
         'zoom'
       ]))
     .configureOutput({

--- a/tools/psoxy-test/cli.js
+++ b/tools/psoxy-test/cli.js
@@ -32,6 +32,7 @@ const { name, version, description } = require('./package.json');
         'gcal', 
         'gdrive', 
         'gdirectory',
+        'gmail',
         'google-chat', 
         'google-meet', 
         'slack-discovery-api',

--- a/tools/psoxy-test/cli.js
+++ b/tools/psoxy-test/cli.js
@@ -30,6 +30,7 @@ const { name, version, description } = require('./package.json');
     .addOption(new Option('-d, --data-source <name>', 
       'Data source to test all available endpoints').choices([
         'asana',
+        'azure-ad',
         'gcal', 
         'gdrive', 
         'gdirectory',
@@ -37,6 +38,8 @@ const { name, version, description } = require('./package.json');
         'google-chat', 
         'google-meet', 
         'slack-discovery-api',
+        'outlook-cal',
+        'outlook-mail',
         'zoom'
       ]))
     .configureOutput({

--- a/tools/psoxy-test/data-sources/spec.js
+++ b/tools/psoxy-test/data-sources/spec.js
@@ -53,6 +53,19 @@ export default {
       },
     ],
   },
+  'azure-ad': {
+    name: 'Azure Directory',
+    endpoints: [
+      {
+        name: 'Users',
+        path: '/v1.0/users',
+      },
+      {
+        name: 'Groups',
+        path: '/v1.0/groups',
+      },
+    ],
+  },
   gcal: {
     name: 'Google Calendar',
     endpoints: [
@@ -280,6 +293,55 @@ export default {
         name: 'Messages',
         path: '/admin/reports/v1/activity/users/all/applications/meet',
         params: { maxResults: 10 },
+      },
+    ],
+  },
+  'outlook-cal': {
+    name: 'Outlook Calendar',
+    endpoints: [
+      {
+        name: 'Users',
+        path: '/v1.0/users',
+        refs: [
+          {
+            name: 'Events',
+            accessor: 'value[0].id',
+            pathReplacement: '[user_id]',
+          },
+        ],
+      },
+      {
+        name: 'Events',
+        path: '/v1.0/users/[user_id]/events',
+      },
+    ],
+  },
+  'outlook-mail': {
+    name: 'Outlook Mail',
+    endpoints: [
+      {
+        name: 'Users',
+        path: '/beta/users',
+        refs: [
+          {
+            name: 'Mailbox Settings',
+            accessor: 'value[0].id',
+            pathReplacement: '[user_id]',
+          },
+          {
+            name: 'Messages Sent',
+            accessor: 'value[0].id',
+            pathReplacement: '[user_id]',
+          },
+        ],
+      },
+      {
+        name: 'Mailbox Settings',
+        path: '/beta/users/[user_id]/mailboxSettings',
+      },
+      {
+        name: 'Messages Sent',
+        path: '/beta/users/[user_id]/mailFolders/SentItems/messages',
       },
     ],
   },

--- a/tools/psoxy-test/data-sources/spec.js
+++ b/tools/psoxy-test/data-sources/spec.js
@@ -188,6 +188,27 @@ export default {
       },
     ],
   },
+  gmail: {
+    name: 'GMail',
+    endpoints: [
+      {
+        name: 'Messages',
+        path: '/gmail/v1/users/me/messages',
+        refs: [
+          {
+            name: 'Message Details',
+            accessor: 'messages[0].id',
+            pathReplacement: '[message_id]',
+          }
+        ]
+      }, 
+      {
+        name: 'Message Details',
+        path: '/gmail/v1/users/me/messages/[message_id]',
+        params: {format: 'metadata'},
+      }
+    ],
+  },
   'google-chat': {
     name: 'Google Chat',
     endpoints: [

--- a/tools/psoxy-test/data-sources/spec.js
+++ b/tools/psoxy-test/data-sources/spec.js
@@ -1,4 +1,58 @@
 export default {
+  asana: {
+    name: 'Asana',
+    endpoints: [
+      {
+        name: 'Workspaces',
+        path: '/api/1.0/workspaces',
+        refs: [
+          {
+            name: 'Workspace Users',
+            accessor: 'data[0].gid',
+            paramReplacement: 'workspace',
+          },
+          {
+            name: 'Workspace Projects',
+            accessor: 'data[0].gid',
+            pathReplacement: 'workspace_id',
+          },
+        ],
+      },
+      {
+        name: 'Workspace Users',
+        path: '/api/1.0/users',
+        params: { workspace: null, limit: 10 },
+      },
+      {
+        name: 'Workspace Projects',
+        path: '/api/1.0/workspaces/[workspace_id]/projects',
+        param: { limit: 10 },
+        refs: [
+          {
+            name: 'Project Tasks',
+            accessor: 'data[0].gid',
+            pathReplacement: '[project_id]',
+          },
+        ],
+      },
+      {
+        name: 'Project Tasks',
+        path: '/api/1.0/projects/[project_id]/tasks',
+        param: { limit: 10 },
+        refs: [
+          {
+            name: 'Task Stories',
+            accessor: 'data[0].gid',
+            pathReplacement: '[task_id]',
+          },
+        ],
+      },
+      {
+        name: 'Task Stories',
+        path: '/api/1.0/tasks/[task_id]/stories',
+      },
+    ],
+  },
   gcal: {
     name: 'Google Calendar',
     endpoints: [
@@ -199,14 +253,14 @@ export default {
             name: 'Message Details',
             accessor: 'messages[0].id',
             pathReplacement: '[message_id]',
-          }
-        ]
-      }, 
+          },
+        ],
+      },
       {
         name: 'Message Details',
         path: '/gmail/v1/users/me/messages/[message_id]',
-        params: {format: 'metadata'},
-      }
+        params: { format: 'metadata' },
+      },
     ],
   },
   'google-chat': {

--- a/tools/psoxy-test/data-sources/spec.js
+++ b/tools/psoxy-test/data-sources/spec.js
@@ -27,6 +27,73 @@ export default {
       },
     ],
   },
+  gdirectory: {
+    name: 'Google Directory',
+    endpoints: [
+      {
+        name: 'Domains',
+        path: '/admin/directory/v1/customer/my_customer/domains',
+      },
+      {
+        name: 'Groups',
+        path: '/admin/directory/v1/groups',
+        params: { customer: 'my_customer' },
+        refs: [
+          {
+            name: 'Group',
+            accessor: 'groups[0].id',
+            pathReplacement: '[group_id]',
+          },
+          {
+            name: 'Group Members',
+            accessor: 'groups[0].id',
+            pathReplacement: '[group_id]',
+          },
+        ],
+      },
+      {
+        name: 'Group',
+        path: '/admin/directory/v1/groups/[group_id]',
+      },
+      {
+        name: 'Group Members',
+        path: '/admin/directory/v1/groups/[group_id]/members',
+      },
+      {
+        name: 'Users',
+        path: '/admin/directory/v1/users',
+        param: { customer: 'my_customer' },
+        refs: [
+          {
+            name: 'User Details',
+            accessor: 'users[0].id',
+            pathReplacement: '[user_id]',
+          },
+          {
+            name: 'User Thumbnail',
+            accessor: 'users[0].id',
+            pathReplacement: '[user_id]',
+          },
+        ],
+      },
+      {
+        name: 'User Details',
+        path: '/admin/directory/v1/users/[user_id]',
+      },
+      {
+        name: 'User Thumbnail',
+        path: '/admin/directory/v1/users/[user_id]/photos/thumbnail',
+      },
+      {
+        name: 'Roles',
+        path: '/admin/directory/v1/customer/my_customer/roles',
+      },
+      {
+        name: 'Role Assingments',
+        path: '/admin/directory/v1/customer/my_customer/roleassignments',
+      },
+    ],
+  },
   gdrive: {
     name: 'Google Drive',
     endpoints: [
@@ -128,7 +195,7 @@ export default {
         name: 'Messages',
         path: '/admin/reports/v1/activity/users/all/applications/chat',
         params: { maxResults: 10 },
-      }
+      },
     ],
   },
   'google-meet': {
@@ -221,6 +288,6 @@ export default {
         name: 'Users',
         path: '/v2/users',
       },
-    ]
-  }
+    ],
+  },
 };

--- a/tools/psoxy-test/index.js
+++ b/tools/psoxy-test/index.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import aws from './lib/aws.js';
 import gcp from './lib/gcp.js';
+import { inspect }  from 'util';
 import { saveRequestResultToFile } from './lib/utils.js';
 
 /**
@@ -33,6 +34,7 @@ export default async function (options = {}) {
     url = new URL(options.url);
   } catch (err) {
     result.error = `"${options.url}" is not a valid URL`;
+    console.error(chalk.bold(result.error));
     return result;
   }
 
@@ -85,7 +87,7 @@ export default async function (options = {}) {
     console.error(chalk.bold.red(result.error));
   } else if (result.status === 200) {
     console.log(chalk.bold.green(`${result.status}: OK`));
-    console.log(result.data);
+    console.log(inspect(result.data, {depth: null, colors: true}));
   }
 
   if (options.verbose) {

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -1,4 +1,4 @@
-import { getCommonHTTPHeaders, fetch } from './utils.js';
+import { getCommonHTTPHeaders, fetch, executeCommand } from './utils.js';
 
 /**
  * Helper: check url deploy type
@@ -14,6 +14,20 @@ function isValidURL(url) {
 }
 
 /**
+ * Get identity token for current gcloud account.
+ * 
+ * Refs: 
+ * - https://cloud.google.com/sdk/gcloud/reference/auth/login
+ * - https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token
+ * 
+ * @returns {String} identity token
+ */
+function getIdentityToken() {
+  const command = 'gcloud auth print-identity-token';
+  return executeCommand(command).trim();
+}
+
+/**
  * Psoxy test
  *
  * @param {Object} options - see `../index.js`
@@ -21,7 +35,7 @@ function isValidURL(url) {
  */
 async function call(options = {}) {
   if (!options.token) {
-    throw new Error('Authorization token is required for GCP endpoints');
+    options.token = getIdentityToken();
   }
 
   const headers = {
@@ -45,5 +59,6 @@ async function call(options = {}) {
 
 export default {
   isValidURL: isValidURL,
+  getIdentityToken: getIdentityToken,
   call: call,
 };

--- a/tools/psoxy-test/test/gcp.test.js
+++ b/tools/psoxy-test/test/gcp.test.js
@@ -1,6 +1,8 @@
 import test from 'ava';
 import * as td from 'testdouble';
 
+const GCP_URL = 'https://foo.cloudfunctions.net';
+
 test.beforeEach(async t => {
   t.context.utils = await td.replaceEsm('../lib/utils.js'); 
   t.context.subject = (await import('../lib/gcp.js')).default;
@@ -11,19 +13,28 @@ test.afterEach(() => td.reset());
 test('isValidURL URL', t => {
   const gcp = t.context.subject;
 
-  t.true(gcp.isValidURL('https://foo.cloudfunctions.net'));
-  t.true(gcp.isValidURL(new URL('https://foo.cloudfunctions.net')));
+  t.true(gcp.isValidURL(GCP_URL));
+  t.true(gcp.isValidURL(GCP_URL));
 
   t.false(gcp.isValidURL('http://foo.com'));
   t.throws(() => { gcp.isValidURL('foo'); }, {instanceOf: TypeError});
 });
 
-test('Psoxy Call: missing auth token throws error', async t => {
+test('Psoxy Call: get identity token when option missing', async t => {
   const gcp = t.context.subject;
+  const utils = t.context.utils;
+  
+  const options = {
+    url: new URL(GCP_URL),
+  }
 
-  const url = new URL('http://foo.com');
-  await t.throwsAsync(async () => gcp.call(url, {}), {
-    instanceOf: Error, 
-    message: 'Authorization token is required for GCP endpoints',
-  });
+  const command = 'gcloud auth print-identity-token';
+  td.when(utils.executeCommand(command)).thenReturn('foo');
+  td.when(utils.fetch(options.url, td.matchers.contains({headers: {}})))
+    .thenReturn({status: 200});
+
+  const result = await gcp.call(options);
+  t.is(result.status, 200);
+
+  td.verify(utils.executeCommand(command));
 });


### PR DESCRIPTION
### Fixes
.

### Features
- User can omit `-t` option for GCP deploys: script will execute `gcloud auth print-identity-token` automatically
- Pretty print nested objects in successful responses
- Add missing data sources: 
  - Asana
  - Azure AD
  - GMail
  - Google Directory
  - Outlook Calendar
  - Outlook Mail

### Change implications

 - dependencies added/changed? **no**
