### PR TITLE
S142 misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,32 +32,47 @@ Orchestration continues to be performed on the Worklytics-side.
 
 ## Getting Started - Customers
 
-### Prereqs
-As of Oct 2021, Psoxy is implemented with Java 11 and built via Maven. Infrastructure is provisioned
-via Terraform, relying on Google Cloud and/or AWS command line tools.  You will need recent
-versions of all of the following:
+### Prerequisites
+As of Feb 2023, Psoxy is implemented with Java 11 and built via Maven. The proxy infrastructure is
+provisioned and the Psoxy code deployed using Terraform, relying on Azure, Google Cloud, and/or AWS
+command line tools.
 
-  - git
-  - Java 11+ JDK variant, but not Java 19 (currently broken, see [docs/troubleshooting.md](docs/troubleshooting.md) for downgrade help)
-  - [Maven 3.6+](https://maven.apache.org/docs/history.html)
-  - [terraform 1.3.x+](https://www.terraform.io/) optional; if you don't use this, you'll need to
-    configure your GCP/AWS project via the web console/CLI tools. Adapting one of our
-    [terraform examples](infra/examples) or writing your own config that re-uses our
-    [modules](infra/modules) will simplify things greatly.
+You will need all of the following:
 
-Depending on your scenario, you may also need:
-  - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) is
-    required to deploy your psoxy instances in AWS.
-  - [Google Cloud Command Line tool](https://cloud.google.com/sdk/docs/install) Required to host
-    your psoxy instances in GCP *OR* if you plan to connect Google Workspace as a data source. It
-    should be configured for the GCP project that will host your psoxy instance(s) and/or your
-    connectors.
-  - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) Required to connect to
-    Microsoft 365 sources.
-  - [openssl](https://www.openssl.org/) If generating local certificates (see
-    [`infra/modules/azure-local-cert`](infra/modules/azuread-local-cert))
-  - [Node.js v16+](https://nodejs.org/en/) and [npm v8+](https://www.npmjs.com/package/npm), to be
-    able to test your proxy instances locally (see `tools/psoxy-test/README.md`).
+| Tool                                         | Version        | Test Command        |
+|----------------------------------------------|----------------|---------------------|
+| [git](https://git-scm.com/)                  | 2.17+          | `git --version`     |
+| [Maven](https://maven.apache.org/)           | 3.6+           | `mvn -v`            |
+| [Java 11+ JDK](https://openjdk.org/install/) | 11+, but < 19  | `mvn -v \| grep Java` |
+| [Terraform](https://www.terraform.io/)       | 1.3.x+         | `terraform version` |
+
+
+NOTE: Java 19 is currently broken, see [docs/troubleshooting.md](docs/troubleshooting.md); we suggest
+Java 17, which is a LTS edition.
+
+NOTE: Using `terraform` is not strictly necessary, but it is the only supported method. You may
+provision your infrastructure via your host's CLI, web console, or another infrastructure provisioning
+tool, but we don't offer documentation or support in doing so.  Adapting one of our
+[terraform examples](infra/examples) or writing your own config that re-uses our
+[modules](infra/modules) will simplify things greatly.
+
+
+Depending on your Cloud Host / Data Sources, you will need:
+
+| Condition                         | Tool                                                                                       | Version | Test Command     |
+|-----------------------------------|--------------------------------------------------------------------------------------------|---------|------------------|
+| if deploying to AWS               | [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)   | 2.2+    | `aws --version`  |
+| if deploying to GCP               | [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)                              | 1.0+    | `gcloud version` |
+| if connecting to Microsoft 365    | [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)                  | 2.29+   | `az --version`   |
+| if connecting to Google Workspace | [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)                              | 1.0+    | `gcloud version` |
+
+For testing your psoxy instance, you will need:
+
+| Tool                                                               | Version | Test Command      |
+|--------------------------------------------------------------------|---------|-------------------|
+| [Node.js](https://nodejs.org/en/)                                  | 16+     | `node --version`  |
+| [npm](https://www.npmjs.com/package/npm) (should come with `node`) | 8+      | `npm --version`   |
+
 
 ### Setup
 

--- a/docs/aws/getting-started.md
+++ b/docs/aws/getting-started.md
@@ -1,14 +1,10 @@
 # AWS - Getting Started
 
-To deploy to AWS, you'll need an AWS account in which to deploy. We *strongly* recommend you
-provision one specifically for use to host Psoxy, as this will create an implicit security boundary,
-reduce possible conflicts with other infra configured in the account, and simplify eventual cleanup.
-
 ## Prerequisites
 
 1. **An AWS Account in which to deploy Psoxy** We *strongly* recommend you provision one specifically
-   for use to host Psoxy, as this will create  an implicit security boundary, reduce possible conflicts with other infra configured in the
-   account, and simplify eventual cleanup.
+   for use to host Psoxy, as this will create  an implicit security boundary, reduce possible
+   conflicts with other infra configured in the account, and simplify eventual cleanup.
 
    You will need the numeric AWS Account ID for this account, which you can find in the AWS Console.
 

--- a/docs/aws/getting-started.md
+++ b/docs/aws/getting-started.md
@@ -1,25 +1,43 @@
 # AWS - Getting Started
 
-**YMMV : this is a work-in-progress guide on how to use EC2 or other environment to deploy psoxy 
-to AWS.**
-
-To deploy to AWS, you'll need an AWS account in which to deploy. We *strongly* recommend you 
+To deploy to AWS, you'll need an AWS account in which to deploy. We *strongly* recommend you
 provision one specifically for use to host Psoxy, as this will create an implicit security boundary,
 reduce possible conflicts with other infra configured in the account, and simplify eventual cleanup.
 
 ## Prerequisites
 
-You must have a IAM Role within the target AWS account with sufficient privileges to (AWS managed role examples linked):
-   1. create IAM roles + policies (eg [IAMFullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/IAMFullAccess$serviceLevelSummary))
-   2. create and update Systems Manager Parameters (eg, [AmazonSSMFullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/AmazonSSMFullAccess$serviceLevelSummary) )
-   3. create and manage Lambdas (eg [AWSLambda_FullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/AWSLambda_FullAccess$serviceLevelSummary) )
-   4. create and manage S3 buckets (eg [AmazonS3FullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/AmazonS3FullAccess$serviceLevelSummary) )
-   5. create Cloud Watch Log groups (eg [CloudWatchFullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/CloudWatchFullAccess$serviceLevelSummary))
+1. **An AWS Account in which to deploy Psoxy** We *strongly* recommend you provision one specifically
+   for use to host Psoxy, as this will create  an implicit security boundary, reduce possible conflicts with other infra configured in the
+   account, and simplify eventual cleanup.
 
-You must be able to assume that role.
+   You will need the numeric AWS Account ID for this account, which you can find in the AWS Console.
 
-(Yes, the use of AWS Managed Policies results in a role with many privileges; that's why we
-recommend you use a dedicated AWS account to host proxy which is NOT shared with any other use case)
+
+2. **A sufficiently privileged AWS Role** You must have a IAM Role within the AWS account with
+  sufficient privileges to (AWS managed role examples linked):
+       1. create IAM roles + policies (eg [IAMFullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/IAMFullAccess$serviceLevelSummary))
+       2. create and update Systems Manager Parameters (eg, [AmazonSSMFullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/AmazonSSMFullAccess$serviceLevelSummary) )
+       3. create and manage Lambdas (eg [AWSLambda_FullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/AWSLambda_FullAccess$serviceLevelSummary) )
+       4. create and manage S3 buckets (eg [AmazonS3FullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/AmazonS3FullAccess$serviceLevelSummary) )
+       5. create Cloud Watch Log groups (eg [CloudWatchFullAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::aws:policy/CloudWatchFullAccess$serviceLevelSummary))
+
+    (Yes, the use of AWS Managed Policies results in a role with many privileges; that's why we
+    recommend you use a dedicated AWS account to host proxy which is NOT shared with any other use case)
+
+    You will need the ARN of this role.
+
+3. **An authenticated AWS CLI in your provisioning environment**. Your environment (eg, shell/etc
+   from which you'll run terraform commands) must be authenticated as an identity that can assume
+   that role. (see next section for tips on options for various environments you can use)
+
+    Eg, if your Role is `arn:aws:iam::123456789012:role/PsoxyProvisioningRole`, the following
+    should work:
+
+```shell
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/PsoxyProvisioningRole --role-session-name tf_session
+```
+
+    If not, use `aws sts get-caller-identity` to confirm how your CLI is authenticated.
 
 ## Provisioning Environment
 
@@ -63,9 +81,9 @@ when ready, continue with [README](../../README.md).
 
 ## Terraform State Backend
 
-You'll also need a backend location for your Terraform state (such as an S3 bucket). It can be in 
-any AWS account, as long as the AWS role that you'll use to run Terraform has read/write access to 
-it. 
+You'll also need a backend location for your Terraform state (such as an S3 bucket). It can be in
+any AWS account, as long as the AWS role that you'll use to run Terraform has read/write access to
+it.
 
 Alternatively, you may use a local file system, but this is not recommended for production use - as
 your Terraform state may contain secrets such as API keys, depending on the sources you connect.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,41 @@ NOTE:
     3 again to reset your `JAVA_HOME`
 
 
+### General Build / Packaging Failures
+Our example Terraform configurations should compile and package the Java code into a JAR file, which
+is then deployed by Terraform to your host environment.
+
+This is done via a build script, invoked by a Terraform module (see [`modules/psoxy-package`](../infra/modules/psoxy-package)).
+
+If, on your first `terraform plan`/`terraform apply`, you see the line such as
+
+`module.psoxy-aws-msft-365.module.psoxy-aws.module.psoxy-package.data.external.deployment_package: Reading...`
+
+And that returns really quickly, something may have gone wrong with the build. You can trigger the
+build directly by running:
+```bash
+# from the root of your checkout of the repository
+cd java/gateway-core
+mvn package install
+cd ../core
+mvn package install
+cd ../impl/aws
+mvn package
+```
+That may give you some clues as to what went wrong.
+
+You can also look for a file called `last-build.log` in the directory where your Terraform
+configuration resides.
+
+Some problems we've seen:
+  - **Maven repository access** - the build process must get various dependencies from a remote
+    Maven respository; if your laptop cannot reach Maven Central, is configured to get dependencies
+    from some other Maven repository, etc - you might need to fix this issue. You can check your
+    `~/.m2/settings.xml` file, which might give you some insight into what Maven repository you're
+    using. It's also where you'd configure credentials for a private Maven repository, such as
+    Artifactory/etc - so make sure those are correct.
+
+
 ### Upgrading Psoxy Code
 
 If you upgrade your psoxy code, it may be worth trying `terraform init --upgrade` to make sure

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,9 @@
 If you are using openjdk 19.0.1, you may run into problems with the build. We suggest you downgrade
 to some java 17 (which is Long-Term Support edition) and use that.
 
+NOTE: we believe the issue is fixed in 19.0.2, which was [released Jan 23, 2023](https://www.oracle.com/java/technologies/javase/19-0-2-relnotes.html).
+So alternatively you could try upgrading to that (or higher).
+
 On Mac, steps would be:
 
 1. check version
@@ -29,10 +32,16 @@ mvn -v
 brew install openjdk@17
 ```
 
-3. set `JAVA_HOME` env variable to point to java 17:
+3. set `JAVA_HOME` env variable to point to java 17; for example:
 
 ```bash
-export JAVA_HOME=`/opt/homebrew/Cellar/openjdk@17/17.0.5/libexec/openjdk.jdk/Contents/Home`
+export JAVA_HOME='/opt/homebrew/Cellar/openjdk@17/17.0.5/libexec/openjdk.jdk/Contents/Home'
+```
+
+or, possibly your Homebrew default installation is at `/usr/local/Cellar/`, in which case:
+
+```bash
+/usr/local/Cellar/openjdk@17/17.0.5/libexec/openjdk.jdk/Contents/Home
 ```
 
 NOTE:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,13 +11,10 @@
 
 ## General Tips
 
-### Build problems with Java 19 (specifically, openjdk 19.0.1)
+### Build problems with Java 19 (specifically, openjdk 19)
 
-If you are using openjdk 19.0.1, you may run into problems with the build. We suggest you downgrade
-to some java 17 (which is Long-Term Support edition) and use that.
-
-NOTE: we believe the issue is fixed in 19.0.2, which was [released Jan 23, 2023](https://www.oracle.com/java/technologies/javase/19-0-2-relnotes.html).
-So alternatively you could try upgrading to that (or higher).
+If you are using openjdk 19.0.1 or 19.0.2, you may run into problems with the build. We suggest you
+downgrade to some java 17 (which is Long-Term Support edition) and use that.
 
 On Mac, steps would be:
 
@@ -25,7 +22,8 @@ On Mac, steps would be:
 ```bash
 mvn -v
 ```
-- java version says "17", you're good to go. otherwise, try to downgrade
+- java version says "17", you're good to go. if it is <=8, or >=19, you should upgrade/downgrade
+  respectively.
 
 2. install java 17
 ```bash
@@ -35,13 +33,13 @@ brew install openjdk@17
 3. set `JAVA_HOME` env variable to point to java 17; for example:
 
 ```bash
-export JAVA_HOME='/opt/homebrew/Cellar/openjdk@17/17.0.5/libexec/openjdk.jdk/Contents/Home'
+export JAVA_HOME='/opt/homebrew/Cellar/openjdk@17/17.0.6/libexec/openjdk.jdk/Contents/Home'
 ```
 
 or, possibly your Homebrew default installation is at `/usr/local/Cellar/`, in which case:
 
 ```bash
-/usr/local/Cellar/openjdk@17/17.0.5/libexec/openjdk.jdk/Contents/Home
+/usr/local/Cellar/openjdk@17/17.0.6/libexec/openjdk.jdk/Contents/Home
 ```
 
 NOTE:

--- a/infra/examples/aws-msft-365/README.md
+++ b/infra/examples/aws-msft-365/README.md
@@ -44,14 +44,10 @@ Review the plan and confirm to apply.
 
 ## Security
 
-This example includes generation of certificates for your Azure AD application listings.
-   - anyone in possession of those certificates could access your data with whatever permissions you
-     grant to the Azure AD application.
-   - this example should be used with caution and only run from a location that, based on your
-     org's infosec rules, can be used to generate such a certificate.
-   - the terraform state produced by this module should be persisted to a secure location, such as
-     an encrypted disk of a VM dedicated for this purpose OR a cloud storage service (GCS, S3 etc).
-     It is generally NOT good practice to commit such state files to a source code repository such
-     as git/github.
-
+As of `v0.4.11`, authentication of your instance with Microsoft 365 is done via identity federation,
+establishing a trust relationship between your Azure AD Application and your AWS account,
+allowing the latter to authenticate as the former to access Microsoft 365 APIs. This approach
+requires no shared secrets between your AWS account and your Microsoft 365 tenant, nor any secrets/
+certficates to be generated/stored on your machine or in your AWS account. As such, this alone will
+not result in anything sensitive being in your Terraform state files.
 

--- a/infra/examples/aws-msft-365/terraform.tfvars.example
+++ b/infra/examples/aws-msft-365/terraform.tfvars.example
@@ -1,6 +1,11 @@
 aws_account_id                = "123123123123" # your AWS account ID here
 aws_assume_role_arn           = "arn:aws:iam::123123123123:role/InfraAdmin" # role in that AWS account ID to assume
-msft_tenant_id                = "" # your Microsoft tenant ID here
+
+# your Microsoft 365 tenant ID
+# hint: if you run `az login --allow-no-subscriptions`, there's a `tenantId` in the JSON output; you
+# can copy-paste that value into this variable
+msft_tenant_id                = ""
+
 enabled_connectors = [
   "asana",
   "dropbox-business",

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -71,6 +71,7 @@ variable "connector_display_name_suffix" {
 variable "certificate_subject" {
   type        = string
   description = "IGNORED; value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
+  default     = null
 }
 
 variable "psoxy_base_dir" {

--- a/infra/examples/msft-365/README.md
+++ b/infra/examples/msft-365/README.md
@@ -9,11 +9,7 @@ component will be run separately.
 As of Aug 2022, this is alpha-quality and generally not tested/recommended. Please carefully
 review Terraform plan and be prepared to debug issues.
 
-NOTE: this generates local certificate/etc. You can always remove these from Azure AD, and replace
-with your own generated out of band. Goal of terraform scripts is to simplify everything.
-
 ## Authentication
-
 
 ### Azure AD (Microsoft 365)
 Download and install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
@@ -36,14 +32,9 @@ msft_tenant_id                = "some-uuid-of-msft-tenant" # should hold your Mi
 
 ## Security
 
-This example includes generation of certificates for your Azure AD application listings.
-   - anyone in possession of those certificates could access your data with whatever permissions you
-     grant to the Azure AD application.
-   - this example should be used with caution and only run from a location that, based on your
-     org's infosec rules, can be used to generate such a certificate.
-   - the terraform state produced by this module should be persisted to a secure location, such as
-     an encrypted disk of a VM dedicated for this purpose OR a cloud storage service (GCS, S3 etc).
-     It is generally NOT good practice to commit such state files to a source code repository such
-     as git/github.
-
-
+As of `v0.4.11`, authentication of your instance with Microsoft 365 is done via identity federation,
+establishing a trust relationship between your Azure AD Application and your AWS account,
+allowing the latter to authenticate as the former to access Microsoft 365 APIs. This approach
+requires no shared secrets between your AWS account and your Microsoft 365 tenant, nor any secrets/
+certficates to be generated/stored on your machine or in your AWS account. As such, this alone will
+not result in anything sensitive being in your Terraform state files.

--- a/infra/examples/msft-365/variables.tf
+++ b/infra/examples/msft-365/variables.tf
@@ -58,6 +58,7 @@ variable "connector_display_name_suffix" {
 variable "certificate_subject" {
   type        = string
   description = "value for 'subject' passed to openssl when generation certificate (eg '/C=US/ST=New York/L=New York/CN=www.worklytics.co')"
+  default     = null
 }
 
 variable "psoxy_base_dir" {

--- a/tools/init-example.sh
+++ b/tools/init-example.sh
@@ -5,21 +5,31 @@ RED='\033[0;31m'
 BLUE='\33[0;34m'
 NC='\033[0m' # No Color
 
-if [ -f terraform.tfvars ]; then
-    printf "${RED}Nothing to initialize. File terraform.tfvars already exists!${NC}\n"
-    exit 1 # error
+TF_CONFIG_ROOT=`pwd`
+cd ../../..
+PSOXY_BASE_DIR=`pwd`
+
+
+if [ ! -f terraform.tfvars ]; then
+  TFVARS_FILE="${TF_CONFIG_ROOT}/terraform.tfvars"
+
+  cp ${TF_CONFIG_ROOT}/terraform.tfvars.example $TFVARS_FILE
+
+  # append root of checkout automatically
+  echo "psoxy_base_dir                = \"${PSOXY_BASE_DIR}/\"" >> $TFVARS_FILE
+
+  # give user some feedback
+  printf "Init'd example terraform config. Please open ${BLUE}terraform.tfvars${NC} and customize it to your needs.\n"
+  printf "Review ${BLUE}variables.tf${NC} for descriptions of each variable.\n\n"
+else
+  printf "${RED}Nothing to initialize. File terraform.tfvars already exists!${NC}\n\n"
 fi
 
-cp terraform.tfvars.example terraform.tfvars
-
-TFVARS_FILE="$(pwd)/terraform.tfvars"
-
-# append root of checkout automatically
-cd ../../..
-echo "psoxy_base_dir                = \"$(pwd)/\"" >> $TFVARS_FILE
-
-# give user some feedback
-printf "Init'd example terraform config. Please open ${BLUE}terraform.tfvars${NC} and customize it to your needs.\n"
-printf "Review ${BLUE}variables.tf${NC} for descriptions of each variable.\n"
-
+if which node > /dev/null; then
+  printf "Node available. Installing ${BLUE}psoxy-test${NC} tool ...\n"
+  cd ${PSOXY_BASE_DIR}/tools/psoxy-test
+  npm --prefix ${PSOXY_BASE_DIR}/tools/psoxy-test install
+else
+  printf "${RED}Node.JS not available; could not install test tool.${NC}\n"
+fi
 


### PR DESCRIPTION
### Fixes
 - default value for `certificate_subject`, to avoid unnecessary prompt
 
### Features
 - hint on how to get MSFT tenantID; many ppl don't know theirs
 - update JDK notes; clarify 19.0.2 also doesn't work
 - remove references to certs from MSFT readmes
 - improve prereq docs
 - install node test tool in `init` script

### Change implications

 - dependencies added/changed? **no**
