### PR TITLE
support re-writing bulk object path prefixes when processing

### DIFF
--- a/infra/modules/psoxy-package/build.sh
+++ b/infra/modules/psoxy-package/build.sh
@@ -23,6 +23,8 @@ if [ ! -f $PATH_TO_DEPLOYMENT_JAR ] || [ ! -z "$FORCE_BUILD" ] ; then
 
   ln -sf ${LOG_FILE} ${TERRAFORM_CONFIG_PATH}/last-build.log
 
+  mvn clean -f ${JAVA_SOURCE_ROOT}/pom.xml > ${LOG_FILE} 2>&1
+
   mvn package install -f ${JAVA_SOURCE_ROOT}/gateway-core/pom.xml > ${LOG_FILE} 2>&1
 
   mvn package install -f ${JAVA_SOURCE_ROOT}/core/pom.xml >> ${LOG_FILE} 2>&1

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/BulkModeConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/BulkModeConfigProperty.java
@@ -7,7 +7,26 @@ package co.worklytics.psoxy.gateway;
 public enum BulkModeConfigProperty implements ConfigService.ConfigProperty {
 
     OUTPUT_BUCKET,
+
+    /**
+     * if provided, this path segment will be prepended to keys of output objects
+     */
     ADDITIONAL_TRANSFORMS,
+
+    /**
+     * if provided, this path segment will be removed from keys of input object to produce
+     * keys of corresponding output objects.
+     *
+     * NOTE: objects with keys that do not start with this segment will still be processed; this is
+     * not any kind of filter.
+     */
+    INPUT_BASE_PATH,
+
+    /**
+     * if provided, this path segment will be prepended to keys of output objects, after removing
+     * any {@link #INPUT_BASE_PATH} segment
+     */
+    OUTPUT_BASE_PATH,
     ;
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/StorageEventRequest.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/StorageEventRequest.java
@@ -2,6 +2,7 @@ package co.worklytics.psoxy.gateway;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 
 import java.io.InputStreamReader;
 
@@ -14,20 +15,35 @@ public class StorageEventRequest {
     /**
      * Stream where the object can be read
      */
+
+    @NonNull
     InputStreamReader readerStream;
 
     /**
      * Name of the bucket where the object is. Example: "mybucket"
      */
+
+    @NonNull
     String sourceBucketName;
 
     /**
      * Path without the bucket of the object. Example: "outputs/test/file.csv"
      */
+
+    @NonNull
     String sourceObjectPath;
 
     /**
-     * If provided, the name of the destination bucket that can be used
+     * Name of the bucket where the object will be written. Example: "mybucket"
      */
+    @NonNull
     String destinationBucketName;
+
+    /**
+     * Path tow the bucket of the object. Example: "outputs/test/file.csv"
+     */
+    @NonNull
+    String destinationObjectPath;
+
+
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -1,19 +1,26 @@
 package co.worklytics.psoxy.storage;
 
 import co.worklytics.psoxy.Pseudonymizer;
+import co.worklytics.psoxy.gateway.BulkModeConfigProperty;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.StorageEventRequest;
 import co.worklytics.psoxy.gateway.StorageEventResponse;
 import co.worklytics.psoxy.rules.CsvRules;
+import co.worklytics.psoxy.rules.RulesUtils;
 import com.avaulta.gateway.rules.BulkDataRules;
 import lombok.*;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.InputStreamReader;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * solves a DaggerMissingBinding exception in tests
  */
+@Singleton
 @NoArgsConstructor(onConstructor_ = @Inject)
 public class StorageHandler {
 
@@ -26,27 +33,82 @@ public class StorageHandler {
     @Inject
     Pseudonymizer pseudonymizer;
 
+    @Inject
+    BulkDataRules defaultRuleSet;
+
+    @Inject
+    RulesUtils rulesUtils;
+
     @SneakyThrows
     public StorageEventResponse handle(StorageEventRequest request, BulkDataRules rules) {
 
         BulkDataSanitizer fileHandler = bulkDataSanitizerFactory.get(request.getSourceObjectPath());
 
         return StorageEventResponse.builder()
-                .destinationBucketName(request.getDestinationBucketName())
                 .bytes(fileHandler.sanitize(request.getReaderStream(), rules, pseudonymizer))
-                .destinationObjectPath(request.getSourceObjectPath())
+                .destinationBucketName(request.getDestinationBucketName())
+                .destinationObjectPath(request.getDestinationObjectPath())
                 .build();
     }
 
-    @AllArgsConstructor(staticName = "of")
+    public StorageEventRequest buildRequest(InputStreamReader reader, String sourceBucketName, String sourceObjectPath, StorageHandler.ObjectTransform transform) {
+
+        String sourceObjectPathWithinBase =
+            config.getConfigPropertyAsOptional(BulkModeConfigProperty.INPUT_BASE_PATH)
+                .map(inputBasePath -> sourceObjectPath.replace(inputBasePath, ""))
+                .orElse(sourceObjectPath);
+
+        return StorageEventRequest.builder()
+            .readerStream(reader)
+            .sourceBucketName(sourceBucketName)
+            .sourceObjectPath(sourceObjectPath)
+            .destinationBucketName(transform.getDestinationBucketName())
+            .destinationObjectPath(transform.getPathWithinBucket() + sourceObjectPathWithinBase)
+            .build();
+    }
+
+    public List<ObjectTransform> buildTransforms() {
+        List<StorageHandler.ObjectTransform> transforms = new ArrayList<>();
+        transforms.add(buildDefaultTransform());
+
+        rulesUtils.parseAdditionalTransforms(config)
+            .forEach(transforms::add);
+
+        return transforms;
+    }
+
+    ObjectTransform buildDefaultTransform() {
+        return ObjectTransform.builder()
+            .destinationBucketName(config.getConfigPropertyOrError(BulkModeConfigProperty.OUTPUT_BUCKET))
+            .pathWithinBucket(config.getConfigPropertyAsOptional(BulkModeConfigProperty.OUTPUT_BASE_PATH).orElse(""))
+            .rules((CsvRules) defaultRuleSet)
+            .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
     @NoArgsConstructor
     @Data
     public static class ObjectTransform implements Serializable {
 
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 2L;
 
+        /**
+         * destination bucket in which to write the transformed object
+         */
         @NonNull
         String destinationBucketName;
+
+        /**
+         * path within the destination bucket in which to write the transformed object, prepended
+         * the object's original path within the source bucket.
+         *
+         * if destinationBucketName is the same as the source bucket, then NOT specifying this
+         * will overwrite your original file - so make sure that's what you intend
+         */
+        @NonNull
+        @Builder.Default
+        String pathWithinBucket = "";
 
         //NOTE: need a concrete type here to serialize to/from YAML
         //TODO: support proper jackson polymorphism here, across potential BulkDataRules implementations

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
@@ -85,9 +85,12 @@ class RulesUtilsTest {
 
     List<StorageHandler.ObjectTransform> transformList =
         ImmutableList.<StorageHandler.ObjectTransform>builder()
-            .add(StorageHandler.ObjectTransform.of("blah", CsvRules.builder()
+            .add(StorageHandler.ObjectTransform.builder()
+                .destinationBucketName("blah")
+                .rules(CsvRules.builder()
                 .columnToPseudonymize("something")
-                .build()))
+                .build())
+                .build())
             .build();
 
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -1,0 +1,101 @@
+package co.worklytics.psoxy.storage;
+
+import co.worklytics.psoxy.PsoxyModule;
+import co.worklytics.psoxy.gateway.BulkModeConfigProperty;
+import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.psoxy.gateway.StorageEventRequest;
+import co.worklytics.test.MockModules;
+import dagger.Component;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.io.InputStreamReader;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StorageHandlerTest {
+
+    @Singleton
+    @Component(modules = {
+        PsoxyModule.class,
+        MockModules.ForRules.class,
+        MockModules.ForConfigService.class
+    })
+    public interface Container {
+        void inject( StorageHandlerTest test);
+    }
+
+    @Inject
+    ConfigService config;
+
+    @Inject
+    StorageHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        Container container = DaggerStorageHandlerTest_Container.create();
+        container.inject(this);
+
+        when(config.getConfigPropertyOrError(eq(BulkModeConfigProperty.OUTPUT_BUCKET)))
+            .thenReturn("bucket");
+    }
+
+    @ValueSource(strings = { "", "/", "/foo", "/foo/bar" })
+    @ParameterizedTest
+    void buildDefaultTransform(String outputBasePath) {
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.OUTPUT_BASE_PATH)))
+            .thenReturn(Optional.of(outputBasePath));
+
+
+        assertEquals(outputBasePath,
+            handler.buildDefaultTransform().getPathWithinBucket());
+    }
+
+    @Test
+    void buildRequest() {
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.INPUT_BASE_PATH)))
+            .thenReturn(Optional.empty());
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.OUTPUT_BASE_PATH)))
+            .thenReturn(Optional.empty());
+
+        StorageEventRequest request = handler.buildRequest(mock(InputStreamReader.class), "bucket-in", "directory/file.csv", handler.buildDefaultTransform());
+
+        assertEquals("directory/file.csv", request.getDestinationObjectPath());
+    }
+
+
+    /**
+     * test a bunch of permutations of how this could be configured
+     */
+    @CsvSource({
+        ",,directory/file.csv",
+        "directory/,,file.csv",
+        ",out/,out/directory/file.csv",
+        "directory/,out/,out/file.csv",
+        "in/,out/,out/directory/file.csv", //yeah, weird case
+    })
+    @ParameterizedTest
+    void buildRequest(String inputBasePath, String outputBasePath, String expectedOutputPath) {
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.INPUT_BASE_PATH)))
+            .thenReturn(Optional.ofNullable(inputBasePath));
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.OUTPUT_BASE_PATH)))
+            .thenReturn(Optional.ofNullable(outputBasePath));
+
+        StorageEventRequest request = handler.buildRequest(mock(InputStreamReader.class), "bucket-in", "directory/file.csv", handler.buildDefaultTransform());
+
+        assertEquals("bucket-in", request.getSourceBucketName());
+        assertEquals("directory/file.csv", request.getSourceObjectPath());
+        assertEquals("bucket", request.getDestinationBucketName());
+        assertEquals(expectedOutputPath, request.getDestinationObjectPath());
+    }
+}

