### PR TITLE
S142: Remove invalid underscore on path

### DIFF
--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GcpModule.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GcpModule.java
@@ -4,7 +4,9 @@ package co.worklytics.psoxy;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.HostEnvironment;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
-import co.worklytics.psoxy.gateway.impl.*;
+import co.worklytics.psoxy.gateway.impl.CompositeConfigService;
+import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
+import co.worklytics.psoxy.gateway.impl.VaultConfigService;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
 import com.bettercloud.vault.Vault;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -54,7 +56,7 @@ public interface GcpModule {
 
         String pathToInstanceConfig =
             envVarsConfigService.getConfigPropertyAsOptional(ProxyConfigProperty.PATH_TO_INSTANCE_CONFIG)
-                .orElseGet(() -> asSecretManagerNamespace(hostEnvironment.getInstanceId()) + "_");
+                .orElseGet(() -> asSecretManagerNamespace(hostEnvironment.getInstanceId()));
 
         return CompositeConfigService.builder()
                 .preferred(new SecretManagerConfigService(pathToInstanceConfig, ServiceOptions.getDefaultProjectId()))

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/SecretManagerConfigService.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/SecretManagerConfigService.java
@@ -61,14 +61,6 @@ public class SecretManagerConfigService implements ConfigService {
                 .orElseThrow(() -> new NoSuchElementException("Proxy misconfigured; no value for " + property));
     }
 
-    private String parameterName(ConfigProperty property) {
-        if (StringUtils.isBlank(this.namespace)) {
-            return property.name();
-        } else {
-            return String.join("_", this.namespace, property.name());
-        }
-    }
-
     @SneakyThrows
     @Override
     public Optional<String> getConfigPropertyAsOptional(ConfigProperty property) {
@@ -83,6 +75,14 @@ public class SecretManagerConfigService implements ConfigService {
         } catch (Exception ignored) {
             // If secret is not found, it will return an exception
             return Optional.empty();
+        }
+    }
+
+    private String parameterName(ConfigProperty property) {
+        if (StringUtils.isBlank(this.namespace)) {
+            return property.name();
+        } else {
+            return String.join("_", this.namespace, property.name());
         }
     }
 }


### PR DESCRIPTION
An invalid underscore was generating invalid paths when looking for settings (ex: *MY_FUNCTION__TOKEN* instead of *MY_FUNCTION_TOKEN*)

### Fixes
[Cloud functions secret](https://app.asana.com/0/1203887186711888/1203950796624032)

### Change implications

 - dependencies added/changed? **no**
