### PR TITLE
 fix connector spec ref for HRIS case

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -526,7 +526,7 @@ EOT
     }
     "hris" = {
       source_kind               = "hris"
-      worklytics_connector_id   = "bulk-import-psoxy"
+      worklytics_connector_id   = "hris-import-psoxy"
       worklytics_connector_name = "HRIS Data Import via Psoxy"
       rules = {
         columnsToRedact = []


### PR DESCRIPTION
### Fixes
  - `worklytics_connector_id` wrong for HRIS example 


### Change implications

 - dependencies added/changed? **no**
