### PR TITLE
fix msft 365 example

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -10,12 +10,17 @@ Please review the `README.md` within each provider's module for pre-reqs and usa
 
   - `examples/` - example configurations to be adapted by customers
   - `examples-dev/` - example configurations to be adapted by developers
-  - `modules/` - modules to be re-used primarily by other modules or if customers need very custom configurations
+  - `modules/` - modules to be re-used primarily by other modules or if customers need very custom
+     configurations. We do NOT commit to maintaining backwards compatibility of these modules
+     interfaces between minor or patch versions. (eg, `0.4.z` variants may break things)
   - `modules-examples/` - psoxy configurations that have been 'modularized', to enable use by
     customers via a minimal root configuration (see `examples/`) OR as part of their larger
     Terraform configuration (presumably covering infra beyond psoxy). If you need more control than
     what variables of these  modules expose, you can copy one of these modules, use it as a root
-    terraform configuration, and directly modify how it invokes modules.
+    terraform configuration, and directly modify how it invokes modules.  We DO commit to maintaining
+    the interfaces of these modules between minor patch versions (eg, `0.4.z` variants should not
+    break).
+
 
 ## Per Connector Setup
 

--- a/infra/examples/msft-365/main.tf
+++ b/infra/examples/msft-365/main.tf
@@ -61,18 +61,18 @@ module "msft-connection" {
 }
 
 
-# if you don't want Terraform to generate certificate for you on your local machine, comment this
-# out
-module "msft-connection-auth" {
+module "msft-connection-auth-federation" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
-  # source = "../../modules/azuread-local-cert"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-local-cert?ref=v0.4.11"
+  # source = "../../modules/azuread-federated-credentials"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=v0.4.11"
 
   application_object_id = module.msft-connection[each.key].connector.id
-  rotation_days         = 60
-  cert_expiration_days  = 180
-  certificate_subject   = var.certificate_subject
+  display_name          = "AccessFromAWS"
+  description           = "AWS federation to be used for psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
+  issuer                = "https://cognito-identity.amazonaws.com"
+  audience              = var.cognito_pool_id
+  subject               = var.cognito_connector_identities[each.key]
 }
 
 

--- a/infra/examples/msft-365/variables.tf
+++ b/infra/examples/msft-365/variables.tf
@@ -85,3 +85,15 @@ variable "enabled_connectors" {
     "zoom",
   ]
 }
+
+# see infra/modules/aws-cognito-pool
+variable "cognito_pool_id" {
+  type        = string
+  description = "id of cognito pool to use for identity management (eg, cognito-identity-pool.pool_id from an aws_cognito_identity_pool resource)."
+}
+
+# see infra/modules/aws-cognito-identity-cli
+variable "cognito_connector_identities" {
+  type        = map(string)
+  description = "map of connector ids to cognito identity ids (eg, IdentityId from running `aws cognito-identity get-open-id-token-for-developer-identity ` for given login)."
+}

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -394,6 +394,10 @@ output "instances" {
   value = local.all_instances
 }
 
