### PR TITLE
use object metadata to avoid loop

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -110,13 +110,19 @@ public class StorageHandler {
     }
 
     /**
+     * @param sourceBucket the bucket from which the original object was read
+     * @param sourceKey the key of the original object within the source bucket
+     * @param transform the transform that was applied to the object
+     *
      * @return metadata to be written to the transformed object
      */
-    public Map<String, String> getObjectMeta(String importBucket, String sourceKey, ObjectTransform transform) {
+    public Map<String, String> buildObjectMetadata(String sourceBucket, String sourceKey, ObjectTransform transform) {
+        //transform currently unused; in future we probably want to record what transform was
+        // applied, to aid traceability of pipelines
         return Map.of(
             BulkMetaData.INSTANCE_ID.getMetaDataKey(), hostEnvironment.getInstanceId(),
             BulkMetaData.VERSION.getMetaDataKey(), config.getConfigPropertyAsOptional(ProxyConfigProperty.BUNDLE_FILENAME).orElse("unknown"),
-            BulkMetaData.ORIGINAL_OBJECT_KEY.getMetaDataKey(), importBucket + "/" + sourceKey
+            BulkMetaData.ORIGINAL_OBJECT_KEY.getMetaDataKey(), sourceBucket + "/" + sourceKey
         );
     }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -14,7 +14,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * solves a DaggerMissingBinding exception in tests
@@ -56,7 +55,8 @@ public class StorageHandler {
         // map back to actual value for debugging
         ;
 
-        static final String META_DATA_KEY_PREFIX = "x-psoxy-meta-";
+        // aws prepends `x-amz-meta-`
+        static final String META_DATA_KEY_PREFIX = "psoxy-";
 
 
         public String getMetaDataKey() {

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -130,6 +130,11 @@ public class StorageHandler {
         // such a scenario, if lambda 1 triggered from bucket A, writes to B, which triggers lambda
         // 2 to write back to A
 
+        if (objectMeta == null) {
+            //GCP seems to return null here, rather than an empty map
+            return false;
+        }
+
         return objectMeta.getOrDefault(BulkMetaData.INSTANCE_ID.getMetaDataKey(), "")
             .equals(hostEnvironment.getInstanceId());
     }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -40,11 +40,6 @@ public class StorageHandler {
     @Inject
     HostEnvironment hostEnvironment;
 
-
-
-    //TODO: double check keys/values work for all bulk file storage cases
-    // - GCS
-    // - S3
     @RequiredArgsConstructor
     public enum BulkMetaData {
         INSTANCE_ID,
@@ -55,7 +50,10 @@ public class StorageHandler {
         // map back to actual value for debugging
         ;
 
-        // aws prepends `x-amz-meta-`
+        // aws prepends `x-amz-meta-` to this; but per documentation, that's not visible via the
+        // java client (eg, they add/remove it automatically); it is visible through AWS console
+        //
+        // gcp doesn't prepend anything
         static final String META_DATA_KEY_PREFIX = "psoxy-";
 
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -5,6 +5,7 @@ import co.worklytics.psoxy.gateway.BulkModeConfigProperty;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.StorageEventRequest;
 import co.worklytics.test.MockModules;
+import com.google.common.collect.ImmutableMap;
 import dagger.Component;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,5 +109,12 @@ class StorageHandlerTest {
         assertTrue(handler.getObjectMeta("bucket", "directory/file.csv", handler.buildDefaultTransform())
             .containsKey(StorageHandler.BulkMetaData.INSTANCE_ID.getMetaDataKey()));
 
+    }
+
+    @Test
+    public void hasBeenSanitized() {
+        assertFalse(handler.hasBeenSanitized(null));
+        assertFalse(handler.hasBeenSanitized(ImmutableMap.of()));
+        assertTrue(handler.hasBeenSanitized(ImmutableMap.of(StorageHandler.BulkMetaData.INSTANCE_ID.getMetaDataKey(), "psoxy-test")));
     }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -29,7 +29,8 @@ class StorageHandlerTest {
     @Component(modules = {
         PsoxyModule.class,
         MockModules.ForRules.class,
-        MockModules.ForConfigService.class
+        MockModules.ForConfigService.class,
+        MockModules.ForHostEnvironment.class,
     })
     public interface Container {
         void inject( StorageHandlerTest test);
@@ -97,5 +98,11 @@ class StorageHandlerTest {
         assertEquals("directory/file.csv", request.getSourceObjectPath());
         assertEquals("bucket", request.getDestinationBucketName());
         assertEquals(expectedOutputPath, request.getDestinationObjectPath());
+    }
+
+    @Test
+    public void metadata() {
+        handler.getObjectMeta("bucket", "directory/file.csv", handler.buildDefaultTransform());
+
     }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -102,7 +102,11 @@ class StorageHandlerTest {
 
     @Test
     public void metadata() {
-        handler.getObjectMeta("bucket", "directory/file.csv", handler.buildDefaultTransform());
+
+        //kinda pointless
+
+        assertTrue(handler.getObjectMeta("bucket", "directory/file.csv", handler.buildDefaultTransform())
+            .containsKey(StorageHandler.BulkMetaData.INSTANCE_ID.getMetaDataKey()));
 
     }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -102,11 +102,11 @@ class StorageHandlerTest {
     }
 
     @Test
-    public void metadata() {
+    public void getObjectMetadata() {
 
         //kinda pointless
 
-        assertTrue(handler.getObjectMeta("bucket", "directory/file.csv", handler.buildDefaultTransform())
+        assertTrue(handler.buildObjectMetadata("bucket", "directory/file.csv", handler.buildDefaultTransform())
             .containsKey(StorageHandler.BulkMetaData.INSTANCE_ID.getMetaDataKey()));
 
     }

--- a/java/core/src/test/java/co/worklytics/test/MockModules.java
+++ b/java/core/src/test/java/co/worklytics/test/MockModules.java
@@ -1,6 +1,7 @@
 package co.worklytics.test;
 
 import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.psoxy.gateway.HostEnvironment;
 import co.worklytics.psoxy.gateway.SourceAuthStrategy;
 import co.worklytics.psoxy.rules.CsvRules;
 import co.worklytics.psoxy.rules.RESTRules;
@@ -98,5 +99,16 @@ public class MockModules {
 
     }
 
+    @Module
+    public interface ForHostEnvironment {
+
+        @Provides
+        @Singleton
+        static HostEnvironment hostEnvironment() {
+            HostEnvironment hostEnvironment = mock(HostEnvironment.class);
+            when(hostEnvironment.getInstanceId()).thenReturn("psoxy-test");
+            return hostEnvironment;
+        }
+    }
 }
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
@@ -1,8 +1,8 @@
 package co.worklytics.psoxy;
 
 import co.worklytics.psoxy.aws.DaggerAwsContainer;
-import co.worklytics.psoxy.gateway.StorageEventRequest;
-import co.worklytics.psoxy.gateway.StorageEventResponse;
+
+import co.worklytics.psoxy.gateway.*;
 import co.worklytics.psoxy.storage.StorageHandler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
@@ -76,9 +76,10 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
         try (InputStream is = new ByteArrayInputStream(storageEventResponse.getBytes())) {
 
             ObjectMetadata meta = new ObjectMetadata();
-
             meta.setContentLength(storageEventResponse.getBytes().length);
             meta.setContentType(s3Object.getObjectMetadata().getContentType());
+
+            meta.setUserMetadata(storageHandler.getObjectMeta(importBucket, sourceKey, transform));
 
             s3Client.putObject(storageEventResponse.getDestinationBucketName(),
                 storageEventResponse.getDestinationObjectPath(),

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSFileEvent.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSFileEvent.java
@@ -79,7 +79,7 @@ public class GCSFileEvent implements BackgroundFunction<GCSFileEvent.GcsEvent> {
                 storage.createFrom(
                     BlobInfo.newBuilder(BlobId.of(storageEventResponse.getDestinationBucketName(), storageEventResponse.getDestinationObjectPath()))
                         .setContentType(blobInfo.getContentType())
-                        .setMetadata(storageHandler.getObjectMeta(importBucket, sourceName, transform))
+                        .setMetadata(storageHandler.buildObjectMetadata(importBucket, sourceName, transform))
                         .build(),
                     processedStream);
 

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSFileEvent.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSFileEvent.java
@@ -68,9 +68,12 @@ public class GCSFileEvent implements BackgroundFunction<GCSFileEvent.GcsEvent> {
                 log.info("Writing to: " + storageEventResponse.getDestinationBucketName() + "/" + storageEventResponse.getDestinationObjectPath());
 
 
-                storage.createFrom(BlobInfo.newBuilder(BlobId.of(storageEventResponse.getDestinationBucketName(), storageEventResponse.getDestinationObjectPath()))
-                    .setContentType(blobInfo.getContentType())
-                    .build(), processedStream);
+                storage.createFrom(
+                    BlobInfo.newBuilder(BlobId.of(storageEventResponse.getDestinationBucketName(), storageEventResponse.getDestinationObjectPath()))
+                        .setContentType(blobInfo.getContentType())
+                        .setMetadata(storageHandler.getObjectMeta(importBucket, sourceName, transform))
+                        .build(),
+                    processedStream);
 
 
                 log.info("Successfully pseudonymized " + importBucket + "/"


### PR DESCRIPTION
### Features
  - write metadata on object, to help us detect that it was previously processed
  - consume object metadata and, if object was written by proxy, skip it so customers can't create loops as easily (currently, if they used a default notification rule to trigger lambdas, but put an ADDITIONAL_TRANSFORM back to the original bucket, it would loop infinitely)

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204260893379996
  - https://app.asana.com/0/0/1204260893379998