### PR TITLE
fix lookup tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,27 @@ Working tracking of changes, updated as work done prior to release.  Please revi
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
-## v0.4.11
+## [v0.4.14](https://github.com/Worklytics/psoxy/releases/tag/v0.4.14)
+
+Changes:
+  - you may see deletion and recreation of `aws_s3_bucket_notification` resources; this is expected
+    and will not alter behavior of deployment
+
+Fixes:
+  - the "Lookup" file use-case, supported in our examples through `lookup_table_builders` variable,
+    never worked as expected due to S3 limitation, where only 1 of the 2 "event notifications" our
+    modules set on a given S3 bucket actually work (race-case as to which). This should be fixed if
+    you re-apply your terraform configuration with this version.
+
+## [v0.4.13](https://github.com/Worklytics/psoxy/releases/tag/v0.4.13)
+
+see https://github.com/Worklytics/psoxy/releases/tag/v0.4.13
+
+## [v0.4.12](https://github.com/Worklytics/psoxy/releases/tag/v0.4.12)
+
+see https://github.com/Worklytics/psoxy/releases/tag/v0.4.12
+
+## [v0.4.11](https://github.com/Worklytics/psoxy/releases/tag/v0.4.11)
 Features:
  - avoid ENV vars for config paths if default values
  - troubleshooting docs
@@ -35,7 +55,7 @@ Fixes:
   - update NPM dependencies to avoid some vulnerabilities (npm packages are only used for testing;
     not exposed to any external clients)
 
-## v0.4.10
+## [v0.4.10](https://github.com/Worklytics/psoxy/releases/tag/v0.4.10)
 
 Features:
   - `PATH_TO_SHARED_CONFIG`/`PATH_TO_CONNECTOR_CONFIG` fully supported for AWS SSM Parameter Store

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -68,6 +68,7 @@ resource "aws_lambda_permission" "allow_input_bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
+  count = var.enable_input_trigger ? 1 : 0
 
   bucket = var.input_bucket
 

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -102,6 +102,12 @@ variable "memory_size_mb" {
   default     = 512
 }
 
+variable "enable_input_trigger" {
+  type        = bool
+  description = "Whether to provision `aws_s3_bucket_notification` to trigger lambda on new objects in input bucket. Set to `false` if you plan to do this outside this module, which would support more sophisticated use cases."
+  default     = true # legacy behavior
+}
+
 variable "todo_step" {
   type        = number
   description = "of all todos, where does this one logically fall in sequence"

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -111,6 +111,8 @@ resource "aws_lambda_permission" "allow_input_bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
+  count = var.enable_input_trigger ? 1 : 0
+
   bucket = aws_s3_bucket.input.id
 
   lambda_function {
@@ -120,7 +122,6 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 
   depends_on = [aws_lambda_permission.allow_input_bucket]
 }
-
 
 # the lambda function needs to get single objects from the input bucket
 resource "aws_iam_policy" "input_bucket_getObject_policy" {

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -131,6 +131,12 @@ variable "memory_size_mb" {
   default     = 512
 }
 
+variable "enable_input_trigger" {
+  type        = bool
+  description = "Whether to provision `aws_s3_bucket_notification` to trigger lambda on new objects in input bucket. Set to `false` if you plan to do this outside this module, which would support more sophisticated use cases."
+  default     = true # legacy behavior
+}
+
 variable "todo_step" {
   type        = number
   description = "of all todos, where does this one logically fall in sequence"


### PR DESCRIPTION
### Fixes
  - lookup table builders don't work, bc S3 doesn't allow multiple notifications configured on a bucket

--> well, turns out they ALSO don't allow a single notification to be configured to multiple lambdas with same event type, wtf

### Change implications

 - dependencies added/changed? **no**


--> current blocker is:

![psoxy_–_TODO_2_-_test_hris_md__infra_](https://user-images.githubusercontent.com/102831/225166735-43259ff6-cf99-4492-8146-701a6f67d28e.jpg)


I was attempted what Terraform docs show: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification#trigger-multiple-lambda-functions

--> but apparently the `filter_prefix`/`filter_suffix` part is needed, and they don't allow the thing to be the same???



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204091733599946