### PR TITLE
expose deployment pkg references from modular examples

### DIFF
--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -398,3 +398,13 @@ output "caller_role_arn" {
   description = "ARN of the AWS IAM role that can be assumed to invoke the Lambdas."
   value       = module.psoxy-aws.api_caller_role_arn
 }
+
+output "path_to_deployment_jar" {
+  description = "Path to the package to deploy (JAR) as lambda."
+  value       = module.psoxy-aws.path_to_deployment_jar
+}
+
+output "deployment_package_hash" {
+  description = "Hash of deployment package."
+  value       = module.psoxy-aws.deployment_package_hash
+}

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -436,3 +436,13 @@ output "caller_role_arn" {
   description = "ARN of the AWS IAM role that can be assumed to invoke the Lambdas."
   value       = module.psoxy-aws.api_caller_role_arn
 }
+
+output "path_to_deployment_jar" {
+  description = "Path to the package to deploy (JAR) as lambda."
+  value       = module.psoxy-aws.path_to_deployment_jar
+}
+
+output "deployment_package_hash" {
+  description = "Hash of deployment package."
+  value       = module.psoxy-aws.deployment_package_hash
+}

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -340,3 +340,15 @@ output "todos_3" {
     values(module.worklytics-psoxy-connection)[*].todo
   )
 }
+
+
+# use case: let someone consume this deploy another psoxy instance, reusing artifacts
+output "artifacts_bucket_name" {
+  description = "Name of GCS bucket with deployment artifacts."
+  value       = module.psoxy-gcp.artifacts_bucket_name
+}
+
+output "deployment_bundle_object_name" {
+  description = "Object name of deplyment bundle within artifacts bucket."
+  value       = module.psoxy-gcp.deployment_bundle_object_name
+}


### PR DESCRIPTION

### Features
 - expose deployment pkg references from modular examples; facilitates customer configs that add some more lambdas on top of examples, without rebuilding JARs

### Change implications

 - dependencies added/changed? **no**
