### PR TITLE
S140 tf extensibility

### DIFF
--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -76,6 +76,7 @@ module "psoxy-aws-google-workspace" {
   custom_bulk_connectors         = var.custom_bulk_connectors
   gcp_project_id                 = data.google_project.psoxy-google-connectors.project_id
   google_workspace_example_user  = var.google_workspace_example_user
+  google_workspace_example_admin = var.google_workspace_example_admin
   general_environment_variables  = var.general_environment_variables
 }
 

--- a/infra/examples-dev/aws-google-workspace/terraform.tfvars.example
+++ b/infra/examples-dev/aws-google-workspace/terraform.tfvars.example
@@ -1,8 +1,9 @@
-aws_account_id                = "123123123123" # your AWS account ID here
-aws_assume_role_arn           = "arn:aws:iam::123123123123:role/InfraAdmin" # role in that AWS account ID to assume
-gcp_project_id                = "psoxy-acme-example"
-google_workspace_example_user = "example@acme.com"
-force_bundle                  = true # if making changes to Java code w/o changing version number, set to true
+aws_account_id                 = "123123123123" # your AWS account ID here
+aws_assume_role_arn            = "arn:aws:iam::123123123123:role/InfraAdmin" # role in that AWS account ID to assume
+gcp_project_id                 = "psoxy-acme-example"
+google_workspace_example_user  = "example@acme.com"
+google_workspace_example_admin = "admin@acme.com"
+force_bundle                   = true # if making changes to Java code w/o changing version number, set to true
 enabled_connectors = [
   "asana",
   "dropbox-business",

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -200,6 +200,12 @@ variable "google_workspace_example_user" {
   description = "user to impersonate for Google Workspace API calls (null for none)"
 }
 
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}
+
 variable "vpc_ip_block" {
   type        = string
   description = "IP block for VPC to create for psoxy instances, in CIDR notation"

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -29,7 +29,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
   default     = false
 }
@@ -113,7 +113,7 @@ variable "custom_bulk_connectors" {
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
     })
-    settings_to_provide     = optional(map(string), {})
+    settings_to_provide = optional(map(string), {})
   }))
   description = "specs of custom bulk connectors to create"
 

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -71,7 +71,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
   default     = false
 }
@@ -120,7 +120,7 @@ variable "custom_bulk_connectors" {
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
     })
-    settings_to_provide     = optional(map(string), {})
+    settings_to_provide = optional(map(string), {})
   }))
   description = "specs of custom bulk connectors to create"
 

