### PR TITLE
Psoxy HRIS use-case: `parserId` as "auto filled" setting

### DIFF
--- a/infra/modules/worklytics-psoxy-connection-generic/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-generic/main.tf
@@ -13,6 +13,7 @@ locals {
     PROXY_AWS_REGION   = "AWS Psoxy Region"
     PROXY_ENDPOINT     = "Psoxy Base URL"
     PROXY_BUCKET_NAME  = "Bucket Name"
+    parserId           = "Parser"
   }
 
   query_params = [for k, v in local.autofilled_settings : "${k}=${urlencode(var.settings_to_provide[(v)])}"

--- a/infra/modules/worklytics-psoxy-connection-generic/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-generic/main.tf
@@ -7,7 +7,7 @@ locals {
 
   worklytics_add_connection_url = "https://intl.worklytics.co/analytics/connect/"
 
-  # map of Worklytics setting key --> display name
+  # map of Worklytics setting key --> display name (matches `settings_to_provide` keys)
   autofilled_settings = {
     PROXY_AWS_ROLE_ARN = "AWS Psoxy Role ARN",
     PROXY_AWS_REGION   = "AWS Psoxy Region"


### PR DESCRIPTION
### Fixes
.

### Features
- [prefill Parser, other custom settings via URL ](https://app.asana.com/0/1204206783999405/1204260047113081/f)

### Change implications

 - dependencies added/changed? **no**
