### PR TITLE
relax az provider version constraints

### DIFF
--- a/infra/modules/azuread-connection/main.tf
+++ b/infra/modules/azuread-connection/main.tf
@@ -5,7 +5,7 @@
 terraform {
   required_providers {
     azuread = {
-      version = "~> 2.33.0"
+      version = ">= 2.7.0"
     }
   }
 }
@@ -20,6 +20,8 @@ resource "azuread_service_principal" "msgraph" {
 resource "azuread_application" "connector" {
   display_name = var.display_name
 
+  # NOTE: introduced in 2.7.0
+  # see https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application
   feature_tags {
     hide       = true  # don't show as 'App' to users, as there is no user-facing experience for connector
     enterprise = false # default; just clarify this is intentional. see https://marileeturscak.medium.com/the-difference-between-app-registrations-enterprise-applications-and-service-principals-in-azure-4f70b9a80fe5

--- a/infra/modules/azuread-federated-credentials/main.tf
+++ b/infra/modules/azuread-federated-credentials/main.tf
@@ -3,11 +3,12 @@
 terraform {
   required_providers {
     azuread = {
-      version = "~> 2.33.0"
+      version = ">= 2.14.0"
     }
   }
 }
 
+# introduced in 2.14.0 - https://registry.terraform.io/providers/hashicorp/azuread/2.14.0/docs/resources/application_federated_identity_credential
 resource "azuread_application_federated_identity_credential" "federated_credential" {
   application_object_id = var.application_object_id
   display_name          = var.display_name

--- a/infra/modules/azuread-grant-all-users/main.tf
+++ b/infra/modules/azuread-grant-all-users/main.tf
@@ -2,14 +2,6 @@
 #  - there is no way to do another org unit / group via Terraform; if that's the configure you
 #   desire, you'll have to do that via Azure AD console OR cli
 
-terraform {
-  required_providers {
-    azuread = {
-      version = "~> 2.33.0"
-    }
-  }
-}
-
 # TODO: if grant can be made fully through API, do it here; until then, TODO file is best option
 
 # NOTE: using `azuread_service_principal_delegated_permission_grant` seems to NOT work for this,

--- a/infra/modules/azuread-local-cert/main.tf
+++ b/infra/modules/azuread-local-cert/main.tf
@@ -6,7 +6,7 @@
 terraform {
   required_providers {
     azuread = {
-      version = "~> 2.15.0"
+      version = "> 2.0, < 3.0"
     }
   }
 }


### PR DESCRIPTION
> Description here

### Fixes
 - customer still needs to use certs, but also set owners. our az modules that do those things have incompatible version constraints

### Change implications

 - dependencies added/changed? **yes** - relax provider dependencies
