### PR TITLE
reversibly encode asana user gids

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -186,6 +186,7 @@ locals {
       reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       example_api_calls : [
+        "/api/1.0/workspaces",
         "/api/1.0/users?workspace={ANY_WORKSPACE_GID}&limit=10",
         "/api/1.0/workspaces/{ANY_WORKSPACE_GID}/teams&limit=10",
         "/api/1.0/teams/{ANY_TEAM_GID}/projects?limit=20",

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
@@ -23,9 +23,12 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$.data[*].photo")
                     .build())
             .transform(Transform.Pseudonymize.builder()
-                    .jsonPath("$.data[*].gid")
                     .jsonPath("$.data[*].email")
                     .build())
+            .transform(Transform.Pseudonymize.builder()
+                .includeReversible(true)
+                .jsonPath("$.data[*].gid")
+                .build())
             .build();
 
     static final Rules2.Endpoint TEAMS = Rules2.Endpoint.builder()

--- a/java/core/src/main/resources/rules/asana/asana.yaml
+++ b/java/core/src/main/resources/rules/asana/asana.yaml
@@ -10,8 +10,12 @@ endpoints:
           - "$.data[*].photo"
       - !<pseudonymize>
         jsonPaths:
-          - "$.data[*].gid"
           - "$.data[*].email"
+        encoding: "JSON"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$.data[*].gid"
+        includeReversible: true
         encoding: "JSON"
   - pathRegex: "^/api/1.0/workspaces/[^/]*/teams?[^/]*"
     transforms:
@@ -53,6 +57,7 @@ endpoints:
           - "$.data[*].custom_fields[*].people_value[*].gid"
           - "$.data[*].followers[*].gid"
           - "$.data[*]..email"
+        encoding: "JSON"
   - pathRegex: "^/api/1.0/tasks/[^/]*(\\?)?[^/]*"
     transforms:
       - !<redact>
@@ -72,6 +77,7 @@ endpoints:
           - "$.data.custom_fields[*].people_value[*].gid"
           - "$.data.followers[*].gid"
           - "$.data..email"
+        encoding: "JSON"
   - pathRegex: "^/api/1.0/tasks/[^/]*/stories?[^/]*"
     transforms:
       - !<redact>
@@ -93,6 +99,7 @@ endpoints:
           - "$.data[*].likes[*].user.gid"
           - "$.data[*].story.created_by.gid"
           - "$.data[*]..email"
+        encoding: "JSON"
   - pathRegex: "^/api/1.0/tasks/[^/]*/subtasks?[^/]*"
     transforms:
       - !<redact>
@@ -112,6 +119,7 @@ endpoints:
           - "$.data[*].custom_fields[*].people_value[*].gid"
           - "$.data[*].followers[*].gid"
           - "$.data[*]..email"
+        encoding: "JSON"
   - pathRegex: "^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*"
     transforms:
       - !<redact>
@@ -131,3 +139,4 @@ endpoints:
           - "$.data[*].custom_fields[*].people_value[*].gid"
           - "$.data[*].followers[*].gid"
           - "$.data[*]..email"
+        encoding: "JSON"

--- a/java/core/src/test/resources/api-response-examples/asana/sanitized/users.json
+++ b/java/core/src/test/resources/api-response-examples/asana/sanitized/users.json
@@ -1,7 +1,7 @@
 {
   "data":[
     {
-      "gid":"{\"scope\":\"asana\",\"hash\":\"qspPhKOOLuFUBz1_ZKi5N75VXBnwVjYwv9pilOk6TPI\"}",
+      "gid":"{\"scope\":\"asana\",\"hash\":\"qspPhKOOLuFUBz1_ZKi5N75VXBnwVjYwv9pilOk6TPI\",\"reversible\":\"p~r4ONZUfEyn9MUkcyDQkQ5MBNpdIerM24MasxFpuQBaGzFatT5PGvb7S57rNnHGwT\"}",
       "resource_type":"user",
       "email":"{\"scope\":\"email\",\"domain\":\"example.com\",\"hash\":\"e_xeGdBtXUAYxRh.u2wBe57WK_OqPGm6S2K8w7QL2Zc\"}",
       "workspaces":[


### PR DESCRIPTION

### Features
  - recover `/workspaces` endpoint; useful for testing if nothing else
  - reversibly encode user gids - not sure we need this, but in case

### Change implications

 - dependencies added/changed? **no**
