### PR TITLE
S143 api gateway paths

### DIFF
--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
@@ -32,7 +32,13 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
 
     @Override
     public String getPath() {
-        return StringUtils.prependIfMissing(event.getRawPath(), "/");
+        //remove stage portion from path
+        String rawPath = event.getRawPath().replace("/" + event.getRequestContext().getStage(), "");
+
+        //TODO: route portion
+
+        //don't think needed
+        return StringUtils.prependIfMissing(rawPath, "/");
     }
 
     @Override

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
@@ -32,6 +32,13 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
 
     @Override
     public String getPath() {
+
+        // unclear whether this will exist, but if it does, use it
+        // q: is this only a v1 thing??
+        if (event.getPathParameters().containsKey("proxy")) {
+            return StringUtils.prependIfMissing(event.getPathParameters().get("proxy"), "/");
+        }
+
         //remove stage portion from path, if any
         //  - for Lambda URL deployments, we expect 'stage' to be '$default', and not match any portion
         //    of rawPath; this will be no-op

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
@@ -34,8 +34,12 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
     public String getPath() {
 
         // unclear whether this will exist, but if it does, use it
-        // q: is this only a v1 thing??
-        if (event.getPathParameters().containsKey("proxy")) {
+        // q: is this only a v1 thing?? or only a v2 thing??
+        // - I can't find a v2 proxy payload example
+        // - AWS docs seem to have a v1 exxample, but not v2 https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-proxy
+        // - https://github.com/aws/aws-sam-cli/issues/3654 - shows it, but not filled with a value that
+        //   seems consistent with other properties
+        if (event.getPathParameters() != null && event.getPathParameters().containsKey("proxy")) {
             return StringUtils.prependIfMissing(event.getPathParameters().get("proxy"), "/");
         }
 

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
@@ -43,7 +43,19 @@ class APIGatewayV2HTTPEventRequestAdapterTest {
 
         APIGatewayV2HTTPEventRequestAdapter requestAdapter = new APIGatewayV2HTTPEventRequestAdapter(apiGatewayV2HTTPEvent);
 
-        assertEquals("/nodejs-apig-function-1G3XMPLZXVXYI", requestAdapter.getPath());
+        assertEquals("/", requestAdapter.getPath());
+    }
+
+    @SneakyThrows
+    @Test
+    public void parse_apigatewayv2_route() {
+
+        APIGatewayV2HTTPEvent apiGatewayV2HTTPEvent = objectMapper.readerFor(APIGatewayV2HTTPEvent.class)
+            .readValue(TestUtils.getData("lambda-proxy-events/api-gateway-v2-event_ours.json"));
+
+        APIGatewayV2HTTPEventRequestAdapter requestAdapter = new APIGatewayV2HTTPEventRequestAdapter(apiGatewayV2HTTPEvent);
+
+        assertEquals("/calendars/v2/users/me/settings", requestAdapter.getPath());
     }
 
     @Test

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
@@ -34,6 +34,18 @@ class APIGatewayV2HTTPEventRequestAdapterTest {
         assertEquals("value1,value2", String.join(",", requestAdapter.getMultiValueHeader("multi-header").get()));
     }
 
+    @SneakyThrows
+    @Test
+    public void parse_apigatewayv2() {
+
+        APIGatewayV2HTTPEvent apiGatewayV2HTTPEvent = objectMapper.readerFor(APIGatewayV2HTTPEvent.class)
+            .readValue(TestUtils.getData("lambda-proxy-events/api-gateway-v2-event.json"));
+
+        APIGatewayV2HTTPEventRequestAdapter requestAdapter = new APIGatewayV2HTTPEventRequestAdapter(apiGatewayV2HTTPEvent);
+
+        assertEquals("/nodejs-apig-function-1G3XMPLZXVXYI", requestAdapter.getPath());
+    }
+
     @Test
     public void getHeader() {
         APIGatewayV2HTTPEvent apiGatewayV2HTTPEvent = new APIGatewayV2HTTPEvent();

--- a/java/impl/aws/src/test/resources/lambda-proxy-events/README.md
+++ b/java/impl/aws/src/test/resources/lambda-proxy-events/README.md
@@ -4,6 +4,7 @@ configured as an 'AWS_PROXY'.
 
 Examples:
  - `api-gateway-v2-event.json` - taken from https://github.com/awsdocs/aws-lambda-developer-guide/blob/main/sample-apps/nodejs-apig/event-v2.json
+ - `api-gateway-v2-event_ours.json` - guess of how API Gateway v2 payload looks like given expected stages+routes in real deployment
  - `generic-request.json` - looks like a direct Lambda URL invocation
  - `generic-request_explicit-stage.json` - looks like a API Gateway v1 payload??
 

--- a/java/impl/aws/src/test/resources/lambda-proxy-events/README.md
+++ b/java/impl/aws/src/test/resources/lambda-proxy-events/README.md
@@ -1,2 +1,10 @@
 Example payloads delivered to AWS Lambda for HTTP requests to an API Gateway v2, via an integration
 configured as an 'AWS_PROXY'.
+
+
+Examples:
+ - `api-gateway-v2-event.json` - taken from https://github.com/awsdocs/aws-lambda-developer-guide/blob/main/sample-apps/nodejs-apig/event-v2.json
+ - `generic-request.json` - looks like a direct Lambda URL invocation
+ - `generic-request_explicit-stage.json` - looks like a API Gateway v1 payload??
+
+

--- a/java/impl/aws/src/test/resources/lambda-proxy-events/api-gateway-v2-event.json
+++ b/java/impl/aws/src/test/resources/lambda-proxy-events/api-gateway-v2-event.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /nodejs-apig-function-1G3XMPLZXVXYI",
+  "rawPath": "/default/nodejs-apig-function-1G3XMPLZXVXYI",
+  "rawQueryString": "",
+  "cookies": [
+    "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2",
+    "regStatus=pre-register"
+  ],
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "content-length": "0",
+    "host": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "cross-site",
+    "sec-fetch-user": "?1",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5e6722a7-cc56xmpl46db7ae02d4da47e",
+    "x-forwarded-for": "205.255.255.176",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "r3pmxmplak",
+    "domainName": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+    "domainPrefix": "r3pmxmplak",
+    "http": {
+      "method": "GET",
+      "path": "/default/nodejs-apig-function-1G3XMPLZXVXYI",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "205.255.255.176",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+    },
+    "requestId": "JKJaXmPLvHcESHA=",
+    "routeKey": "ANY /nodejs-apig-function-1G3XMPLZXVXYI",
+    "stage": "default",
+    "time": "10/Mar/2020:05:16:23 +0000",
+    "timeEpoch": 1583817383220
+  },
+  "isBase64Encoded": true
+}

--- a/java/impl/aws/src/test/resources/lambda-proxy-events/api-gateway-v2-event_ours.json
+++ b/java/impl/aws/src/test/resources/lambda-proxy-events/api-gateway-v2-event_ours.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /gcal",
+  "rawPath": "/default/gcal/calendars/v2/users/me/settings",
+  "rawQueryString": "",
+  "cookies": [
+    "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2",
+    "regStatus=pre-register"
+  ],
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "content-length": "0",
+    "host": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "cross-site",
+    "sec-fetch-user": "?1",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5e6722a7-cc56xmpl46db7ae02d4da47e",
+    "x-forwarded-for": "205.255.255.176",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "r3pmxmplak",
+    "domainName": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+    "domainPrefix": "r3pmxmplak",
+    "http": {
+      "method": "GET",
+      "path": "/default/gcal/calendars/v2/users/me/settings",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "205.255.255.176",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+    },
+    "requestId": "JKJaXmPLvHcESHA=",
+    "routeKey": "ANY /gcal",
+    "stage": "default",
+    "time": "10/Mar/2020:05:16:23 +0000",
+    "timeEpoch": 1583817383220
+  },
+  "isBase64Encoded": true
+}


### PR DESCRIPTION
### Features
  - strip leading `stage`/`route` portions of paths for API Gateway v2 requests. Not sure exactly how this worked when we initially supported API Gateway v2, but believe we should now deal with payloads that come *either* from API Gateway V2 proxy routes *or* via Lambda URLs.

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204068354727093