--- a/java/core/src/test/java/co/worklytics/test/MockModules.java
+++ b/java/core/src/test/java/co/worklytics/test/MockModules.java
@@ -2,9 +2,11 @@ package co.worklytics.test;
 
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.SourceAuthStrategy;
+import co.worklytics.psoxy.rules.CsvRules;
 import co.worklytics.psoxy.rules.RESTRules;
 import co.worklytics.psoxy.rules.RuleSet;
 import co.worklytics.psoxy.utils.RandomNumberGenerator;
+import com.avaulta.gateway.rules.BulkDataRules;
 import com.google.api.client.http.*;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -54,6 +56,11 @@ public class MockModules {
         @Provides @Singleton
         static RuleSet rules() {
             return mock(RuleSet.class);
+        }
+
+        @Provides @Singleton
+        static BulkDataRules bulkDataRules() {
+            return mock(CsvRules.class);
         }
 
         @Provides @Singleton

--- a/java/core/src/test/java/co/worklytics/test/TestModules.java
+++ b/java/core/src/test/java/co/worklytics/test/TestModules.java
@@ -74,5 +74,7 @@ public class TestModules {
             .thenReturn(Optional.of("secret"));
         when(config.getConfigPropertyOrError(ProxyConfigProperty.PSOXY_SALT))
             .thenReturn("salt");
+        when(config.getConfigPropertyAsOptional(ProxyConfigProperty.PSOXY_SALT))
+            .thenReturn(Optional.of("salt"));
     }
 }


### PR DESCRIPTION
### Features
 -  support `INPUT_BASE_PATH`/`OUTPUT_BASE_PATH` config params. by default, key of output object is the same as input object. `INPUT_BASE_PATH`, if provided, will be stripped from the key of the output object; and then `OUTPUT_BASE_PATH`, if provided, will be prepended to the key. 

This allows something like follows:

- input: `s3://my-bucket/in/foo.csv`
- output: `s3://my-bucket/out/foo.csv`

by configuring `INPUT_BASE_PATH='in/'` and `OUTPUT_BASE_PATH='out/'` 

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204251780882977