### PR TITLE
restricting endpoints to pseudonyms

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -22,7 +22,7 @@ public class PrebuiltSanitizerRules {
         .jsonPath("$.['@odata.context']")
         .build();
 
-    static final String DIRECTORY_REGEX_USERS = "^/(v1.0|beta)/users(/p~[a-zA-Z0-9_-]+?)?[^/]*";
+    static final String DIRECTORY_REGEX_USERS = "^/(v1.0|beta)/users/?[^/]*";
     static final String DIRECTORY_REGEX_USERS_BY_PSEUDO = "^/(v1.0|beta)/users(/p~[a-zA-Z0-9_-]+?)?[^/]*";
     static final String DIRECTORY_REGEX_GROUP_MEMBERS = "^/(v1.0|beta)/groups/[^/]*/members.*";
 
@@ -113,7 +113,7 @@ public class PrebuiltSanitizerRules {
         .endpoint(DIRECTORY_GROUPS)
         .endpoint(DIRECTORY_GROUP_MEMBERS)
         .build()
-        .withTransformByEndpoint(DIRECTORY_REGEX_USERS, Transform.Pseudonymize.builder()
+        .withTransformByEndpoint(DIRECTORY_REGEX_USERS_BY_PSEUDO, Transform.Pseudonymize.builder()
             .includeReversible(true)
             .encoding(PseudonymEncoder.Implementations.URL_SAFE_TOKEN)
             .jsonPath("$..id")
@@ -123,7 +123,7 @@ public class PrebuiltSanitizerRules {
             .build());
 
     static final Rules2 DIRECTORY_NO_MSFT_IDS_NO_GROUPS = DIRECTORY_NO_GROUPS
-        .withTransformByEndpoint(DIRECTORY_REGEX_USERS, Transform.Pseudonymize.builder()
+        .withTransformByEndpoint(DIRECTORY_REGEX_USERS_BY_PSEUDO, Transform.Pseudonymize.builder()
             .includeReversible(true)
             .encoding(PseudonymEncoder.Implementations.URL_SAFE_TOKEN)
             .jsonPath("$..id")

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
@@ -33,8 +33,8 @@ public class UrlSafeTokenPseudonymEncoder implements PseudonymEncoder {
     Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     Base64.Decoder decoder = Base64.getUrlDecoder();
 
-    static final Pattern REVERSIBLE_PSEUDONYM_PATTERN =
-        //Pattern.compile("p\\~[a-zA-Z0-9_-]{43}"); //not clear to me why this doesn't work
+    public static final Pattern REVERSIBLE_PSEUDONYM_PATTERN =
+        //Pattern.compile("p\\~[a-zA-Z0-9_-]{43,}"); //not clear to me why this doesn't work
         Pattern.compile(Pattern.quote(PREFIX) + "[a-zA-Z0-9_-]{" + REVERSIBLE_PSEUDONYM_LENGTH_WITHOUT_PREFIX + ",}");
 
     @Override


### PR DESCRIPTION
### Features
  - example rules that limit endpoints to fragments that MUST be pseudonym


### Change implications

 - dependencies added/changed? **no**
