### PR TITLE
more defensive header handling

### DIFF
--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
@@ -10,7 +10,9 @@ import lombok.extern.java.Log;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Adapter for the APIGatewayV2HTTPEvent to the interface the {@link co.worklytics.psoxy.gateway.impl.CommonRequestHandler}
@@ -26,6 +28,8 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
     @NonNull
     final APIGatewayV2HTTPEvent event;
 
+    private Map<String, String> caseInsensitiveHeaders;
+
     @Override
     public String getPath() {
         return StringUtils.prependIfMissing(event.getRawPath(), "/");
@@ -37,13 +41,13 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
     }
 
     @Override
-    public Optional<String> getHeader(String headerName) {
+    public Optional<String> getHeader(@NonNull String headerName) {
         // Seems APIGatewayV2HTTPEvent has the headers lower-case
-        return Optional.ofNullable(event.getHeaders().get(headerName.toLowerCase()));
+        return Optional.ofNullable(getCaseInsensitiveHeaders().get(headerName.toLowerCase()));
     }
 
     @Override
-    public Optional<List<String>> getMultiValueHeader(String headerName) {
+    public Optional<List<String>> getMultiValueHeader(@NonNull String headerName) {
         return getHeader(headerName.toLowerCase()).map(s -> Splitter.on(',').splitToList(s));
     }
 
@@ -61,5 +65,30 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
     @Override
     public String prettyPrint() {
         return event.toString();
+    }
+
+    /**
+     * @return view of Headers with lower-case names
+     *
+     * this is kinda defensive; while AWS seems to pass headers in lower-case, GCP does not. (or
+     * at least docs, and prior practice, suggest they do not). But really we probably want to
+     * presume case-insensitivity, giving clients leeway in how they send headers.
+     *
+     * additionally, we don't want to couple ourselves to (undocumented?) AWS behavior. and we have
+     * both customer implementations directly exposing lambdas via URLs as well as putting behind an
+     * API Gateway; and potentially people could put these behind API Gateway V1 or V2, as well as
+     * define their own API gateway request mappings ... so we want to be as flexible as possible
+     * rather than presume that headers get converted to lower case through all these potential
+     * logical paths.
+     */
+    private Map<String, String> getCaseInsensitiveHeaders() {
+        if (caseInsensitiveHeaders == null) {
+            caseInsensitiveHeaders = event.getHeaders().entrySet().stream()
+                .collect(Collectors.toMap(
+                    entry -> entry.getKey().toLowerCase(),
+                    Map.Entry::getValue
+                ));
+        }
+        return caseInsensitiveHeaders;
     }
 }

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
@@ -3,8 +3,11 @@ package co.worklytics.psoxy.aws.request;
 import co.worklytics.test.TestUtils;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,6 +32,24 @@ class APIGatewayV2HTTPEventRequestAdapterTest {
 
         assertTrue(requestAdapter.getMultiValueHeader("multi-header").isPresent());
         assertEquals("value1,value2", String.join(",", requestAdapter.getMultiValueHeader("multi-header").get()));
+    }
+
+    @Test
+    public void getHeader() {
+        APIGatewayV2HTTPEvent apiGatewayV2HTTPEvent = new APIGatewayV2HTTPEvent();
+        apiGatewayV2HTTPEvent.setHeaders(Map.of(
+            "foo", "bar",
+            "UC-Foo", "barUC"
+        ));
+
+        APIGatewayV2HTTPEventRequestAdapter request = new APIGatewayV2HTTPEventRequestAdapter(apiGatewayV2HTTPEvent);
+        assertEquals("bar", request.getHeader("foo").get());
+        assertEquals("bar", request.getHeader("Foo").get());
+        assertEquals("bar", request.getHeader("FOO").get());
+        assertEquals("barUC", request.getHeader("UC-Foo").get());
+        assertEquals("barUC", request.getHeader("uc-foo").get());
+        assertEquals("barUC", request.getHeader("UC-FOO").get());
+        assertTrue(request.getHeader("not-there").isEmpty());
     }
 
 }

--- a/java/impl/gcp/src/test/java/co/worklytics/psoxy/CloudFunctionRequestTest.java
+++ b/java/impl/gcp/src/test/java/co/worklytics/psoxy/CloudFunctionRequestTest.java
@@ -1,0 +1,35 @@
+package co.worklytics.psoxy;
+
+import com.google.cloud.functions.HttpRequest;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CloudFunctionRequestTest {
+
+    @Test
+    void getHeader() {
+        HttpRequest nativeRequest = mock(HttpRequest.class);
+
+        when(nativeRequest.getHeaders()).thenReturn(Map.of(
+            "foo", Lists.newArrayList("bar"),
+            "UC-Foo", Lists.newArrayList("barUC")
+        ));
+
+        CloudFunctionRequest request = CloudFunctionRequest.of(nativeRequest);
+
+        assertEquals("bar", request.getHeader("foo").get());
+        assertEquals("bar", request.getHeader("Foo").get());
+        assertEquals("bar", request.getHeader("FOO").get());
+        assertEquals("barUC", request.getHeader("UC-Foo").get());
+        assertEquals("barUC", request.getHeader("uc-foo").get());
+        assertEquals("barUC", request.getHeader("UC-FOO").get());
+        assertTrue(request.getHeader("not-there").isEmpty());
+    }
+
+}


### PR DESCRIPTION
### Fixes
 - avoid possibility that header names don't reach Java logic with expected casing


### Change implications

 - dependencies added/changed? **no**
