### PR TITLE
avoid lots of logs, java compliation

### DIFF
--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -69,6 +69,7 @@ module "psoxy-aws-google-workspace" {
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)
   aws_region                     = var.aws_region
   psoxy_base_dir                 = var.psoxy_base_dir
+  force_bundle                   = var.force_bundle
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples-dev/aws-google-workspace/terraform.tfvars.example
+++ b/infra/examples-dev/aws-google-workspace/terraform.tfvars.example
@@ -5,7 +5,7 @@ gcp_org_id                    = "123123123123"
 gcp_folder_id                 = "123123123123"
 gcp_billing_account_id        = "123456-ABCDEFG-ABCDEFG"
 google_workspace_example_user = "example@acme.com"
-# force_bundle                  = false # if making changes to Java code w/o changing version number, set to true
+force_bundle                  = true # if making changes to Java code w/o changing version number, set to true
 enabled_connectors = [
   "asana",
   "dropbox-business",

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -28,6 +28,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
+  default     = false
+}
+
 variable "caller_gcp_service_account_ids" {
   type        = list(string)
   description = "ids of GCP service accounts allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -57,6 +57,7 @@ module "psoxy-aws-msft-365" {
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)
   aws_region                     = var.aws_region
   psoxy_base_dir                 = var.psoxy_base_dir
+  force_bundle                   = var.force_bundle
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples-dev/aws-msft-365/terraform.tfvars.example
+++ b/infra/examples-dev/aws-msft-365/terraform.tfvars.example
@@ -1,29 +1,23 @@
 aws_account_id                = "123123123123" # your AWS account ID here
 aws_assume_role_arn           = "arn:aws:iam::123123123123:role/InfraAdmin" # role in that AWS account ID to assume
-gcp_project_id                = "psoxy-acme-example"
-gcp_org_id                    = "123123123123"
-gcp_folder_id                 = "123123123123"
-gcp_billing_account_id        = "123456-ABCDEFG-ABCDEFG"
-google_workspace_example_user = "example@acme.com"
-# force_bundle                  = false # if making changes to Java code w/o changing version number, set to true
+msft_tenant_id                = "" # your Microsoft tenant ID here
 enabled_connectors = [
   "asana",
   "dropbox-business",
-  "gcal",
-  "gdirectory",
-  "gdrive",
-  "gmail",
-  "google-meet",
-  "google-chat",
+  "outlook-calendar",
+  "outlook-mail",
   "hris",
   "slack-discovery-api",
   "zoom",
 ]
