### PR TITLE
S133 testing tool AWS fixes

### DIFF
--- a/tools/psoxy-test/.gitignore
+++ b/tools/psoxy-test/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-package-lock.json
-responses
+*.json
+!package.json

--- a/tools/psoxy-test/index.js
+++ b/tools/psoxy-test/index.js
@@ -46,14 +46,15 @@ export default async function (options = {}) {
     psoxyCall = options.force === 'aws' ? aws.call : gcp.call;
   } else if (!isAWS && !isGCP) {
     result.error = `"${options.url}" doesn't seem to be a valid endpoint: AWS or GCP`;
+    console.error(chalk.bold(result.error));
     return result;
   } else {
     psoxyCall = isAWS ? aws.call : gcp.call;
   }
-
+  
   try {
     result = await psoxyCall(options);
-    
+
     if (result.status === 200) {
       if (options.saveToFile) {
         try {
@@ -90,8 +91,9 @@ export default async function (options = {}) {
     console.log(inspect(result.data, {depth: null, colors: true}));
   }
 
-  if (options.verbose) {
-    console.log(`Response headers:\n ${result.headers}`);
+  if (options.verbose && result.headers) {
+    console.log(`Response headers:\n 
+      ${inspect(result.headers, {depth: null, colors: true})}`);
   }
 
   return result;

--- a/tools/psoxy-test/index.js
+++ b/tools/psoxy-test/index.js
@@ -54,15 +54,6 @@ export default async function (options = {}) {
   
   try {
     result = await psoxyCall(options);
-
-    if (result.status === 200 && options.saveToFile) {
-      try {
-        await saveRequestResultToFile(url, result.data);
-        console.log(chalk.green('Results saved to file'));
-      } catch (err) {
-        console.error(chalk.red('Unable to save results to file'), err);
-      }        
-    }
   } catch (err) {
     result.error = err.message;
   }
@@ -104,6 +95,16 @@ export default async function (options = {}) {
   if (options.verbose && result.headers) {
     console.log(`Response headers:\n 
       ${inspect(result.headers, {depth: null, colors: true})}`);
+  }
+
+
+  if (result.status === 200 && options.saveToFile) {
+    try {
+      await saveRequestResultToFile(url, result.data, 
+        options.verbose || false);
+    } catch (err) {
+      console.error(chalk.red('Unable to save results to file'), err);
+    }        
   }
 
   return result;

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -1,4 +1,4 @@
-import { getCommonHTTPHeaders, fetch, executeCommand } from './utils.js';
+import { getCommonHTTPHeaders, request, executeCommand } from './utils.js';
 
 /**
  * Helper: check url deploy type
@@ -48,13 +48,11 @@ async function call(options = {}) {
   console.log('Waiting response...');
 
   if (options.verbose) {
-    console.log('Options:');
-    console.log(options);
-    console.log('Request headers:');
-    console.log(headers);
+    console.log('Request options:', options);
+    console.log('Request headers:', headers);
   }
 
-  return await fetch(options.url, { headers: headers });
+  return await request(options.url, headers);
 }
 
 export default {

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -9,8 +9,6 @@ import _ from 'lodash';
 // Since we're using ESM modules, we need to make `__dirname` available
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const RESPONSES_DIR = '/responses';
-
 /**
  * Save data to file.
  *
@@ -51,16 +49,22 @@ function getFileNameFromURL(url, timestamp = true, extension = '.json') {
 /**
  * Helper to save URL responses to a file.
  * File names follow this format:
- * `/responses/[psoxy-function]-[api-path]-[ISO8601 timestamp].json`, example:
- * `/responses/psoxy-gcal-calendar-v3-calendars-primary-2022-09-02T10:15:00.000Z.json`
+ * `[psoxy-function]-[api-path]-[ISO8601 timestamp].json`, example:
+ * `psoxy-gcal-calendar-v3-calendars-primary-2022-09-02T10:15:00.000Z.json`
  *
  * @param {URL} url
  * @param {Object} data
  */
-async function saveRequestResultToFile(url, data) {
+async function saveRequestResultToFile(url, data, log = false) {
   const filename = getFileNameFromURL(url);
+  const dirname = path.resolve(__dirname, '..');
+
+  if (log) {
+    console.log(`Saving results to ${dirname}/${filename}`);
+  }
+
   return saveToFile(
-    path.resolve(__dirname, '..') + RESPONSES_DIR,
+    path.resolve(__dirname, '..'),
     filename,
     JSON.stringify(data, undefined, 4)
   );

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -110,7 +110,7 @@ async function requestWrapper(url, headers) {
         };
 
         if (res.statusCode !== 200) {
-          result.error = res.headers['x-psoxy-error'] || response.statusText;
+          result.error = res.headers['x-psoxy-error'] || res.statusMessage;
           resolve(result);
         } else {
           let responseData = '';

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -110,7 +110,7 @@ async function requestWrapper(url, headers) {
         };
 
         if (res.statusCode !== 200) {
-          result.error = res.headers['x-psoxy-error'] || res.statusMessage;
+          result.error = res.statusMessage;
           resolve(result);
         } else {
           let responseData = '';

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -2,41 +2,41 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
 import aws4 from 'aws4';
-import fetch from 'node-fetch';
+import https from 'https';
 import path from 'path';
 import _ from 'lodash';
 
-// Since we're using ESM modules, we need to make `__dirname` available 
+// Since we're using ESM modules, we need to make `__dirname` available
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const RESPONSES_DIR = '/responses';
 
 /**
  * Save data to file.
- * 
+ *
  * @param {string} dirname
- * @param {string} filename 
- * @param {string} data 
+ * @param {string} filename
+ * @param {string} data
  */
 async function saveToFile(dirname = __dirname, filename, data) {
   let dirExists = false;
-  
+
   try {
     await fs.access(dirname);
     dirExists = true;
-  } catch {};
+  } catch {}
 
-  if (!dirExists){
+  if (!dirExists) {
     await fs.mkdir(dirname);
   }
 
   return fs.writeFile(`${dirname}/${filename}`, data, 'utf-8');
-};
+}
 
 /**
- * Get a file name from a URL object; default: replaces `/` by `-` 
- * 
- * @param {URL} url 
+ * Get a file name from a URL object; default: replaces `/` by `-`
+ *
+ * @param {URL} url
  * @param {boolean} timestamp
  * @param {string} extension
  * @return {string}
@@ -46,33 +46,36 @@ function getFileNameFromURL(url, timestamp = true, extension = '.json') {
   const pathPart = url.pathname.substring(1).replaceAll('/', '-');
   const timestampPart = timestamp ? `-${new Date().toISOString()}` : '';
   return pathPart + timestampPart + extension;
-};
+}
 
 /**
- * Helper to save URL responses to a file. 
+ * Helper to save URL responses to a file.
  * File names follow this format:
  * `/responses/[psoxy-function]-[api-path]-[ISO8601 timestamp].json`, example:
  * `/responses/psoxy-gcal-calendar-v3-calendars-primary-2022-09-02T10:15:00.000Z.json`
- * 
- * @param {URL} url 
- * @param {Object} data 
+ *
+ * @param {URL} url
+ * @param {Object} data
  */
 async function saveRequestResultToFile(url, data) {
   const filename = getFileNameFromURL(url);
-  return saveToFile(path.resolve(__dirname, '..') + RESPONSES_DIR, filename, 
-    JSON.stringify(data, undefined, 4));
-};
+  return saveToFile(
+    path.resolve(__dirname, '..') + RESPONSES_DIR,
+    filename,
+    JSON.stringify(data, undefined, 4)
+  );
+}
 
 /**
- * Get common HTTP requests for Psoxy requests.
- * 
+ * Get common HTTP request headers for Psoxy requests.
+ *
  * @param {Object} options - see `../index.js`
  */
 function getCommonHTTPHeaders(options = {}) {
   const headers = {
     'Accept-Encoding': options.gzip ? 'gzip' : '*',
     'X-Psoxy-Skip-Sanitizer': options.skip?.toString() || 'false',
-  }
+  };
   if (options.impersonate) {
     headers['X-Psoxy-User-To-Impersonate'] = options.impersonate;
   }
@@ -80,64 +83,93 @@ function getCommonHTTPHeaders(options = {}) {
 }
 
 /**
- * Simple wrapper around `node-fetch` to ease testing.
+ * Wrapper for requests using Node.js HTTP interfaces: focused on 
+ * Psoxy use-case (*)
  * 
- * @param {URL} url 
- * @param {Object} options 
+ * @param {Object} headers
+ * @param {String|URL} url
  * @return {Object}
  */
-async function fetchWrapper(url, options) {
-  const response = await fetch(url, options);
+async function requestWrapper(url, headers) {
+  url = typeof url === 'string' ? new URL(url) : url;
+  const params = url.searchParams.toString();
 
-  const responseHeaders = {};
-  response.headers.forEach((key, value) => responseHeaders[key] = value);
+  return new Promise((resolve) => {
+    const req = https.request(
+      {
+        hostname: url.host,
+        port: 443,
+        path: url.pathname + (params !== '' ? `?${params}` : ''),
+        method: 'GET',
+        headers: headers,
+      },
+      (res) => {
+        const result = {
+          status: res.statusCode,
+          headers: res.headers,
+        };
 
-  const result = {
-    status: response.status,
-    headers: JSON.stringify(responseHeaders, undefined, 2),
-  };
-  
-  if (response.status === 200) {
-    result.data = await response.json();
-  } else {
-    result.error = response.headers.get('x-psoxy-error') || response.statusText;
-  }
-
-  return result;
+        if (res.statusCode !== 200) {
+          result.error = res.headers['x-psoxy-error'] || response.statusText;
+          resolve(result);
+        } else {
+          let responseData = '';
+          res.on('data', (data) => (responseData += data));
+          res.on('end', () => {
+            try {
+              result.data = JSON.parse(responseData);
+            } catch (e) {
+              console.log('Error parsing JSON response');
+              result.data = responseData;
+            }
+            resolve(result);
+          });
+        }
+      }
+    );
+    req.on('error', (err) => {
+      // resolve promise to not force caller to "catch"; `status` is not the
+      // right key, but callers expect this a result object with these keys
+      resolve({ status: err.code, error: err.message });
+    });
+    req.end();
+  });
 }
 
 /**
  * Simple wrapper around `aws4` (*) to ease testing.
- * 
+ *
  * (*) aws4 is not able to parse a full URL:
  * https://[id].lambda-url.us-east-1.on.aws/
  * the result is missing `service` and `region` which are mandatory
- * 
- * @param {URL} url 
- * @param {Object} credentials 
+ *
+ * @param {URL} url
+ * @param {Object} credentials
  * @return {Object}
  */
 function signAWSRequestURL(url, credentials) {
   // According to aws4 docs, search params should be part of the "path"
   const params = url.searchParams.toString();
 
-  return aws4.sign({
-    host: url.host,
-    path: url.pathname + (params !== '' ? `?${params}` : '') ,
-    service: 'lambda',
-    region: url.host.split('.')[2],
-  },
-  {
-    accessKeyId: credentials?.Credentials.AccessKeyId,
-    secretAccessKey: credentials?.Credentials.SecretAccessKey,
-    sessionToken: credentials?.Credentials.SessionToken,
-  });
+  return aws4.sign(
+    {
+      host: url.host,
+      path: url.pathname + (params !== '' ? `?${params}` : ''),
+      service: 'lambda',
+      region: url.host.split('.')[2],
+    },
+    {
+      accessKeyId: credentials?.AccessKeyId,
+      secretAccessKey: credentials?.SecretAccessKey,
+      sessionToken: credentials?.SessionToken,
+    }
+  );
 }
 
 /**
  * Simple wrapper around node's `execSync` to ease testing.
- * 
- * @param {string} command 
+ *
+ * @param {string} command
  * @return {string}
  */
 function executeCommand(command) {
@@ -146,27 +178,25 @@ function executeCommand(command) {
 
 /**
  * Transform endpoint's path and params based on previous calls responses
- * 
+ *
  * @param {Object} spec - see `../data-sources/spec.js`
  * @param {Object} res - data source API response
- * @returns 
+ * @returns
  */
 function transformSpecWithResponse(spec = {}, res = {}) {
   (spec?.endpoints || [])
-    .filter(endpoint => endpoint.refs !== undefined)
-    .forEach(endpoint => {
-      endpoint.refs.forEach(ref => {
-        const target = spec.endpoints
-          .find(endpoint => endpoint.name === ref.name);
+    .filter((endpoint) => endpoint.refs !== undefined)
+    .forEach((endpoint) => {
+      endpoint.refs.forEach((ref) => {
+        const target = spec.endpoints.find((endpoint) => endpoint.name === ref.name);
 
         if (target && ref.accessor) {
           const valueReplacement = _.get(res, ref.accessor);
-          
+
           if (valueReplacement) {
             // 2 possible replacements: path or param
             if (ref.pathReplacement) {
-              target.path = target.path
-                .replace(ref.pathReplacement, valueReplacement);
+              target.path = target.path.replace(ref.pathReplacement, valueReplacement);
             }
 
             if (ref.paramReplacement) {
@@ -181,8 +211,8 @@ function transformSpecWithResponse(spec = {}, res = {}) {
 
 export {
   executeCommand,
-  fetchWrapper as fetch,
   getCommonHTTPHeaders,
+  requestWrapper as request,
   saveRequestResultToFile,
   signAWSRequestURL,
   transformSpecWithResponse,

--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -22,8 +22,7 @@
     "aws4": "^1.11.0",
     "chalk": "^5.0.1",
     "commander": "^9.4.0",
-    "lodash": "^4.17.21",
-    "node-fetch": "^3.2.10"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "ava": "^4.3.3",

--- a/tools/psoxy-test/test/gcp.test.js
+++ b/tools/psoxy-test/test/gcp.test.js
@@ -28,13 +28,15 @@ test('Psoxy Call: get identity token when option missing', async t => {
     url: new URL(GCP_URL),
   }
 
-  const command = 'gcloud auth print-identity-token';
-  td.when(utils.executeCommand(command)).thenReturn('foo');
-  td.when(utils.fetch(options.url, td.matchers.contains({headers: {}})))
-    .thenReturn({status: 200});
+  const COMMAND = 'gcloud auth print-identity-token';
+  const TOKEN = 'foo';
+  td.when(utils.executeCommand(COMMAND)).thenReturn(TOKEN);
+  td.when(utils.request(options.url, td.matchers.contains({
+    Authorization: `Bearer ${TOKEN}`
+  }))).thenReturn({status: 200});
 
   const result = await gcp.call(options);
   t.is(result.status, 200);
 
-  td.verify(utils.executeCommand(command));
+  td.verify(utils.executeCommand(COMMAND));
 });


### PR DESCRIPTION
### Fixes
 - [node test tool file-save mode not clear](https://app.asana.com/0/1201039336231823/1203139175050629/f)
 - [bug: aws case of test tool doesn't sign urls w query params properly?](https://app.asana.com/0/1201039336231823/1203152530731881/f): issue caused by `node-fetch` that builds the request differently than [node.http](https://nodejs.org/docs/latest/api/http.html#http_http_request_options_callback) which is the mechanism `aws4` uses for request signing.  

### Features

### Change implications

 - dependencies added/changed? **yes**
   `node-fetch` dependency removed
