### PR TITLE
S143 use refresh endpoint envvar

### DIFF
--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -153,7 +153,6 @@ module "psoxy-msft-connector" {
     {
       IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
       CLIENT_ID            = module.msft-connection[each.key].connector.application_id
-      REFRESH_ENDPOINT     = module.worklytics_connector_specs.msft_token_refresh_endpoint
       PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
       IDENTITY_POOL_ID     = module.cognito-identity-pool.pool_id,
       IDENTITY_ID          = module.cognito-identity.identity_id[each.key]

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -133,7 +133,9 @@ locals {
         "User.Read.All",
         "Group.Read.All"
       ]
-      environment_variables : {}
+      environment_variables : {
+        REFRESH_ENDPOINT = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+      },
       example_api_calls : [
         "/v1.0/users",
         "/v1.0/users/${var.example_msft_user_guid}",
@@ -154,7 +156,9 @@ locals {
         "Group.Read.All",
         "User.Read.All"
       ],
-      environment_variables : {}
+      environment_variables : {
+        REFRESH_ENDPOINT = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+      },
       example_api_calls : [
         "/v1.0/users",
         "/v1.0/users/${var.example_msft_user_guid}/events",

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -486,10 +486,6 @@ output "enabled_oauth_secrets_to_create" {
   value = local.enabled_oauth_secrets_to_create
 }
 
-output "msft_token_refresh_endpoint" {
-  value = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
-}
-
 output "enabled_bulk_connectors" {
   value = local.enabled_bulk_connectors
 }


### PR DESCRIPTION
After https://github.com/Worklytics/psoxy/pull/268, I've realized that `REFRESH_ENDPOINT` from MSFT connectors were coming from output and not from env var in specs. 

### Change implications

 - dependencies added/changed? **no**