--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -31,19 +31,20 @@ module "psoxy-gcp-google-workspace" {
   source = "../../modular-examples/gcp-google-workspace"
   # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=v0.4.9"
 
-  gcp_project_id                = data.google_project.psoxy-project.project_id
-  environment_name              = var.environment_name
-  worklytics_sa_emails          = var.worklytics_sa_emails
-  connector_display_name_suffix = var.connector_display_name_suffix
-  psoxy_base_dir                = var.psoxy_base_dir
-  force_bundle                  = var.force_bundle
-  gcp_region                    = var.gcp_region
-  replica_regions               = var.replica_regions
-  enabled_connectors            = var.enabled_connectors
-  non_production_connectors     = var.non_production_connectors
-  custom_bulk_connectors        = var.custom_bulk_connectors
-  google_workspace_example_user = var.google_workspace_example_user
-  general_environment_variables = var.general_environment_variables
+  gcp_project_id                 = data.google_project.psoxy-project.project_id
+  environment_name               = var.environment_name
+  worklytics_sa_emails           = var.worklytics_sa_emails
+  connector_display_name_suffix  = var.connector_display_name_suffix
+  psoxy_base_dir                 = var.psoxy_base_dir
+  force_bundle                   = var.force_bundle
+  gcp_region                     = var.gcp_region
+  replica_regions                = var.replica_regions
+  enabled_connectors             = var.enabled_connectors
+  non_production_connectors      = var.non_production_connectors
+  custom_bulk_connectors         = var.custom_bulk_connectors
+  google_workspace_example_user  = var.google_workspace_example_user
+  google_workspace_example_admin = var.google_workspace_example_admin
+  general_environment_variables  = var.general_environment_variables
 }
 
 moved {

--- a/infra/examples-dev/gcp-google-workspace/terraform.tfvars.example
+++ b/infra/examples-dev/gcp-google-workspace/terraform.tfvars.example
@@ -1,8 +1,9 @@
-gcp_project_id                = "psoxy-acme-example"
-gcp_org_id                    = "123123123123"
-gcp_folder_id                 = "123123123123"
-gcp_billing_account_id        = "123456-ABCDEFG-ABCDEFG"
-google_workspace_example_user = "example@acme.com"
+gcp_project_id                 = "psoxy-acme-example"
+gcp_org_id                     = "123123123123"
+gcp_folder_id                  = "123123123123"
+gcp_billing_account_id         = "123456-ABCDEFG-ABCDEFG"
+google_workspace_example_user  = "example@acme.com"
+google_workspace_example_admin = "admin@acme.com"
 # gcp_region                    = "us-central1"
 # replica regions = ["us-central1", "us-east1", "us-west1"]
 force_bundle                  = true # if making changes to Java code w/o changing version number, set to true

--- a/infra/examples-dev/gcp-google-workspace/variables.tf
+++ b/infra/examples-dev/gcp-google-workspace/variables.tf
@@ -53,7 +53,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
   default     = false
 }
@@ -120,7 +120,7 @@ variable "custom_bulk_connectors" {
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
     })
-    settings_to_provide     = optional(map(string), {})
+    settings_to_provide = optional(map(string), {})
   }))
   description = "specs of custom bulk connectors to create"
 

--- a/infra/examples-dev/gcp-google-workspace/variables.tf
+++ b/infra/examples-dev/gcp-google-workspace/variables.tf
@@ -70,6 +70,12 @@ variable "google_workspace_example_user" {
   description = "User to impersonate for Google Workspace API calls (null for none)"
 }
 
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}
+
 variable "gcp_region" {
   type        = string
   description = "Region in which to provision GCP resources, if applicable"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -72,6 +72,7 @@ module "psoxy-aws-google-workspace" {
   lookup_table_builders          = var.lookup_table_builders
   gcp_project_id                 = data.google_project.psoxy-google-connectors.project_id
   google_workspace_example_user  = var.google_workspace_example_user
+  google_workspace_example_admin = var.google_workspace_example_admin
   general_environment_variables  = var.general_environment_variables
 }
 

--- a/infra/examples/aws-google-workspace/terraform.tfvars.example
+++ b/infra/examples/aws-google-workspace/terraform.tfvars.example
@@ -1,7 +1,8 @@
-aws_account_id                = "123123123123" # your AWS account ID here
-aws_assume_role_arn           = "arn:aws:iam::123123123123:role/InfraAdmin" # role in that AWS account ID to assume
-gcp_project_id                = "psoxy-acme-example"
-google_workspace_example_user = "example@acme.com"
+aws_account_id                 = "123123123123" # your AWS account ID here
+aws_assume_role_arn            = "arn:aws:iam::123123123123:role/InfraAdmin" # role in that AWS account ID to assume
+gcp_project_id                 = "psoxy-acme-example"
+google_workspace_example_user  = "example@acme.com"
+google_workspace_example_admin = "admin@acme.com"
 # force_bundle                  = false # if making changes to Java code w/o changing version number, set to true
 enabled_connectors = [
   "asana",

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -28,7 +28,7 @@ variable "psoxy_base_dir" {
   }
 }
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
   default     = false
 }
@@ -112,7 +112,7 @@ variable "custom_bulk_connectors" {
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
     })
