### PR TITLE
Add missing param for Asana rules

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
@@ -32,14 +32,6 @@ public class PrebuiltSanitizerRules {
                     Lists.newArrayList("workspace", "team").stream())
             .collect(Collectors.toList());
 
-    private static final List<String> searchTaskByWorkspaceAllowedQueryParameters = Lists.newArrayList(
-            "limit",
-            "modified_at.after",
-            "modified_at.before",
-            "is_subtask",
-            "sort_ascending"
-    );
-
     static final Rules2.Endpoint WORKSPACES = Rules2.Endpoint.builder()
             .pathRegex("^/api/1.0/workspaces[?]?[^/]*$")
             .allowedQueryParams(commonAllowedQueryParameters)
@@ -99,7 +91,6 @@ public class PrebuiltSanitizerRules {
 
     static final Rules2.Endpoint WORKSPACE_TASKS_SEARCH = Rules2.Endpoint.builder()
             .pathRegex("^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*")
-            .allowedQueryParams(searchTaskByWorkspaceAllowedQueryParameters)
             .transforms(getTaskTransforms(true))
             .build();
 

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
@@ -32,6 +32,15 @@ public class PrebuiltSanitizerRules {
                     Lists.newArrayList("workspace", "team").stream())
             .collect(Collectors.toList());
 
+    private static final List<String> searchTaskByWorkspaceAllowedQueryParameters = Lists.newArrayList(
+            "limit",
+            "modified_at.after",
+            "modified_at.before",
+            "is_subtask",
+            "sort_ascending",
+            "opt_fields"
+    );
+
     static final Rules2.Endpoint WORKSPACES = Rules2.Endpoint.builder()
             .pathRegex("^/api/1.0/workspaces[?]?[^/]*$")
             .allowedQueryParams(commonAllowedQueryParameters)
@@ -91,6 +100,7 @@ public class PrebuiltSanitizerRules {
 
     static final Rules2.Endpoint WORKSPACE_TASKS_SEARCH = Rules2.Endpoint.builder()
             .pathRegex("^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*")
+            .allowedQueryParams(searchTaskByWorkspaceAllowedQueryParameters)
             .transforms(getTaskTransforms(true))
             .build();
 

--- a/java/core/src/main/resources/rules/asana/asana.yaml
+++ b/java/core/src/main/resources/rules/asana/asana.yaml
@@ -165,12 +165,6 @@ endpoints:
           - "$.data[*]..email"
         encoding: "JSON"
   - pathRegex: "^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*"
-    allowedQueryParams:
-      - "limit"
-      - "modified_at.after"
-      - "modified_at.before"
-      - "is_subtask"
-      - "sort_ascending"
     transforms:
       - !<redact>
         jsonPaths:

--- a/java/core/src/main/resources/rules/asana/asana.yaml
+++ b/java/core/src/main/resources/rules/asana/asana.yaml
@@ -165,6 +165,13 @@ endpoints:
           - "$.data[*]..email"
         encoding: "JSON"
   - pathRegex: "^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*"
+    allowedQueryParams:
+      - "limit"
+      - "modified_at.after"
+      - "modified_at.before"
+      - "is_subtask"
+      - "sort_ascending"
+      - "opt_fields"
     transforms:
       - !<redact>
         jsonPaths:


### PR DESCRIPTION
Add `opt_field` param for search endpoint in Asana. Required for new connector.


### Features
[Use SearchTask from Workspace when Premium tier](https://app.asana.com/0/0/1203198428622327)

### Change implications

 - dependencies added/changed? **no**
