### PR TITLE
Pseudonym implementation as a config setting

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/SanitizerFactory.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/SanitizerFactory.java
@@ -5,6 +5,7 @@ import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.psoxy.impl.SanitizerImpl;
 
 import co.worklytics.psoxy.rules.RuleSet;
+import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
 import dagger.assisted.AssistedFactory;
 
 @AssistedFactory
@@ -19,6 +20,10 @@ public interface SanitizerFactory {
                 .orElseThrow(() -> new Error("Must configure value for SALT to generate pseudonyms")))
             .defaultScopeId(config.getConfigPropertyAsOptional(ProxyConfigProperty.IDENTIFIER_SCOPE_ID)
                 .orElse(rules.getDefaultScopeIdForSource()));
+
+        config.getConfigPropertyAsOptional(ProxyConfigProperty.PSEUDONYM_IMPLEMENTATION)
+            .map(PseudonymImplementation::parseConfigPropertyValue)
+                .ifPresent(builder::pseudonymImplementation);
 
         builder.rules(rules);
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
@@ -26,6 +26,8 @@ public enum ProxyConfigProperty implements ConfigService.ConfigProperty {
 
 
     //see PseudonymImplementation
+    //use case: use `v0.3` if your initially used a `v0.3.x` version of Proxy to collect data and
+    // want data collected through a later Proxy version to be pseudonymized consistently with that
     PSEUDONYM_IMPLEMENTATION,
 
     //if relying on default rules, whether to use version that pseudonymizes per-account source IDs

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
@@ -20,11 +20,19 @@ public enum ProxyConfigProperty implements ConfigService.ConfigProperty {
 
     @Deprecated //removed from v0.4
     IDENTIFIER_SCOPE_ID,
+
+
     PSOXY_SALT,
+
+
+    //see PseudonymImplementation
+    PSEUDONYM_IMPLEMENTATION,
+
     //if relying on default rules, whether to use version that pseudonymizes per-account source IDs
     // that aren't email addresses (eg, the IDs that sources generate for each account, which aren't
     // usually PII without having access to the source's dataset)
     PSEUDONYMIZE_APP_IDS,
+
     // if set, a base64-YAML encoding of rules
     RULES,
     // for testing - if set, allows for behavior that should only be permitted in development context,

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymImplementation.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymImplementation.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @RequiredArgsConstructor
 public enum PseudonymImplementation {
 
@@ -22,20 +24,13 @@ public enum PseudonymImplementation {
     private final String httpHeaderValue;
 
     public static PseudonymImplementation parseHttpHeaderValue(String httpHeaderValue) {
-        for (PseudonymImplementation impl : values()) {
-            if (impl.getHttpHeaderValue().equals(httpHeaderValue)) {
-                return impl;
-            }
-        }
-        throw new IllegalArgumentException("Unknown pseudonym implementation: " + httpHeaderValue);
+        return Arrays.stream(values())
+            .filter( p -> p.getHttpHeaderValue().equals(httpHeaderValue))
+            .findFirst()
+            .orElseThrow( () -> new IllegalArgumentException("Unknown pseudonym implementation: " + httpHeaderValue));
     }
 
     public static PseudonymImplementation parseConfigPropertyValue(String configPropertyValue) {
-        for (PseudonymImplementation impl : values()) {
-            if (impl.getHttpHeaderValue().equals(configPropertyValue)) {
-                return impl;
-            }
-        }
-        throw new IllegalArgumentException("Unknown pseudonym implementation: " + configPropertyValue);
+        return parseHttpHeaderValue(configPropertyValue);
     }
 }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymImplementation.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymImplementation.java
@@ -7,6 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PseudonymImplementation {
 
+
+    //NOTE: use a version id (v0.3, etc) NOT the enum name, as the enum name --> version number
+    // is convention, to clarify what's default or not
+
+
     //not based on scope; base64-url encoded
     DEFAULT("v0.4"),
     //includes 'scope'

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymImplementation.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymImplementation.java
@@ -16,7 +16,6 @@ public enum PseudonymImplementation {
     @Getter @NonNull
     private final String httpHeaderValue;
 
-
     public static PseudonymImplementation parseHttpHeaderValue(String httpHeaderValue) {
         for (PseudonymImplementation impl : values()) {
             if (impl.getHttpHeaderValue().equals(httpHeaderValue)) {
@@ -24,5 +23,14 @@ public enum PseudonymImplementation {
             }
         }
         throw new IllegalArgumentException("Unknown pseudonym implementation: " + httpHeaderValue);
+    }
+
+    public static PseudonymImplementation parseConfigPropertyValue(String configPropertyValue) {
+        for (PseudonymImplementation impl : values()) {
+            if (impl.getHttpHeaderValue().equals(configPropertyValue)) {
+                return impl;
+            }
+        }
+        throw new IllegalArgumentException("Unknown pseudonym implementation: " + configPropertyValue);
     }
 }

--- a/java/impl/cmd-line/src/main/java/co/worklytics/psoxy/Handler.java
+++ b/java/impl/cmd-line/src/main/java/co/worklytics/psoxy/Handler.java
@@ -1,7 +1,6 @@
 package co.worklytics.psoxy;
 
 import co.worklytics.psoxy.rules.CsvRules;
-import com.avaulta.gateway.rules.ColumnarRules;
 import co.worklytics.psoxy.storage.FileHandlerFactory;
 import com.google.api.client.util.Lists;
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
@@ -26,9 +25,9 @@ public class Handler {
     FileHandlerFactory fileHandlerStrategy;
 
     @SneakyThrows
-    public void pseudonymize(@NonNull Config config,
-                             @NonNull File inputFile,
-                             @NonNull Appendable out) {
+    public void sanitize(@NonNull Config config,
+                         @NonNull File inputFile,
+                         @NonNull Appendable out) {
         Sanitizer.ConfigurationOptions.ConfigurationOptionsBuilder options =
             Sanitizer.ConfigurationOptions.builder()
             .defaultScopeId(config.getDefaultScopeId());

--- a/java/impl/cmd-line/src/main/java/co/worklytics/psoxy/Main.java
+++ b/java/impl/cmd-line/src/main/java/co/worklytics/psoxy/Main.java
@@ -31,7 +31,7 @@ public class Main {
 
         Preconditions.checkArgument(inputFile.exists(), "File %s does not exist", args[0]);
 
-        container.fileHandler().pseudonymize(config, inputFile, System.out);
+        container.fileHandler().sanitize(config, inputFile, System.out);
     }
 
 

--- a/java/impl/cmd-line/src/test/java/co/worklytics/psoxy/HandlerTest.java
+++ b/java/impl/cmd-line/src/test/java/co/worklytics/psoxy/HandlerTest.java
@@ -52,7 +52,7 @@ public class HandlerTest {
         File inputFile = new File(getClass().getResource("/hris-example.csv").getFile());
 
         StringWriter s = new StringWriter();
-        handler.pseudonymize(config, inputFile, s);
+        handler.sanitize(config, inputFile, s);
 
 
         assertEquals(EXPECTED, s.toString());
@@ -75,7 +75,7 @@ public class HandlerTest {
         File inputFile = new File(getClass().getResource("/hris-example.csv").getFile());
 
         StringWriter s = new StringWriter();
-        handler.pseudonymize(config, inputFile, s);
+        handler.sanitize(config, inputFile, s);
 
         assertEquals(EXPECTED, s.toString());
     }
@@ -93,7 +93,7 @@ public class HandlerTest {
         File inputFile = new File(getClass().getResource("/hris-example-headers-w-spaces.csv").getFile());
 
         StringWriter s = new StringWriter();
-        handler.pseudonymize(config, inputFile, s);
+        handler.sanitize(config, inputFile, s);
 
         assertEquals(EXPECTED, s.toString());
     }


### PR DESCRIPTION
### Fixes
 - no way to configure legacy pseudonym implementation on non-REST connectors

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203651923592450