-non_production_connectors = [] # use to mark any of the above as 'non-production' (NOTE: allows test calls that may expose PII)
+force_bundle                  = true # if making changes to Java code w/o changing version number, set to true
+non_production_connectors = [
+  # use to mark any of the above as 'non-production' (NOTE: allows test calls that may expose PII)
+]
 caller_aws_arns = [
 ]
 caller_gcp_service_account_ids = [
-  # "123456712345671234567" # 21-digits; get this from Worklytics once prod-ready
+  # "123456712345671234567" # 21-digits, get this from Worklytics once prod-ready
 ]
 lookup_table_builders = {
     #    "lookup-hris" = {

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -76,6 +76,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
+  default     = false
+}
+
 variable "pseudonymize_app_ids" {
   type        = string
   description = "if set, will set value of PSEUDONYMIZE_APP_IDS environment variable to this value for all sources"

--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -44,6 +44,7 @@ module "psoxy-gcp-google-workspace" {
   worklytics_sa_emails          = var.worklytics_sa_emails
   connector_display_name_suffix = var.connector_display_name_suffix
   psoxy_base_dir                = var.psoxy_base_dir
+  force_bundle                  = var.force_bundle
   gcp_region                    = var.gcp_region
   replica_regions               = var.replica_regions
   enabled_connectors            = var.enabled_connectors

--- a/infra/examples-dev/gcp-google-workspace/terraform.tfvars.example
+++ b/infra/examples-dev/gcp-google-workspace/terraform.tfvars.example
@@ -5,7 +5,7 @@ gcp_billing_account_id        = "123456-ABCDEFG-ABCDEFG"
 google_workspace_example_user = "example@acme.com"
 # gcp_region                    = "us-central1"
 # replica regions = ["us-central1", "us-east1", "us-west1"]
-# force_bundle                  = false # if making changes to Java code w/o changing version number, set to true
+force_bundle                  = true # if making changes to Java code w/o changing version number, set to true
 enabled_connectors = [
   "asana",
   "gcal",

--- a/infra/examples-dev/gcp-google-workspace/variables.tf
+++ b/infra/examples-dev/gcp-google-workspace/variables.tf
@@ -52,6 +52,13 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
+  default     = false
+}
+
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -64,6 +64,7 @@ module "psoxy-aws-google-workspace" {
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)
   aws_region                     = var.aws_region
   psoxy_base_dir                 = var.psoxy_base_dir
+  force_bundle                   = var.force_bundle
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -28,6 +28,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -57,6 +57,7 @@ module "psoxy-aws-msft-365" {
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)
   aws_region                     = var.aws_region
   psoxy_base_dir                 = var.psoxy_base_dir
+  force_bundle                   = var.force_bundle
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples/aws-msft-365/terraform.tfvars.example
+++ b/infra/examples/aws-msft-365/terraform.tfvars.example
@@ -10,6 +10,7 @@ enabled_connectors = [
   "slack-discovery-api",
   "zoom",
 ]
+# force_bundle                  = false # if making changes to Java code w/o changing version number, set to true
 non_production_connectors = [
   # use to mark any of the above as 'non-production' (NOTE: allows test calls that may expose PII)
 ]

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -70,6 +70,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -44,6 +44,7 @@ module "psoxy-gcp-google-workspace" {
   worklytics_sa_emails          = var.worklytics_sa_emails
   connector_display_name_suffix = var.connector_display_name_suffix
   psoxy_base_dir                = var.psoxy_base_dir
+  force_bundle                  = var.force_bundle
   gcp_region                    = var.gcp_region
   replica_regions               = var.replica_regions
   enabled_connectors            = var.enabled_connectors

--- a/infra/examples/gcp-google-workspace/variables.tf
+++ b/infra/examples/gcp-google-workspace/variables.tf
@@ -52,6 +52,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -33,6 +33,7 @@ module "psoxy-aws" {
   psoxy_base_dir                 = var.psoxy_base_dir
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
+  force_bundle                   = var.force_bundle
 }
 
 # secrets shared across all instances

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -71,6 +71,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -38,6 +38,7 @@ module "psoxy-aws" {
   psoxy_base_dir                 = var.psoxy_base_dir
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
+  force_bundle                   = var.force_bundle
 }
 
 module "global_secrets" {

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -54,6 +54,13 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists"
+  default     = false
+}
+
+
 variable "connector_display_name_suffix" {
   type        = string
   description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -26,6 +26,7 @@ module "psoxy-gcp" {
   invoker_sa_emails = var.worklytics_sa_emails
   psoxy_base_dir    = var.psoxy_base_dir
   bucket_location   = var.gcp_region
+  force_bundle      = var.force_bundle
 }
 
 module "google-workspace-connection" {

--- a/infra/modular-examples/gcp-google-workspace/variables.tf
+++ b/infra/modular-examples/gcp-google-workspace/variables.tf
@@ -34,6 +34,12 @@ variable "psoxy_base_dir" {
   }
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -127,15 +127,13 @@ resource "random_password" "encryption_key" {
   special = true
 }
 
-
-
-
 module "psoxy-package" {
   source = "../psoxy-package"
 
   implementation     = "aws"
   path_to_psoxy_java = "${var.psoxy_base_dir}java"
   psoxy_version      = var.psoxy_version
+  force_bundle       = var.force_bundle
 }
 
 output "secrets" {

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -19,6 +19,12 @@ variable "psoxy_base_dir" {
   default     = "../../.."
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists"
+  default     = false
+}
+
 variable "caller_gcp_service_account_ids" {
   type        = list(string)
   description = "ids of GCP OAuth Clients (service accounts) allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -120,6 +120,7 @@ module "psoxy-package" {
   implementation     = "gcp"
   path_to_psoxy_java = "${var.psoxy_base_dir}java"
   psoxy_version      = var.psoxy_version
+  force_bundle       = var.force_bundle
 }
 
 data "archive_file" "source" {

--- a/infra/modules/gcp/variables.tf
+++ b/infra/modules/gcp/variables.tf
@@ -20,6 +20,12 @@ variable "psoxy_base_dir" {
   default     = "../../.."
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists"
+  default     = false
+}
+
 variable "psoxy_version" {
   type        = string
   description = "version of psoxy to deploy"

--- a/infra/modules/psoxy-package/build.sh
+++ b/infra/modules/psoxy-package/build.sh
@@ -2,26 +2,30 @@
 
 # errors halt execution
 set -e
+
 # psoxy build script to be invoked from Terraform 'external' data resource
-# NOTE:
 JAVA_SOURCE_ROOT=$1
 IMPLEMENTATION=$2 # expected to be 'aws', 'gcp', etc ...
 PATH_TO_DEPLOYMENT_JAR=$3
+FORCE_BUILD=$4
 
-TERRAFORM_CONFIG_PATH=`pwd`
-LOG_FILE=/tmp/psoxy-package.`date +%Y%m%d'T'%H%M%S`.log
+#  build JAR if deployment does already not exist, or anything passed for $FORCE_BUILD
+if [ ! -f $PATH_TO_DEPLOYMENT_JAR ] || [ ! -z "$FORCE_BUILD" ] ; then
+  TERRAFORM_CONFIG_PATH=`pwd`
+  LOG_FILE=/tmp/psoxy-package.`date +%Y%m%d'T'%H%M%S`.log
 
-ln -sf ${LOG_FILE} ${TERRAFORM_CONFIG_PATH}/last-build.log
+  ln -sf ${LOG_FILE} ${TERRAFORM_CONFIG_PATH}/last-build.log
 
-cd ${JAVA_SOURCE_ROOT}/gateway-core
-mvn package install > ${LOG_FILE} 2>&1
+  cd ${JAVA_SOURCE_ROOT}/gateway-core
+  mvn package install > ${LOG_FILE} 2>&1
 
-cd ${JAVA_SOURCE_ROOT}/core
-mvn package install > ${LOG_FILE} 2>&1
+  cd ${JAVA_SOURCE_ROOT}/core
+  mvn package install > ${LOG_FILE} 2>&1
 
-cd ${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}
-mvn package >> ${LOG_FILE} 2>&1
+  cd ${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}
+  mvn package >> ${LOG_FILE} 2>&1
+fi
 
-# output back to Terraform
+# output back to Terraform (forces Terraform to be dependent on output)
 OUTPUT_JSON="{\"path_to_deployment_jar\": \"${PATH_TO_DEPLOYMENT_JAR}\"}"
 echo "$OUTPUT_JSON"

--- a/infra/modules/psoxy-package/build.sh
+++ b/infra/modules/psoxy-package/build.sh
@@ -5,7 +5,9 @@ set -e
 # psoxy build script to be invoked from Terraform 'external' data resource
 # NOTE:
 TERRAFORM_CONFIG_PATH=`pwd`
-LOG_FILE=${TERRAFORM_CONFIG_PATH}/psoxy-package.`date +%Y%m%d'T'%H%M%S`.log
+LOG_FILE=/tmp/psoxy-package.`date +%Y%m%d'T'%H%M%S`.log
+
+ln -sf ${LOG_FILE} ${TERRAFORM_CONFIG_PATH}/last-build.log
 
 cd $1/gateway-core
 mvn package install > ${LOG_FILE} 2>&1

--- a/infra/modules/psoxy-package/build.sh
+++ b/infra/modules/psoxy-package/build.sh
@@ -4,20 +4,24 @@
 set -e
 # psoxy build script to be invoked from Terraform 'external' data resource
 # NOTE:
+JAVA_SOURCE_ROOT=$1
+IMPLEMENTATION=$2 # expected to be 'aws', 'gcp', etc ...
+PATH_TO_DEPLOYMENT_JAR=$3
+
 TERRAFORM_CONFIG_PATH=`pwd`
 LOG_FILE=/tmp/psoxy-package.`date +%Y%m%d'T'%H%M%S`.log
 
 ln -sf ${LOG_FILE} ${TERRAFORM_CONFIG_PATH}/last-build.log
 
-cd $1/gateway-core
+cd ${JAVA_SOURCE_ROOT}/gateway-core
 mvn package install > ${LOG_FILE} 2>&1
 
-cd $1/core
+cd ${JAVA_SOURCE_ROOT}/core
 mvn package install > ${LOG_FILE} 2>&1
 
-cd $1/impl/$2
+cd ${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}
 mvn package >> ${LOG_FILE} 2>&1
 
 # output back to Terraform
-OUTPUT_JSON="{\"path_to_deployment_jar\": \"$3\"}"
+OUTPUT_JSON="{\"path_to_deployment_jar\": \"${PATH_TO_DEPLOYMENT_JAR}\"}"
 echo "$OUTPUT_JSON"

--- a/infra/modules/psoxy-package/main.tf
+++ b/infra/modules/psoxy-package/main.tf
@@ -20,7 +20,13 @@ locals {
 # known prior to executing the build
 
 data "external" "deployment_package" {
-  program = ["${path.module}/build.sh", var.path_to_psoxy_java, var.implementation, local.path_to_deployment_jar]
+  program = [
+    "${path.module}/build.sh",
+    var.path_to_psoxy_java,
+    var.implementation,
+    local.path_to_deployment_jar,
+    var.force_bundle ? "--force_bundle" : ""
+  ]
 }
 
 

--- a/infra/modules/psoxy-package/variables.tf
+++ b/infra/modules/psoxy-package/variables.tf
@@ -16,3 +16,9 @@ variable "psoxy_version" {
   default     = "0.4.8"
 }
 
+variable "force_bundle" {
+  type        =  bool
+  description = "whether to force build of deployment bundle, even if it already exists"
+  default     = false
+}
+


### PR DESCRIPTION
### Features
  - avoid tons of `.log` files generated by re-deploys
  - avoid re-build of proxy JAR, *unless* version change *or* forced with a parameter (only developers really need to force re-builds; everyone else should be able to depend on version number changing)

NOTE: this likely renders #200 moot; deterministic builds would avoid unnecessary re-deploys of lambda, but actual Java compilation would still occur. This avoids compilation of Java code entirely.

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203644805511066
  - https://app.asana.com/0/0/1203246719435623