### PR TITLE
document broken jdk, give some downgrade advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via Terraform, relying on Google Cloud and/or AWS command line tools.  You will 
 versions of all of the following:
 
   - git
-  - Java 11+ JDK variant
+  - Java 11+ JDK variant, but not Java 19 (currently broken, see [docs/troubleshooting.md](docs/troubleshooting.md) for downgrade help)
   - [Maven 3.6+](https://maven.apache.org/docs/history.html)
   - [terraform 1.3.x+](https://www.terraform.io/) optional; if you don't use this, you'll need to
     configure your GCP/AWS project via the web console/CLI tools. Adapting one of our

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,6 +11,37 @@
 
 ## General Tips
 
+### Build problems with Java 19 (specifically, openjdk 19.0.1)
+
+If you are using openjdk 19.0.1, you may run into problems with the build. We suggest you downgrade
+to some java 17 (which is Long-Term Support edition) and use that. 
+
+On Mac, steps would be:
+
+1. check version
+```bash
+mvn -v
+```
+- java version says "17", you're good to go. otherwise, try to downgrade
+
+2. install java 17
+```bash
+brew install openjdk@17
+```
+
+3. set `JAVA_HOME` env variable to point to java 17:
+
+```bash
+export JAVA_HOME=`/opt/homebrew/Cellar/openjdk/19.0.1/libexec/openjdk.jdk/Contents/Home`
+```
+
+NOTE:
+  - you may need to edit some similar `export` command in your `.bashrc`/`.zshrc` file, or similar;
+    or repeat the above command every time you open a new terminal window.
+  - if you install/upgrade something via Homebrew that depends on Java, you may need to repeat step
+    3 again to reset your `JAVA_HOME`
+
+
 ### Upgrading Psoxy Code
 
 If you upgrade your psoxy code, it may be worth trying `terraform init --upgrade` to make sure


### PR DESCRIPTION

### Fixes
 - current docs leave open use of JDK version known to be broken; warn users, give downgrade tips


### Change implications

 - dependencies added/changed? **no**
