### PR TITLE
S133 add env variables from specs

### DIFF
--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -35,11 +35,11 @@ provider "aws" {
 
 locals {
   base_config_path = "${var.psoxy_base_dir}/configs/"
-  bulk_sources     = {
+  bulk_sources = {
     "hris" = {
       source_kind = "hris"
-      rules       = {
-        columnsToRedact       = []
+      rules = {
+        columnsToRedact = []
         columnsToPseudonymize = [
           "email",
           "employee_id"
@@ -48,8 +48,8 @@ locals {
     },
     "qualtrics" = {
       source_kind = "qualtrics"
-      rules       = {
-        columnsToRedact       = []
+      rules = {
+        columnsToRedact = []
         columnsToPseudonymize = [
           "email",
           "employee_id"
@@ -179,7 +179,7 @@ module "worklytics-psoxy-connection-google-workspace" {
 # Create secure parameters (later filled by customer)
 # Can be later passed on to a module and store in other vault if needed
 resource "aws_ssm_parameter" "long-access-secrets" {
-  for_each = {for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry}
+  for_each = { for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
 
   name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -35,11 +35,11 @@ provider "aws" {
 
 locals {
   base_config_path = "${var.psoxy_base_dir}/configs/"
-  bulk_sources = {
+  bulk_sources     = {
     "hris" = {
       source_kind = "hris"
-      rules = {
-        columnsToRedact = []
+      rules       = {
+        columnsToRedact       = []
         columnsToPseudonymize = [
           "email",
           "employee_id"
@@ -48,8 +48,8 @@ locals {
     },
     "qualtrics" = {
       source_kind = "qualtrics"
-      rules = {
-        columnsToRedact = []
+      rules       = {
+        columnsToRedact       = []
         columnsToPseudonymize = [
           "email",
           "employee_id"
@@ -179,7 +179,7 @@ module "worklytics-psoxy-connection-google-workspace" {
 # Create secure parameters (later filled by customer)
 # Can be later passed on to a module and store in other vault if needed
 resource "aws_ssm_parameter" "long-access-secrets" {
-  for_each = { for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
+  for_each = {for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry}
 
   name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"
@@ -227,6 +227,13 @@ module "aws-psoxy-long-auth-connectors" {
   global_parameter_arns          = module.psoxy-aws.global_parameters_arns
   function_parameters            = each.value.secured_variables
   todo_step                      = module.source_token_external_todo[each.key].next_todo_step
+
+  environment_variables = merge(each.value.environment_variables,
+    {
+      PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
+      IS_DEVELOPMENT_MODE  = "true"
+    }
+  )
 }
 
 module "worklytics-psoxy-connection" {

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -71,13 +71,13 @@ module "worklytics_connector_specs" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.6"
 
   enabled_connectors = [
-    "asana",
-    "azure-ad",
+   // "asana",
+   // "azure-ad",
     "dropbox-business",
-    "outlook-cal",
-    "outlook-mail",
-    "slack-discovery-api",
-    "zoom"
+   // "outlook-cal",
+   // "outlook-mail",
+   // "slack-discovery-api",
+    //"zoom"
   ]
 
   msft_tenant_id = var.msft_tenant_id
@@ -247,10 +247,13 @@ module "aws-psoxy-long-auth-connectors" {
   global_parameter_arns                 = module.psoxy-aws.global_parameters_arns
   function_parameters                   = each.value.secured_variables
 
-  environment_variables = {
-    PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
-    IS_DEVELOPMENT_MODE  = "true"
-  }
+
+  environment_variables = merge(each.value.environment_variables,
+    {
+  PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
+  IS_DEVELOPMENT_MODE  = "true"
+    }
+  )
 }
 
 module "worklytics-psoxy-connection-oauth-long-access" {

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -38,10 +38,10 @@ provider "azuread" {
 
 locals {
   base_config_path = "${var.psoxy_base_dir}configs/"
-  bulk_sources     = {
+  bulk_sources = {
     "hris" = {
       source_kind = "hris"
-      rules       = {
+      rules = {
         columnsToRedact = [
         ]
         columnsToPseudonymize = [
@@ -54,8 +54,8 @@ locals {
     },
     "qualtrics" = {
       source_kind = "qualtrics"
-      rules       = {
-        columnsToRedact       = []
+      rules = {
+        columnsToRedact = []
         columnsToPseudonymize = [
           "employee_id"
         ]
@@ -71,12 +71,12 @@ module "worklytics_connector_specs" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.6"
 
   enabled_connectors = [
-     "asana",
-     "azure-ad",
+    "asana",
+    "azure-ad",
     "dropbox-business",
-     "outlook-cal",
-     "outlook-mail",
-     "slack-discovery-api",
+    "outlook-cal",
+    "outlook-mail",
+    "slack-discovery-api",
     "zoom"
   ]
 
@@ -198,7 +198,7 @@ module "worklytics-psoxy-connection-msft-365" {
 # Create secure parameters (later filled by customer)
 # Can be later passed on to a module and store in other vault if needed
 resource "aws_ssm_parameter" "long-access-secrets" {
-  for_each = {for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry}
+  for_each = { for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
 
   name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -71,13 +71,13 @@ module "worklytics_connector_specs" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.6"
 
   enabled_connectors = [
-    // "asana",
-    // "azure-ad",
+     "asana",
+     "azure-ad",
     "dropbox-business",
-    // "outlook-cal",
-    // "outlook-mail",
-    // "slack-discovery-api",
-    //"zoom"
+     "outlook-cal",
+     "outlook-mail",
+     "slack-discovery-api",
+    "zoom"
   ]
 
   msft_tenant_id = var.msft_tenant_id

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -38,10 +38,10 @@ provider "azuread" {
 
 locals {
   base_config_path = "${var.psoxy_base_dir}configs/"
-  bulk_sources = {
+  bulk_sources     = {
     "hris" = {
       source_kind = "hris"
-      rules = {
+      rules       = {
         columnsToRedact = [
         ]
         columnsToPseudonymize = [
@@ -54,8 +54,8 @@ locals {
     },
     "qualtrics" = {
       source_kind = "qualtrics"
-      rules = {
-        columnsToRedact = []
+      rules       = {
+        columnsToRedact       = []
         columnsToPseudonymize = [
           "employee_id"
         ]
@@ -71,12 +71,12 @@ module "worklytics_connector_specs" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.6"
 
   enabled_connectors = [
-   // "asana",
-   // "azure-ad",
+    // "asana",
+    // "azure-ad",
     "dropbox-business",
-   // "outlook-cal",
-   // "outlook-mail",
-   // "slack-discovery-api",
+    // "outlook-cal",
+    // "outlook-mail",
+    // "slack-discovery-api",
     //"zoom"
   ]
 
@@ -198,7 +198,7 @@ module "worklytics-psoxy-connection-msft-365" {
 # Create secure parameters (later filled by customer)
 # Can be later passed on to a module and store in other vault if needed
 resource "aws_ssm_parameter" "long-access-secrets" {
-  for_each = { for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry }
+  for_each = {for entry in module.worklytics_connector_specs.enabled_oauth_secrets_to_create : "${entry.connector_name}.${entry.secret_name}" => entry}
 
   name        = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   type        = "SecureString"
@@ -247,11 +247,10 @@ module "aws-psoxy-long-auth-connectors" {
   global_parameter_arns                 = module.psoxy-aws.global_parameters_arns
   function_parameters                   = each.value.secured_variables
 
-
   environment_variables = merge(each.value.environment_variables,
     {
-  PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
-  IS_DEVELOPMENT_MODE  = "true"
+      PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
+      IS_DEVELOPMENT_MODE  = "true"
     }
   )
 }

--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -12,11 +12,11 @@ terraform {
 
 locals {
   base_config_path = "${var.psoxy_base_dir}/configs/"
-  bulk_sources     = {
+  bulk_sources = {
     "hris" = {
       source_kind = "hris"
-      rules       = {
-        columnsToRedact       = []
+      rules = {
+        columnsToRedact = []
         columnsToPseudonymize = [
           "employee_email",
           "employee_id"
@@ -25,8 +25,8 @@ locals {
     },
     "qualtrics" = {
       source_kind = "qualtrics"
-      rules       = {
-        columnsToRedact       = []
+      rules = {
+        columnsToRedact = []
         columnsToPseudonymize = [
           "employee_email",
           "employee_id"
@@ -185,7 +185,7 @@ module "connector-long-auth-create-function" {
 
   secret_bindings = {
     ACCESS_TOKEN = {
-      secret_id      = module.connector-long-auth-block[each.key].access_token_secret_id
+      secret_id = module.connector-long-auth-block[each.key].access_token_secret_id
       # in case of long lived tokens we want latest version always
       version_number = "latest"
     }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -286,7 +286,9 @@ EOT
         { name : "CLIENT_ID", writable : false },
         { name : "CLIENT_SECRET", writable : false },
       ],
-      token_endpoint : "https://api.dropboxapi.com/oauth2/token",
+      environment_variables : {
+        REFRESH_ENDPOINT : "https://api.dropboxapi.com/oauth2/token"
+      }
       reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       external_token_todo : <<EOT
@@ -344,22 +346,22 @@ EOT
 # computed values filtered by enabled connectors
 locals {
   enabled_google_workspace_connectors = {
-    for k, v in local.google_workspace_sources : k => v if contains(var.enabled_connectors, k)
+  for k, v in local.google_workspace_sources : k => v if contains(var.enabled_connectors, k)
   }
   enabled_msft_365_connectors = {
-    for k, v in local.msft_365_connectors : k => v if contains(var.enabled_connectors, k)
+  for k, v in local.msft_365_connectors : k => v if contains(var.enabled_connectors, k)
   }
-  enabled_oauth_long_access_connectors = { for k, v in local.oauth_long_access_connectors : k => v if contains(var.enabled_connectors, k) }
+  enabled_oauth_long_access_connectors = {for k, v in local.oauth_long_access_connectors : k => v if contains(var.enabled_connectors, k)}
 
-  enabled_oauth_long_access_connectors_todos = { for k, v in local.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
+  enabled_oauth_long_access_connectors_todos = {for k, v in local.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null}
   # list of pair of [(conn1, secret1), (conn1, secret2), ... (connN, secretM)]
-  enabled_oauth_secrets_to_create = distinct(flatten([
-    for k, v in local.enabled_oauth_long_access_connectors : [
-      for secret_var in v.secured_variables : {
-        connector_name = k
-        secret_name    = secret_var.name
-      }
-    ]
+  enabled_oauth_secrets_to_create            = distinct(flatten([
+  for k, v in local.enabled_oauth_long_access_connectors : [
+  for secret_var in v.secured_variables : {
+    connector_name = k
+    secret_name    = secret_var.name
+  }
+  ]
   ]))
 }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -72,7 +72,11 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
 
     @Override
     public Set<ConfigService.ConfigProperty> getRequiredConfigProperties() {
-        Stream<ConfigService.ConfigProperty> propertyStream = Arrays.stream(ConfigProperty.values());
+        Stream<ConfigService.ConfigProperty> propertyStream = Stream.of(ConfigProperty.REFRESH_ENDPOINT,
+                // ACCESS_TOKEN is optional
+                ConfigProperty.GRANT_TYPE,
+                ConfigProperty.CLIENT_ID);
+
         if (refreshHandler instanceof RequiresConfiguration) {
             propertyStream = Stream.concat(propertyStream,
                 ((RequiresConfiguration) refreshHandler).getRequiredConfigProperties().stream());
@@ -216,7 +220,11 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
 
         @Override
         public Set<ConfigService.ConfigProperty> getRequiredConfigProperties() {
-            Stream<ConfigService.ConfigProperty> propertyStream = Arrays.stream(ConfigProperty.values());
+            Stream<ConfigService.ConfigProperty> propertyStream = Stream.of(ConfigProperty.REFRESH_ENDPOINT,
+                    // ACCESS_TOKEN is optional
+                    ConfigProperty.GRANT_TYPE,
+                    ConfigProperty.CLIENT_ID);
+
             if (payloadBuilder instanceof RequiresConfiguration) {
                 propertyStream = Stream.concat(propertyStream,
                     ((RequiresConfiguration) payloadBuilder).getRequiredConfigProperties().stream());


### PR DESCRIPTION
See the task for further details, but mainly:
- Add env vars that can be used for providing values from connector specs to instances (required for Dropbox, as it needs the endpoint used for refreshing the token
- Check that `ACCESS_TOKEN` is not mandatory for having a value for `OAuthRefreshTokenSourceAuthStrategy`; in case of Dropbox that setting is not provided from the spec. Open to discuss this point.

PD: Only updated AWS dev examples, I'll do GCP as part of https://github.com/Worklytics/psoxy/pull/151

### Fixes
[Psoxy: Env vars support for connector specs](https://app.asana.com/0/1203089823685764/1203161159580855)

### Change implications

 - dependencies added/changed? **yes (explain) / no**