-    settings_to_provide     = optional(map(string), {})
+    settings_to_provide = optional(map(string), {})
   }))
   description = "specs of custom bulk connectors to create"
 

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -197,3 +197,9 @@ variable "google_workspace_example_user" {
   type        = string
   description = "user to impersonate for Google Workspace API calls (null for none)"
 }
+
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -71,7 +71,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
   default     = false
 }
@@ -120,7 +120,7 @@ variable "custom_bulk_connectors" {
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
     })
-    settings_to_provide     = optional(map(string), {})
+    settings_to_provide = optional(map(string), {})
   }))
   description = "specs of custom bulk connectors to create"
 

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -32,17 +32,18 @@ module "psoxy-gcp-google-workspace" {
   # source = "../../modular-examples/gcp-google-workspace"
   source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp-google-workspace?ref=v0.4.9"
 
-  gcp_project_id                = data.google_project.project_id
-  environment_name              = var.environment_name
-  worklytics_sa_emails          = var.worklytics_sa_emails
-  connector_display_name_suffix = var.connector_display_name_suffix
-  psoxy_base_dir                = var.psoxy_base_dir
-  force_bundle                  = var.force_bundle
-  gcp_region                    = var.gcp_region
-  replica_regions               = var.replica_regions
-  enabled_connectors            = var.enabled_connectors
-  non_production_connectors     = var.non_production_connectors
-  custom_bulk_connectors        = var.custom_bulk_connectors
-  google_workspace_example_user = var.google_workspace_example_user
-  general_environment_variables = var.general_environment_variables
+  gcp_project_id                 = data.google_project.project_id
+  environment_name               = var.environment_name
+  worklytics_sa_emails           = var.worklytics_sa_emails
+  connector_display_name_suffix  = var.connector_display_name_suffix
+  psoxy_base_dir                 = var.psoxy_base_dir
+  force_bundle                   = var.force_bundle
+  gcp_region                     = var.gcp_region
+  replica_regions                = var.replica_regions
+  enabled_connectors             = var.enabled_connectors
+  non_production_connectors      = var.non_production_connectors
+  custom_bulk_connectors         = var.custom_bulk_connectors
+  google_workspace_example_user  = var.google_workspace_example_user
+  google_workspace_example_admin = var.google_workspace_example_admin
+  general_environment_variables  = var.general_environment_variables
 }

--- a/infra/examples/gcp-google-workspace/terraform.tfvars.example
+++ b/infra/examples/gcp-google-workspace/terraform.tfvars.example
@@ -1,5 +1,6 @@
-gcp_project_id                = "psoxy-acme-example"
-google_workspace_example_user = "example@acme.com"
+gcp_project_id                 = "psoxy-acme-example"
+google_workspace_example_user  = "example@acme.com"
+google_workspace_example_admin = "admin@acme.com"
 # gcp_region                    = "us-central1"
 # replica regions = ["us-central1", "us-east1", "us-west1"]
 # force_bundle                  = false # if making changes to Java code w/o changing version number, set to true

--- a/infra/examples/gcp-google-workspace/variables.tf
+++ b/infra/examples/gcp-google-workspace/variables.tf
@@ -69,6 +69,12 @@ variable "google_workspace_example_user" {
   description = "User to impersonate for Google Workspace API calls (null for none)"
 }
 
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}
+
 variable "gcp_region" {
   type        = string
   description = "Region in which to provision GCP resources, if applicable"

--- a/infra/examples/gcp-google-workspace/variables.tf
+++ b/infra/examples/gcp-google-workspace/variables.tf
@@ -53,7 +53,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists for this proxy version"
   default     = false
 }
@@ -119,7 +119,7 @@ variable "custom_bulk_connectors" {
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
     })
-    settings_to_provide     = optional(map(string), {})
+    settings_to_provide = optional(map(string), {})
   }))
   description = "specs of custom bulk connectors to create"
 

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -21,8 +21,9 @@ module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.9
 
