### PR TITLE
add azure-ad to msft example

### DIFF
--- a/infra/examples/aws-msft-365/terraform.tfvars.example
+++ b/infra/examples/aws-msft-365/terraform.tfvars.example
@@ -8,6 +8,7 @@ msft_tenant_id                = ""
 
 enabled_connectors = [
   "asana",
+  "azure-ad",
   "dropbox-business",
   "outlook-calendar",
   "outlook-mail",


### PR DESCRIPTION
### Fixes
 - need `azure-ad` enabled by default in example

### Change implications

 - dependencies added/changed? **no**
