### PR TITLE
Fix default values for `environment_name`

### DIFF
--- a/infra/examples-dev/gcp-google-workspace/variables.tf
+++ b/infra/examples-dev/gcp-google-workspace/variables.tf
@@ -6,7 +6,7 @@ variable "gcp_project_id" {
 variable "environment_name" {
   type        = string
   description = "qualifier to append to name of project that will host your psoxy instance"
-  default     = null
+  default     = ""
 }
 
 variable "gcp_folder_id" {

--- a/infra/examples/gcp-google-workspace/variables.tf
+++ b/infra/examples/gcp-google-workspace/variables.tf
@@ -6,7 +6,7 @@ variable "gcp_project_id" {
 variable "environment_name" {
   type        = string
   description = "qualifier to append to name of project that will host your psoxy instance"
-  default     = null
+  default     = ""
 }
 
 variable "gcp_folder_id" {

--- a/infra/modular-examples/gcp-google-workspace/variables.tf
+++ b/infra/modular-examples/gcp-google-workspace/variables.tf
@@ -6,7 +6,7 @@ variable "gcp_project_id" {
 variable "environment_name" {
   type        = string
   description = "qualifier to append to name of project that will host your psoxy instance"
-  default     = null
+  default     = ""
 }
 
 variable "worklytics_sa_emails" {


### PR DESCRIPTION
### Fixes
- Default values for `environment_name` to "" instead of `null` that causes interpolation errors

### Features
.

### Change implications

 - dependencies added/changed? **no**
