### PR TITLE
Canonical equivalence for emails with dots

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/Sanitizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/Sanitizer.java
@@ -1,11 +1,15 @@
 package co.worklytics.psoxy;
 
-import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
 import co.worklytics.psoxy.rules.RuleSet;
-import lombok.*;
+import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
 
 public interface Sanitizer {
 
@@ -37,6 +41,12 @@ public interface Sanitizer {
 
         @Builder.Default
         PseudonymImplementation pseudonymImplementation = PseudonymImplementation.DEFAULT;
+
+        @Builder.Default
+        Set<String> customerDomains = new HashSet<>();
+
+        @Builder.Default
+        boolean ignoreDotsOnCustomerDomains = false;
 
     }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/SanitizerFactory.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/SanitizerFactory.java
@@ -3,9 +3,12 @@ package co.worklytics.psoxy;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.psoxy.impl.SanitizerImpl;
-
 import co.worklytics.psoxy.rules.RuleSet;
+import com.google.common.base.Splitter;
 import dagger.assisted.AssistedFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @AssistedFactory
 public interface SanitizerFactory {
@@ -19,6 +22,18 @@ public interface SanitizerFactory {
                 .orElseThrow(() -> new Error("Must configure value for SALT to generate pseudonyms")))
             .defaultScopeId(config.getConfigPropertyAsOptional(ProxyConfigProperty.IDENTIFIER_SCOPE_ID)
                 .orElse(rules.getDefaultScopeIdForSource()));
+
+        String customerDomainsConfig = config.getConfigPropertyAsOptional(ProxyConfigProperty.CUSTOMER_DOMAINS)
+            .orElse("");
+        Set<String> customerDomains = new HashSet<>(Splitter.on(",")
+            .trimResults()
+            .omitEmptyStrings()
+            .splitToList(customerDomainsConfig));
+        builder.customerDomains(customerDomains);
+
+        config.getConfigPropertyAsOptional(ProxyConfigProperty.IGNORED_DOTS_ON_EMAILS)
+            .map(Boolean::parseBoolean)
+            .ifPresent(builder::ignoreDotsOnCustomerDomains);
 
         builder.rules(rules);
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
@@ -9,6 +9,11 @@ public enum ProxyConfigProperty implements ConfigService.ConfigProperty {
     @Deprecated //removed from v0.4
     IDENTIFIER_SCOPE_ID,
     PSOXY_SALT,
+    // If this customer email provider considers emails with dots as equivalent to emails without
+    // f.e. Gmail -> John.Smith@gmail.com == johnsmith@gmail.com
+    IGNORED_DOTS_ON_EMAILS,
+    // if IGNORED_DOTS_ON_EMAILS set, the list of domains to apply the rule
+    CUSTOMER_DOMAINS,
     //if relying on default rules, whether to use version that pseudonymizes per-account source IDs
     // that aren't email addresses (eg, the IDs that sources generate for each account, which aren't
     // usually PII without having access to the source's dataset)

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerImpl.java
@@ -1,10 +1,14 @@
 package co.worklytics.psoxy.impl;
 
-import co.worklytics.psoxy.*;
+import co.worklytics.psoxy.HashUtils;
+import co.worklytics.psoxy.PseudonymizedIdentity;
+import co.worklytics.psoxy.Sanitizer;
 import co.worklytics.psoxy.rules.Rules2;
 import co.worklytics.psoxy.rules.Transform;
 import co.worklytics.psoxy.utils.URLUtils;
-import com.avaulta.gateway.pseudonyms.*;
+import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
+import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
@@ -338,9 +342,15 @@ public class SanitizerImpl implements Sanitizer {
     String emailCanonicalization(String original) {
         String domain = EmailAddressParser.getDomain(original, EmailAddressCriteria.DEFAULT, true);
 
-        //NOTE: lower-case here is NOT stipulated by RFC
-        return  EmailAddressParser.getLocalPart(original, EmailAddressCriteria.DEFAULT, true)
-            .toLowerCase()
+        String localPart = EmailAddressParser.getLocalPart(original, EmailAddressCriteria.DEFAULT, true)
+            //NOTE: lower-case here is NOT stipulated by RFC
+            .toLowerCase();
+
+        if (configurationOptions.isIgnoreDotsOnCustomerDomains() && configurationOptions.getCustomerDomains().contains(domain)) {
+            localPart = localPart.replace(".","");
+        }
+
+        return localPart
             + "@"
             + domain.toLowerCase();
 

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/SanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/SanitizerImplTest.java
@@ -1,6 +1,9 @@
 package co.worklytics.psoxy.impl;
 
-import co.worklytics.psoxy.*;
+import co.worklytics.psoxy.PseudonymizedIdentity;
+import co.worklytics.psoxy.PsoxyModule;
+import co.worklytics.psoxy.Sanitizer;
+import co.worklytics.psoxy.SanitizerFactory;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.rules.PrebuiltSanitizerRules;
 import co.worklytics.psoxy.rules.Rules2;
@@ -124,6 +127,7 @@ class SanitizerImplTest {
         "\"Alice Different Last name\" <alice@worklytics.co>",
         "Alice@worklytics.co",
         "AlIcE@worklytics.co",
+        "ali.ce@worklytics.co",
     })
     @ParameterizedTest
     void emailCanonicalEquivalents(String mailHeaderValue) {

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/SanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/SanitizerImplTest.java
@@ -137,13 +137,23 @@ class SanitizerImplTest {
         "\"Alice Different Last name\" <alice@worklytics.co>",
         "Alice@worklytics.co",
         "AlIcE@worklytics.co",
-        "ali.ce@worklytics.co",
     })
     @ParameterizedTest
     void emailCanonicalEquivalents(String mailHeaderValue) {
         PseudonymizedIdentity canonicalExample = sanitizer.pseudonymize(ALICE_CANONICAL);
 
         assertEquals(canonicalExample.getHash(),
+            sanitizer.pseudonymize(mailHeaderValue).getHash());
+    }
+
+    @ValueSource(strings = {
+        "ali.ce@worklytics.co",
+    })
+    @ParameterizedTest
+    void emailCanonicalNotEquivalents(String mailHeaderValue) {
+        PseudonymizedIdentity canonicalExample = sanitizer.pseudonymize(ALICE_CANONICAL);
+
+        assertNotEquals(canonicalExample.getHash(),
             sanitizer.pseudonymize(mailHeaderValue).getHash());
     }
 


### PR DESCRIPTION
If provider allows it add configuration to be able to make canonical equivalents of emails with dots.

### Change implications

 - dependencies added/changed? **no**