-  enabled_connectors            = var.enabled_connectors
-  google_workspace_example_user = var.google_workspace_example_user
+  enabled_connectors             = var.enabled_connectors
+  google_workspace_example_user  = var.google_workspace_example_user
+  google_workspace_example_admin = coalesce(var.google_workspace_example_admin, var.google_workspace_example_user)
 }
 
 module "psoxy-aws" {

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -248,7 +248,7 @@ module "worklytics-psoxy-connection" {
 
 module "psoxy-bulk" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors,
-                   var.custom_bulk_connectors)
+  var.custom_bulk_connectors)
 
   source = "../../modules/aws-psoxy-bulk"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.9"
@@ -279,7 +279,7 @@ module "psoxy-bulk" {
 
 module "psoxy-bulk-to-worklytics" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors,
-                   var.custom_bulk_connectors)
+  var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
 
@@ -321,9 +321,9 @@ module "psoxy_lookup_tables_builders" {
 
 locals {
   all_instances = merge(
-    { for instance in module.psoxy-google-workspace-connector : instance.instance_id => instance},
-    { for instance in module.psoxy-bulk : instance.instance_id => instance},
-    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance}
+    { for instance in module.psoxy-google-workspace-connector : instance.instance_id => instance },
+    { for instance in module.psoxy-bulk : instance.instance_id => instance },
+    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance }
   )
 }
 

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -323,7 +323,8 @@ locals {
   all_instances = merge(
     { for instance in module.psoxy-google-workspace-connector : instance.instance_id => instance },
     { for instance in module.psoxy-bulk : instance.instance_id => instance },
-    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance }
+    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance },
+    { for instance in module.psoxy_lookup_tables_builders : instance.instance_id => instance }
   )
 }
 

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -181,3 +181,9 @@ variable "google_workspace_example_user" {
   type        = string
   description = "user to impersonate for Google Workspace API calls (null for none)"
 }
+
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -72,7 +72,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists"
   default     = false
 }

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -260,7 +260,7 @@ module "worklytics-psoxy-connection-oauth-long-access" {
 
 module "psoxy-bulk" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors,
-                   var.custom_bulk_connectors)
+  var.custom_bulk_connectors)
 
   source = "../../modules/aws-psoxy-bulk"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.9"
@@ -295,7 +295,7 @@ module "psoxy-bulk" {
 
 module "psoxy-bulk-to-worklytics" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors,
-                   var.custom_bulk_connectors)
+  var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
 
@@ -343,9 +343,9 @@ output "lookup_tables" {
 
 locals {
   all_instances = merge(
-    { for instance in module.psoxy-msft-connector : instance.instance_id => instance},
-    { for instance in module.psoxy-bulk : instance.instance_id => instance},
-    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance}
+    { for instance in module.psoxy-msft-connector : instance.instance_id => instance },
+    { for instance in module.psoxy-bulk : instance.instance_id => instance },
+    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance }
   )
 }
 

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -345,7 +345,8 @@ locals {
   all_instances = merge(
     { for instance in module.psoxy-msft-connector : instance.instance_id => instance },
     { for instance in module.psoxy-bulk : instance.instance_id => instance },
-    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance }
+    { for instance in module.aws-psoxy-long-auth-connectors : instance.instance_id => instance },
+    { for instance in module.psoxy_lookup_tables_builders : instance.instance_id => instance }
   )
 }
 

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -55,7 +55,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists"
   default     = false
 }

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -247,7 +247,7 @@ module "worklytics-psoxy-connection-long-auth" {
 # BEGIN BULK CONNECTORS
 module "psoxy-gcp-bulk" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors,
-                   var.custom_bulk_connectors)
+  var.custom_bulk_connectors)
 
   source = "../../modules/gcp-psoxy-bulk"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.9"
@@ -275,7 +275,7 @@ module "psoxy-gcp-bulk" {
 
 module "psoxy-bulk-to-worklytics" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors,
-                   var.custom_bulk_connectors)
+  var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=v0.4.9"

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -14,8 +14,9 @@ module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.9"
 
