### PR TITLE
S134 aws entity names

### DIFF
--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -47,7 +47,8 @@ resource "aws_cloudwatch_log_group" "lambda-log" {
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda_${var.function_name}"
+  name        = "PsoxyExec_${var.function_name}"
+  description = "execution role for psoxy instance"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -42,7 +42,8 @@ locals {
 
 # role that Worklytics user will use to call the API
 resource "aws_iam_role" "api-caller" {
-  name = "PsoxyApiCaller"
+  name        = "PsoxyCaller"
+  description = "role for AWS principals that may invoke the psoxy instance or read an instance's output"
 
   # who can assume this role
   assume_role_policy = jsonencode({


### PR DESCRIPTION
### Features
 - better Psoxy caller role name (role no longer invokes API gateway, and now both invokes functions directly OR accesses output bucket)
 - better Psoxy exec role name; snake_case isn't typical AWS role name style, nor is saying "iam_for" - these are all implicitly `iam` entities

### Change implications

 - dependencies added/changed? **no**
