### PR TITLE
build tool, to directly build bundle outside terraform module

### DIFF
--- a/infra/examples/aws-google-workspace/build
+++ b/infra/examples/aws-google-workspace/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# NOTE: Terraform modules *should* build deployment bundle themselves, but in case that fails, this
+# script will do the equivalent with its output directly in your terminal
+
+../../../tools/build.sh aws ../../../java

--- a/infra/examples/aws-msft-365/build
+++ b/infra/examples/aws-msft-365/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# NOTE: Terraform modules *should* build deployment bundle themselves, but in case that fails, this
+# script will do the equivalent with its output directly in your terminal
+
+../../../tools/build.sh aws ../../../java

--- a/infra/examples/gcp-google-workspace/build
+++ b/infra/examples/gcp-google-workspace/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# NOTE: Terraform modules *should* build deployment bundle themselves, but in case that fails, this
+# script will do the equivalent with its output directly in your terminal
+
+../../../tools/build.sh gcp ../../../java

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#see ../infra/modules/psoxy-package/build.sh
+# this is similar, but outputs errors directly instead of to log file; and doesn'
+
+IMPLEMENTATION=$1 # 'aws' or 'gcp'
+JAVA_SOURCE_ROOT=$2
+
+# set to fail on erors
+set -e
+
+
+#TODO: validate prereqs?? (mvn??)
+cd ${JAVA_SOURCE_ROOT}
+
+mvn clean
+
+cd gateway-core
+mvn package install
+
+cd ../core
+mvn package install
+
+cd ../impl/${IMPLEMENTATION}
+mvn package


### PR DESCRIPTION
### Features
  - shell scripts to directly build proxy deployment bundle from examples - eases debugging, should build under terraform fail (arguably may just add this to `init` as well, rather than using terraform for it at all in usual case)

### Change implications

 - dependencies added/changed? **no**
