### PR TITLE
s138 : explicitly force sha1, as some openssl default to sha256

### DIFF
--- a/infra/modules/azuread-local-cert/local-cert.sh
+++ b/infra/modules/azuread-local-cert/local-cert.sh
@@ -16,7 +16,7 @@ openssl req -x509 -newkey rsa:2048 -subj "${SUBJECT}" -keyout $KEY_FILE -out $CE
 openssl pkcs8 -nocrypt -in $KEY_FILE  -inform PEM -topk8 -outform PEM -out $KEY_FILE_PKCS8 >/dev/null 2>&1
 
 #CERT_DER=`openssl x509 -in $CERT_FILE -outform DER | base64`
-FINGERPRINT_RESULT=`openssl x509 -in $CERT_FILE -noout -fingerprint`
+FINGERPRINT_RESULT=`openssl x509 -in $CERT_FILE -noout -fingerprint -sha1`
 # output as JSON
 OUTPUT_JSON="{\"cert\": \"`cat $CERT_FILE | base64`\",\"key_pkcs8\": \"`cat $KEY_FILE_PKCS8 | base64`\",\"fingerprint\":\"${FINGERPRINT_RESULT}\"}"
 echo "$OUTPUT_JSON"


### PR DESCRIPTION
### Fixes
 - for some `openssl` implementations, default fingerprint alg is `sha256` rather than `sha1`.  This causes two problems for us: 1) our regex that strips `Fingerprint= SHA1` fails to trim prefix from the fingerprint, so fingerprint is stored with this in our configurations; and 2) the fingerprint doesn't match what MSFT calculates, as it's still using SHA1.


### Change implications

 - dependencies added/changed? **no**