-  enabled_connectors            = var.enabled_connectors
-  google_workspace_example_user = var.google_workspace_example_user
+  enabled_connectors             = var.enabled_connectors
+  google_workspace_example_user  = var.google_workspace_example_user
+  google_workspace_example_admin = coalesce(var.google_workspace_example_admin, var.google_workspace_example_user)
 }
 
 module "psoxy-gcp" {

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -288,3 +288,15 @@ module "psoxy-bulk-to-worklytics" {
     "Bucket Name" = module.psoxy-gcp-bulk[each.key].sanitized_bucket
   }, try(each.value.settings_to_provide, {}))
 }
+
+locals {
+  all_instances = merge(
+    { for instance in module.psoxy-google-workspace-connector : instance.instance_id => instance },
+    { for instance in module.psoxy-gcp-bulk : instance.instance_id => instance },
+    { for instance in module.connector-long-auth-function : instance.instance_id => instance }
+  )
+}
+
+output "instances" {
+  value = ""
+}

--- a/infra/modular-examples/gcp-google-workspace/variables.tf
+++ b/infra/modular-examples/gcp-google-workspace/variables.tf
@@ -35,7 +35,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists"
   default     = false
 }
@@ -87,7 +87,7 @@ variable "non_production_connectors" {
 
 variable "custom_bulk_connectors" {
   type = map(object({
-    source_kind         = string
+    source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
       columnsToRedact       = optional(list(string), [])

--- a/infra/modular-examples/gcp-google-workspace/variables.tf
+++ b/infra/modular-examples/gcp-google-workspace/variables.tf
@@ -118,3 +118,9 @@ variable "google_workspace_example_user" {
   type        = string
   description = "User to impersonate for Google Workspace API calls (null for none)"
 }
+
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}

--- a/infra/modules/aws-ssm-secrets/main.tf
+++ b/infra/modules/aws-ssm-secrets/main.tf
@@ -14,7 +14,7 @@ resource "aws_ssm_parameter" "secret" {
   lifecycle {
     ignore_changes = [
       # value, # previously, we ignored changes to value; but this doesn't actually prevent new
-               # value from being in your state file - so little point.
+      # value from being in your state file - so little point.
       tags
     ]
   }

--- a/infra/modules/aws-vault-access/main.tf
+++ b/infra/modules/aws-vault-access/main.tf
@@ -9,7 +9,7 @@ resource "vault_aws_auth_backend_role" "example" {
   resolve_aws_unique_ids   = false
   token_ttl                = 3600      # in seconds; so this is one hour
   token_max_ttl            = 24 * 3600 # in seconds; so this is one day
-  token_policies           = [
+  token_policies = [
     var.vault_policy_name
   ]
 }

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -20,7 +20,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists"
   default     = false
 }

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -140,10 +140,18 @@ resource "google_cloudfunctions_function" "function" {
   ]
 }
 
-output "next_todo_step" {
-  value = var.todo_step + 1
+output "instance_id" {
+  value = local.function_name
+}
+
+output "input_bucket" {
+  value = google_storage_bucket.input-bucket.name
 }
 
 output "sanitized_bucket" {
   value = google_storage_bucket.output-bucket.name
+}
+
+output "next_todo_step" {
+  value = var.todo_step + 1
 }

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -123,6 +123,14 @@ Contact support@worklytics.co for assistance modifying the rules as needed.
 EOT
 }
 
+output "instance_id" {
+  value = var.instance_id
+}
+
+output "cloud_function_name" {
+  value = google_cloudfunctions_function.function.name
+}
+
 
 output "cloud_function_url" {
   value = local.proxy_endpoint_url

--- a/infra/modules/gcp/variables.tf
+++ b/infra/modules/gcp/variables.tf
@@ -21,7 +21,7 @@ variable "psoxy_base_dir" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists"
   default     = false
 }

--- a/infra/modules/psoxy-package/variables.tf
+++ b/infra/modules/psoxy-package/variables.tf
@@ -17,7 +17,7 @@ variable "psoxy_version" {
 }
 
 variable "force_bundle" {
-  type        =  bool
+  type        = bool
   description = "whether to force build of deployment bundle, even if it already exists"
   default     = false
 }

--- a/infra/modules/vault-access-token/main.tf
+++ b/infra/modules/vault-access-token/main.tf
@@ -10,28 +10,28 @@
 # see : https://developer.hashicorp.com/vault/tutorials/tokens/tokens#periodic-service-tokens
 
 resource "vault_token_auth_backend_role" "lambda_role" {
-  role_name              = var.instance_id
-  allowed_policies       = [var.vault_policy_name]
-  orphan                 = true
-  token_period           = 14*24*60*60 # 2 weeks
-  renewable              = true
+  role_name        = var.instance_id
+  allowed_policies = [var.vault_policy_name]
+  orphan           = true
+  token_period     = 14 * 24 * 60 * 60 # 2 weeks
+  renewable        = true
 
   # no explicit_max_ttl, so should be a 'periodic' token
 
 }
 
 resource "vault_token" "periodic_service_token" {
-  role_name        = vault_token_auth_backend_role.lambda_role.role_name # name to give token's role in Vault
-  period           = "${14*24}h" # 2 weeks
-  renewable        = true
-  renew_min_lease  = 8*24*60*60  # 8 days
-  renew_increment  = 14*24*60*60 # 2 weeks
-  policies         = [var.vault_policy_name]
+  role_name       = vault_token_auth_backend_role.lambda_role.role_name # name to give token's role in Vault
+  period          = "${14 * 24}h"                                       # 2 weeks
+  renewable       = true
+  renew_min_lease = 8 * 24 * 60 * 60  # 8 days
+  renew_increment = 14 * 24 * 60 * 60 # 2 weeks
+  policies        = [var.vault_policy_name]
   # no explicit_max_ttl, so should be a 'periodic' token
 }
 
 
 # actual vault token to output, so can be passed as env var to proxy instance
 output "vault_token" {
-  value     = vault_token.periodic_service_token.client_token
+  value = vault_token.periodic_service_token.client_token
 }

--- a/infra/modules/vault-psoxy/main.tf
+++ b/infra/modules/vault-psoxy/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 resource "vault_policy" "psoxy_instance" {
-  name   = var.instance_id
+  name = var.instance_id
 
   # TODO: as of 4 Jan 2023, secret/* case needed here; please scope better for your prod use!!
   policy = <<EOT

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -28,7 +28,7 @@ locals {
         "/admin/directory/v1/customer/my_customer/roles?maxResults=10",
         "/admin/directory/v1/customer/my_customer/roleassignments?maxResults=10"
       ]
-      example_api_calls_user_to_impersonate : var.google_workspace_example_user
+      example_api_calls_user_to_impersonate : var.google_workspace_example_admin
     },
     "gcal" : {
       source_kind : "gcal",

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -9,6 +9,12 @@ variable "google_workspace_example_user" {
   default     = null
 }
 
+variable "google_workspace_example_admin" {
+  type        = string
+  description = "user to impersonate for Google Workspace API calls (null for value of `google_workspace_example_user`)"
+  default     = null # will failover to user
+}
+
 variable "msft_tenant_id" {
   type        = string
   default     = ""


### PR DESCRIPTION
### Features
 - pass distinct Google Workspace Admin v Google Workspace User, as latter may be needed for GDirectory APIs, but latter may be better examples for actual work data APIS (gcal, gmail, etc) - esp in usual case where customer wants an "Service Account" user for the directory APIs
 - output more values, more consistently from our tf modules/examples, to let customers extend more: get the functions to put in VPC/etc, output buckets for chaining/monitoring, etc. 

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203696578378056