### PR TITLE
defaults for psoxy_instance_id

### DIFF
--- a/infra/modules/worklytics-psoxy-connection-aws/variables.tf
+++ b/infra/modules/worklytics-psoxy-connection-aws/variables.tf
@@ -1,6 +1,7 @@
 variable "psoxy_instance_id" {
   type        = string
   description = "friendly unique-id for Psoxy instance"
+  default     = null
 }
 
 variable "psoxy_endpoint_url" {

--- a/infra/modules/worklytics-psoxy-connection/variables.tf
+++ b/infra/modules/worklytics-psoxy-connection/variables.tf
@@ -1,6 +1,7 @@
 variable "psoxy_instance_id" {
   type        = string
   description = "friendly unique-id for Psoxy instance"
+  default     = null
 }
 
 variable "psoxy_endpoint_url" {


### PR DESCRIPTION
### Fixes
  - connection modules missing default value, even though they expect param to be omitted

### Change implications

 - dependencies added/changed? **no**