-output "cognito-identities" {
+output "cognito_identities" {
   value = module.cognito-identity
+}
+
+output "cognito_identity_pool_id" {
+  value = module.cognito-identity-pool.pool_id
 }

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -91,7 +91,7 @@ module "cognito-identity" {
 
   identity_pool_id = module.cognito-identity-pool.pool_id
   aws_region       = var.aws_region
-  login-ids        = { for k in keys(module.msft-connection) : k => "${module.cognito-identity-pool.developer_provider_name}=${module.msft-connection[k].connector.application_id}" }
+  login_ids        = { for k in keys(module.msft-connection) : k => "${module.cognito-identity-pool.developer_provider_name}=${module.msft-connection[k].connector.application_id}" }
   aws_role         = var.aws_assume_role_arn
 }
 

--- a/infra/modules/aws-cognito-identity-cli/main.tf
+++ b/infra/modules/aws-cognito-identity-cli/main.tf
@@ -1,5 +1,5 @@
 data "external" "identity-result" {
-  for_each = var.login-ids
+  for_each = var.login_ids
 
   program = [
     "${path.module}/addIdentity.sh",
@@ -12,5 +12,5 @@ data "external" "identity-result" {
 }
 
 output "identity_id" {
-  value = { for k, v in var.login-ids : k => data.external.identity-result[k].result.IdentityId }
+  value = { for k, v in var.login_ids : k => data.external.identity-result[k].result.IdentityId }
 }

--- a/infra/modules/aws-cognito-identity-cli/variables.tf
+++ b/infra/modules/aws-cognito-identity-cli/variables.tf
@@ -13,6 +13,9 @@ variable "aws_role" {
   description = "Role to assume during script execution"
 }
 
-variable "login-ids" {
+# TODO: expect value format "${module.cognito-identity-pool.developer_provider_name}=${module.msft-connection[k].connector.application_id}"
+# --> add validation of that OR split those components in properties of an object??
+variable "login_ids" {
   type = map(string)
+  description = "Map of connector id => login id for which to create identities in pool"
 }

--- a/infra/modules/azuread-local-cert/README.md
+++ b/infra/modules/azuread-local-cert/README.md
@@ -1,0 +1,92 @@
+# Azure AD Local Certificate **deprecated**
+
+**DEPRECATED** - will be removed in v0.5; this is not recommended approach, for a variety of
+reasons, since Microsoft release support for federated credentials in ~Sept 202. See our module
+`azuread-federated-credentials` for preferred alternative.
+
+Module to generate a certificate locally, using `openssl`, and push it to target Azure AD application.
+
+Prereqs:
+  - auth'd in Azure CLI as user who can update certificate on Azure AD enterprise application listing
+  - `openssl` We have not documented exact version required, so YMMV.
+  - [`jq`](https://stedolan.github.io/jq/)
+
+NOTE:
+  - the key used for the certificate WILL be stored by Terraform in your local state. You should
+    1) run this from a secure location, 2) store your Terraform state securely
+  - this will regenerate certificates on every run. In simple scenarios, this is probably desirable,
+    but may be a nuisance if it's part of a large Terraform configuration.
+
+
+## Non-Terraform Alternative
+
+
+If security risks of managing a certificate with Terraform are not acceptable, we suggest:
+  1. generate the certificate(s) outside of terraform by invoking `local-cert.sh` script directly
+  2. pass the `fingerprint` value(s) from the resulting JSON as a variable to your Terraform
+     configuration, so that the "private key id" SSM param can be correctly populated
+  3. take the `key` value(s) from the resulting JSON, and directly set the value of the SSM parameter
+     via AWS console or the cli.  This could be done by a user with write-only permission to the
+     parameter.
+
+Prereqs:
+  - `openssl` We have not documented exact version required, so YMMV.
+  - [`jq`](https://stedolan.github.io/jq/)
+
+Example:
+```shell
+
+# change the subject to something more appropriate for your organization; use TTL in days that you like
+./local-cert.sh "/C=US/ST=New York/L=New York/CN=www.worklytics.co" 180 > cert.json
+
+cat cert.json | jq -r .fingerprint
+
+# take the hex value, without the ':' characters as the value to pass to your terraform config
+# (or directly fill relevant PRIVATE_KEY_ID value in secret manager of your target cloud)
+
+export KEY_PKCS8=`cat cert.json | jq -r .key_pkcs8 | base64 --decode`
+
+# gives you `KEY_PKCS8` env variable, which you could then use to fill secret in secret manager of your choice
+
+cat cert.json | jq -r .key | base64 --decode > cert.pem
+
+# gives you a certificate you can upload directly to Azure AD console
+# the value you see for 'Thumbprint' in the Azure AD console should MATCH the value you set for
+# Private Key ID in the secret manager of your target cloud
+
+
+# remember to clean up the files into which you just wrote your certificate/keys!!
+rm cert.pem
+rm cert.json
+```
+
+see:
+  - https://docs.aws.amazon.com/cli/latest/reference/ssm/put-parameter.html
+  - https://cloud.google.com/sdk/gcloud/reference/secrets/versions/add
+
+## Non-Terraform Alternative, No Shell Script
+
+Don't want to clone our whole repo, just to use our `local-cert.sh` script? Then you can use all of
+the following commands directly from your shell.
+
+Prereqs:
+  - `openssl` We have not documented exact version required, so YMMV.
+  - [`jq`](https://stedolan.github.io/jq/)
+
+```shell
+SUBJECT="/C=US/ST=New York/L=New York/CN=www.worklytics.co"
+openssl req -x509 -newkey rsa:2048 -subj $SUBJECT -keyout key.pem -out cert.pem -days 180 -nodes
+openssl pkcs8 -nocrypt -in key.pem -inform PEM -topk8 -outform PEM -out key_pkcs8.pem
+
+openssl x509 -in cert.pem -noout -fingerprint
+# take the hex value, without the ':' characters as the value to pass to your terraform config
+# (or directly fill relevant PRIVATE_KEY_ID value in secret manager of your target cloud)
+
+# 1. upload the cert.pem to the app in your Azure AD console (the value it then shows for 'Thumbprint' should match the value you set for Private Key ID in the secret manager of your target cloud)
+# 2. set the *content* of key_pkcs8.pem as the value of the secret for your proxy's private key
+
+# clean everything up!!
+rm key.pem
+rm cert.pem
+rm key_pkcs8.pem
+```

--- a/infra/modules/azuread-local-cert/local-cert.sh
+++ b/infra/modules/azuread-local-cert/local-cert.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# generate keys for MSFT connectors; adapted from Worklytics node script to do this, with output
+# formatted to be consumed by Terraform via `data "external" {}`
+# example usage: ./local-cert.sh "/C=US/ST=New York/L=New York/CN=www.worklytics.co" 30
+SUBJECT=$1
+TTL=$2
+
+# avoid conflict if building multiple connectors concurrently
+RAND_ID=`echo $RANDOM | md5 | head -c 20`
+KEY_FILE=key_${RAND_ID}.pem
+KEY_FILE_PKCS8=key_pkcs8_${RAND_ID}.pem
+CERT_FILE=cert_${RAND_ID}.pem
+
+# build generate key
+openssl req -x509 -newkey rsa:2048 -subj "${SUBJECT}" -keyout $KEY_FILE -out $CERT_FILE -days $TTL -nodes >/dev/null 2>&1
+openssl pkcs8 -nocrypt -in $KEY_FILE  -inform PEM -topk8 -outform PEM -out $KEY_FILE_PKCS8 >/dev/null 2>&1
+
+#CERT_DER=`openssl x509 -in $CERT_FILE -outform DER | base64`
+FINGERPRINT_RESULT=`openssl x509 -in $CERT_FILE -noout -fingerprint -sha1`
+# output as JSON
+OUTPUT_JSON="{\"cert\": \"`cat $CERT_FILE | base64`\",\"key_pkcs8\": \"`cat $KEY_FILE_PKCS8 | base64`\",\"fingerprint\":\"${FINGERPRINT_RESULT}\"}"
+echo "$OUTPUT_JSON"
+
+# cleanup
+rm $CERT_FILE
+rm $KEY_FILE
+rm $KEY_FILE_PKCS8

--- a/infra/modules/azuread-local-cert/main.tf
+++ b/infra/modules/azuread-local-cert/main.tf
@@ -1,0 +1,64 @@
+# generate certificate for Azure AD application locally and deploy it to Azure AD
+# NOTE: certificate will only be temporarily written to your local file system, but out of abundance
+# of caution should:
+#  - run this only in an environment that is approved from key generation in your organization
+#  - use a secure location for your Terraform state (eg, not local file systme of your laptop)
+terraform {
+  required_providers {
+    azuread = {
+      version = "~> 2.15.0"
+    }
+  }
+}
+
+resource "time_rotating" "rotation" {
+  rotation_days = var.rotation_days
+}
+
+# done with external as Terraform docs suggest
+
+data "external" "certificate" {
+  program = ["${path.module}/local-cert.sh", var.certificate_subject, var.cert_expiration_days]
+}
+
+# for JWT signing
+# NOTE: have gotten '400 with OData error: KeyCredentialsInvalidEndDate: Key credential end date is invalid'
+# when trying to apply this, even though only using 6 month expiration window. Re-apply worked ...
+resource "azuread_application_certificate" "certificate" {
+  application_object_id = var.application_object_id
+  type                  = "AsymmetricX509Cert"
+  value                 = base64decode(data.external.certificate.result.cert)
+  end_date              = timeadd(time_rotating.rotation.id, "${var.cert_expiration_days * 24}h")
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "private_key_id" {
+  # hackery to translate output of openssl fingerprint --> string of hex chars equivalent to how MSFT does
+  # (eg, MSFT will compute fingerprint server-side of the certificate value posted above)
+  # "SHA1 Fingerprint=8F:0E:46:89:7A:41:AE:5E:93:8C:BA:56:FC:AA:49:6E:0F:E2:F4:2C" -->
+  #   "8F0E46897A41AE5E938CBA56FCAA496E0FE2F42C"
+  value = replace(replace(data.external.certificate.result.fingerprint, "SHA1 Fingerprint=", ""), ":", "")
+}
+
+output "private_key" {
+  value     = base64decode(data.external.certificate.result.key_pkcs8)
+  sensitive = true
+}
+
+# for 3-legged OAuth flows, which believe aren't needed in this case as we have no OIDC/sign-on
+# flow for psoxy use-cases
+#resource "azuread_application_password" "oauth-client-secret" {
+#  application_object_id = var.application_id # oauthClientId
+#
+#  rotate_when_changed = {
+#    rotation = time_rotating.rotation.id
+#  }
+#}
+
+#output "oauth_client_secret" {
+#  value = azuread_application_password.oauth-client-secret.value
+#}
+

--- a/infra/modules/azuread-local-cert/variables.tf
+++ b/infra/modules/azuread-local-cert/variables.tf
@@ -1,0 +1,21 @@
+variable "rotation_days" {
+  type        = number
+  default     = 60
+  description = "terraform should rotate cert after this many days"
+}
+
+variable "cert_expiration_days" {
+  type        = number
+  default     = 180
+  description = "cert will expire in this many days"
+}
+
+variable "application_object_id" {
+  type        = string
+  description = "object ID of the Azure AD application to authenticate"
+}
+
+variable "certificate_subject" {
+  type        = string
+  description = "value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
+}


### PR DESCRIPTION
### Fixes
 - msft-365 example uses legacy local_cert module, which isn't preferred
 - local_cert module was removed in 0.4.11, but probably don't want to do that in case we break things for people. 


### Change implications

 - dependencies added/changed? **no**
