### PR TITLE
S143 docs and TODO files fixes

### DIFF
--- a/infra/examples-dev/aws-google-workspace/README.md
+++ b/infra/examples-dev/aws-google-workspace/README.md
@@ -17,4 +17,7 @@ gcp_project_id                = "psoxy-dev-aws-example-12314332"
 psoxy_base_dir                = "~/psoxy/" # TODO: we suggest using absolute path here
 ```
 
+In order to get the Service Account Unique ID value for `caller_gcp_service_account_ids`, log in to your Worklytics
+Account and visit the [Configuration Values](https://app.worklytics.co/analytics/integrations/configuration) page.
+
 

--- a/infra/examples-dev/aws-msft-365/README.md
+++ b/infra/examples-dev/aws-msft-365/README.md
@@ -41,6 +41,8 @@ caller_gcp_service_account_ids = [
 psoxy_base_dir                = "../../../"
 ```
 
+In order to get the Service Account Unique ID value for `caller_gcp_service_account_ids`, log in to your Worklytics
+Account and visit the [Configuration Values](https://app.worklytics.co/analytics/integrations/configuration) page.
 
 ## Security
 

--- a/infra/examples-dev/gcp-google-workspace/README.md
+++ b/infra/examples-dev/gcp-google-workspace/README.md
@@ -10,8 +10,7 @@ It can serve as guide for  how to create equivalent Terraform configurations for
 ## Usage
 
 Create a file in this directory named `terraform.tfvars` to specify your personal settings, with
-content
-
+content:
 ```terraform
 billing_account_id   = "--your billing account id--"
 project_id           = "--desired project id (must be unique)--"
@@ -21,8 +20,10 @@ worklytics_sa_emails = [
   "--email address of service account that personifies your Worklytics account--"
 ]
 ```
+In order to get the Service Account Email value for `worklytics_sa_emails`, log in to your Worklytics
+Account and visit the [Configuration Values](https://app.worklytics.co/analytics/integrations/configuration) page.
 
-for example:
+For example:
 ```terraform
 billing_account_id   = "0A2AE4-1D396E-1219D9"
 folder_id            = "33576234038"

--- a/infra/examples/aws-google-workspace/terraform.tfvars.example
+++ b/infra/examples/aws-google-workspace/terraform.tfvars.example
@@ -21,7 +21,7 @@ non_production_connectors = [] # use to mark any of the above as 'non-production
 caller_aws_arns = [
 ]
 caller_gcp_service_account_ids = [
-  # "123456712345671234567" # 21-digits; get this from Worklytics once prod-ready
+  # "123456712345671234567" # 21-digits; get this from Worklytics (https://app.worlytics.co/analytics/integrations/configuration) once prod-ready
 ]
 lookup_table_builders = {
     #    "lookup-hris" = {

--- a/infra/examples/aws-msft-365/terraform.tfvars.example
+++ b/infra/examples/aws-msft-365/terraform.tfvars.example
@@ -17,7 +17,7 @@ non_production_connectors = [
 caller_aws_arns = [
 ]
 caller_gcp_service_account_ids = [
-  # "123456712345671234567" # 21-digits, get this from Worklytics once prod-ready
+  # "123456712345671234567" # 21-digits, get this from Worklytics (https://app.worlytics.co/analytics/integrations/configuration) once prod-ready
 ]
 lookup_table_builders = {
     #    "lookup-hris" = {

--- a/infra/modular-examples/gcp-google-workspace/README.md
+++ b/infra/modular-examples/gcp-google-workspace/README.md
@@ -23,7 +23,10 @@ worklytics_sa_emails = [
 psoxy_base_dir                = "/home/user/psoxy/" # use absolute path to your local psoxy repo****
 ```
 
-for example:
+In order to get the Service Account Email value for `worklytics_sa_emails`, log in to your Worklytics
+Account and visit the [Configuration Values](https://app.worklytics.co/analytics/integrations/configuration) page.
+
+For example:
 ```terraform
 gcp_project_id                = "psoxy-dev-alice"
 gcp_org_id                    = "123456789" # your GCP organization ID; if existing project, you can leave as empty string and see the value from `terraform plan`

--- a/infra/modules/aws-ssm-fill-md/main.tf
+++ b/infra/modules/aws-ssm-fill-md/main.tf
@@ -19,7 +19,7 @@ YMMV.
 aws ssm put-parameter \
 --region ${var.region} \
 --name "${var.parameter_name}" \
---type "SecureString " \
+--type "SecureString" \
 --value "YOUR_VALUE_HERE" \
 --overwrite
 ```
@@ -29,7 +29,7 @@ from macOS clipboard
 pbpaste | aws ssm put-parameter \
 --region ${var.region} \
 --name "${var.parameter_name}" \
---type "SecureString " \
+--type "SecureString" \
 --value=- \
 --overwrite
 ```

--- a/infra/modules/gcp-psoxy-bulk/README.md
+++ b/infra/modules/gcp-psoxy-bulk/README.md
@@ -27,7 +27,10 @@ bucket_location      = "--OPTIONAL location where the buckets will be created"
 source_kind          = "Kind of the content to process; it should match one of the config.yaml file available"
 ```
 
-for example:
+In order to get the Service Account Email value for `worklytics_sa_emails`, log in to your Worklytics
+Account and visit the [Configuration Values](https://app.worklytics.co/analytics/integrations/configuration) page.
+
+For example:
 ```terraform
 billing_account_id   = "0A2AE4-1D396E-1219D9"
 folder_id            = "33576234038"
@@ -39,8 +42,8 @@ bucket_prefix        = "alice-psoxy-dev"
 source_kind          = "hris"
 ```
 
-It is mandatory that `source_kind` matches with a configuration file provided into the platform. For example, if the 
-value is `hris` it will expect a `hris.yaml` file at some point. You could include this kind of files as part of `config` 
+It is mandatory that `source_kind` matches with a configuration file provided into the platform. For example, if the
+value is `hris` it will expect a `hris.yaml` file at some point. You could include this kind of files as part of `config`
 folder or include it as part of the deployment files in the target folder.
 
 Example of `hris.yaml` config file with Base64 rules:

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -214,8 +214,9 @@ locals {
       ],
       external_token_todo : <<EOT
   1. Create a [Service Account User + token](https://asana.com/guide/help/premium/service-accounts)
-     or a sufficiently [Personal Access Token]() for a sufficiently privileged user (who can see all
-     the workspaces/teams/projects/tasks you wish to import to Worklytics via this connection).
+    or a sufficiently [Personal Access Token](https://developers.asana.com/docs/personal-access-token)
+    for a sufficiently privileged user (who can see all the workspaces/teams/projects/tasks you wish to
+    import to Worklytics via this connection).
   2. Update the content of PSOXY_ASANA_ACCESS_TOKEN variable with the previous token value obtained
 EOT
     }


### PR DESCRIPTION
### Fixes
- Misc fixes: Asana setup instructions

### Features
- [page in app to expose Tenant SA ID to customers](https://app.asana.com/0/1203997847867294/1203989025919801/f); @eschultink q: regarding `caller_gcp_service_account_ids`, is it worth adding the reference URL to the error messages? (Something like _The values of caller_gcp_service_account_ids should be 21-digit numeric strings: get the value at ...._)

### Change implications

 - dependencies added/changed? **no**
