### PR TITLE
S142 fix health check

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
@@ -38,15 +38,15 @@ public class HealthCheckRequestHandler {
     @Inject
     ObjectMapper objectMapper;
 
-    private boolean isHealthCheckRequest(HttpEventRequest request) {
-        return request.getHeader(ControlHeader.HEALTH_CHECK.getHttpHeader()).isPresent();
-    }
-
     public Optional<HttpEventResponse> handleIfHealthCheck(HttpEventRequest request) {
         if (isHealthCheckRequest(request)) {
             return Optional.of(handle());
         }
         return Optional.empty();
+    }
+
+    private boolean isHealthCheckRequest(HttpEventRequest request) {
+        return request.getHeader(ControlHeader.HEALTH_CHECK.getHttpHeader()).isPresent();
     }
 
     private HttpEventResponse handle() {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
@@ -83,9 +83,10 @@ public class HealthCheckRequestHandler {
         HttpEventResponse.HttpEventResponseBuilder responseBuilder = HttpEventResponse.builder();
 
         try {
-            responseBuilder.statusCode(responseStatusCode(healthCheckResult.build()));
+            HealthCheckResult result = healthCheckResult.build();
+            responseBuilder.statusCode(responseStatusCode(result));
             responseBuilder.header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8).getMimeType());
-            responseBuilder.body(objectMapper.writeValueAsString(healthCheckResult) + "\r\n");
+            responseBuilder.body(objectMapper.writeValueAsString(result) + "\r\n");
         } catch (IOException e) {
             log.log(Level.WARNING, "Failed to write health check details", e);
         }

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandlerTest.java
@@ -1,0 +1,63 @@
+package co.worklytics.psoxy.gateway.impl;
+
+import co.worklytics.psoxy.ControlHeader;
+import co.worklytics.psoxy.PsoxyModule;
+import co.worklytics.psoxy.gateway.HttpEventRequest;
+import co.worklytics.psoxy.gateway.HttpEventResponse;
+import co.worklytics.psoxy.gateway.ProxyConfigProperty;
+import co.worklytics.test.MockModules;
+import dagger.Component;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HealthCheckRequestHandlerTest {
+    @Singleton
+    @Component(modules = {
+            PsoxyModule.class,
+            MockModules.ForConfigService.class,
+            MockModules.ForRules.class,
+            MockModules.ForSourceAuthStrategySet.class,
+    })
+    public interface Container {
+        void inject(HealthCheckRequestHandlerTest test);
+    }
+
+    @BeforeEach
+    public void setup() {
+        HealthCheckRequestHandlerTest.Container container = DaggerHealthCheckRequestHandlerTest_Container.create();
+        container.inject(this);
+
+        when(handler.config.getConfigPropertyAsOptional(eq(ProxyConfigProperty.PSOXY_SALT)))
+                .thenReturn(Optional.of("salt"));
+
+        when(handler.config.getConfigPropertyAsOptional(ProxyConfigProperty.SOURCE))
+                .thenReturn(Optional.of("something"));
+    }
+
+    @Inject
+    HealthCheckRequestHandler handler;
+
+    @Test
+    void handleIfHealthCheck_should_serialize_response() {
+        HttpEventRequest request = mock(HttpEventRequest.class);
+
+        when(request.getHeader(ControlHeader.HEALTH_CHECK.getHttpHeader()))
+                .thenReturn(Optional.of(""));
+
+        Optional<HttpEventResponse> response = handler.handleIfHealthCheck(request);
+
+        assertTrue(response.isPresent());
+
+        assertEquals(200, response.get().getStatusCode());
+    }
+}


### PR DESCRIPTION
Builder was being used instead of Healthcheck response for serialized; causing a 500 as that cannot be serialized

### Fixes
[Psoxy: HealthCheck cannot be serialized](https://app.asana.com/0/1203887186711888/1203975383868152)

### Change implications

 - dependencies added/changed? **no**
