### PR TITLE
test tool install via terraform 

### DIFF
--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -136,6 +136,13 @@ module "psoxy-package" {
   force_bundle       = var.force_bundle
 }
 
+module "test_tool" {
+  source = "../psoxy-test-tool"
+
+  path_to_tools = "${var.psoxy_base_dir}tools"
+  psoxy_version = module.psoxy-package.version
+}
+
 output "secrets" {
   value = {
     PSOXY_ENCRYPTION_KEY = {

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -122,6 +122,14 @@ module "psoxy-package" {
   force_bundle       = var.force_bundle
 }
 
+# install test tool, if it exists in expected location
+module "test_tool" {
+  source = "../psoxy-test-tool"
+
+  path_to_tools = "${var.psoxy_base_dir}tools"
+  psoxy_version = module.psoxy-package.version
+}
+
 data "archive_file" "source" {
   type        = "zip"
   source_file = module.psoxy-package.path_to_deployment_jar

--- a/infra/modules/psoxy-test-tool/main.tf
+++ b/infra/modules/psoxy-test-tool/main.tf
@@ -1,0 +1,27 @@
+
+
+# installs test tool to your machine
+# (no affect if no NPM, or if test tool not at expected location)
+# conditional, as we don't want to depend on test tool
+resource "null_resource" "install_test_tool" {
+  count = fileexists("${var.path_to_tools}/install-test-tool.sh") ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "${var.path_to_tools}/install-test-tool.sh ${var.path_to_tools}"
+  }
+
+  # trigger if path or version has changed
+  triggers = {
+    path_to_psoxy_java = var.path_to_tools
+    version = var.psoxy_version
+  }
+}
+
+# expose whether test tool installed back, in case want to condition test commands on it
+output "test_tool_installed" {
+  value = fileexists("${var.path_to_tools}/psoxy-test/node_modules/.package-lock.json")
+
+  depends_on = [
+    null_resource.install_test_tool
+  ]
+}

--- a/infra/modules/psoxy-test-tool/variables.tf
+++ b/infra/modules/psoxy-test-tool/variables.tf
@@ -1,0 +1,9 @@
+variable "path_to_tools" {
+  type        = string
+  description = "relative path from working directory (from which you call this module) to java/ folder within your checkout of the Psoxy repo"
+}
+
+variable "psoxy_version" {
+  type = string
+  description = "version of psoxy"
+}

--- a/tools/init-example.sh
+++ b/tools/init-example.sh
@@ -44,19 +44,5 @@ else
   printf "${RED}Nothing to initialize. File terraform.tfvars already exists.${NC}\n\n"
 fi
 
-# Install test tool, if npm available
-
-TEST_TOOL_ROOT=${PSOXY_BASE_DIR}tools/psoxy-test
-
-if [ ! -d ${TEST_TOOL_ROOT} ]; then
-  printf "${RED}No test tool source found at ${TEST_TOOL_ROOT}. Failed to install test tool.${NC}\n"
-  exit
-fi
-
-if npm -v &> /dev/null ; then
-  printf "Installing ${BLUE}psoxy-test${NC} tool ...\n"
-  npm --no-audit --no-fund --prefix ${TEST_TOOL_ROOT} install
-else
-  printf "${RED}NPM / Node.JS not available; could not install test tool. We recommend installing Node.JS ( https://nodejs.org/ ), then re-running this init script.${NC}\n"
-fi
-
+# Install test tool
+${PSOXY_BASE_DIR}tools/install-test-tool.sh $PSOXY_BASE_DIR

--- a/tools/init-example.sh
+++ b/tools/init-example.sh
@@ -32,8 +32,9 @@ else
   cd ${TF_CONFIG_ROOT}
 fi
 
-printf "Initializing ${BLUE}terraform.tfvars${NC} file for your configuration ...\n"
 if [ ! -f terraform.tfvars ]; then
+  printf "Initializing ${BLUE}terraform.tfvars${NC} file for your configuration ...\n"
+
   TFVARS_FILE="${TF_CONFIG_ROOT}/terraform.tfvars"
 
   cp ${TF_CONFIG_ROOT}/terraform.tfvars.example $TFVARS_FILE
@@ -42,6 +43,8 @@ if [ ! -f terraform.tfvars ]; then
 else
   printf "${RED}Nothing to initialize. File terraform.tfvars already exists.${NC}\n\n"
 fi
+
+# Install test tool, if npm available
 
 TEST_TOOL_ROOT=${PSOXY_BASE_DIR}tools/psoxy-test
 
@@ -52,7 +55,6 @@ fi
 
 if npm -v &> /dev/null ; then
   printf "Installing ${BLUE}psoxy-test${NC} tool ...\n"
-  cd ${TEST_TOOL_ROOT}
   npm --no-audit --no-fund --prefix ${TEST_TOOL_ROOT} install
 else
   printf "${RED}NPM / Node.JS not available; could not install test tool. We recommend installing Node.JS ( https://nodejs.org/ ), then re-running this init script.${NC}\n"

--- a/tools/init-example.sh
+++ b/tools/init-example.sh
@@ -45,4 +45,4 @@ else
 fi
 
 # Install test tool
-${PSOXY_BASE_DIR}tools/install-test-tool.sh $PSOXY_BASE_DIR
+${PSOXY_BASE_DIR}tools/install-test-tool.sh ${PSOXY_BASE_DIR}tools

--- a/tools/install-test-tool.sh
+++ b/tools/install-test-tool.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # Install test tool, if npm available
 
-PSOXY_BASE_DIR=${1:-$(pwd)}
+PATH_TO_TOOLS=${1:-$(pwd)/tools}
 
 RED='\e[0;31m'
 GREEN='\e[0;32m'
 BLUE='\e[0;34m'
 NC='\e[0m' # No Color
 
-TEST_TOOL_ROOT=${PSOXY_BASE_DIR}tools/psoxy-test
+TEST_TOOL_ROOT=${PATH_TO_TOOLS}/psoxy-test
 
 if [ ! -d ${TEST_TOOL_ROOT} ]; then
   printf "${RED}No test tool source found at ${TEST_TOOL_ROOT}. Failed to install test tool.${NC}\n"

--- a/tools/install-test-tool.sh
+++ b/tools/install-test-tool.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Install test tool, if npm available
+
+PSOXY_BASE_DIR=${1:-$(pwd)}
+
+RED='\e[0;31m'
+GREEN='\e[0;32m'
+BLUE='\e[0;34m'
+NC='\e[0m' # No Color
+
+TEST_TOOL_ROOT=${PSOXY_BASE_DIR}tools/psoxy-test
+
+if [ ! -d ${TEST_TOOL_ROOT} ]; then
+  printf "${RED}No test tool source found at ${TEST_TOOL_ROOT}. Failed to install test tool.${NC}\n"
+  exit
+fi
+
+if npm -v &> /dev/null ; then
+  printf "Installing ${BLUE}psoxy-test${NC} tool ...\n"
+  npm --no-audit --no-fund --prefix ${TEST_TOOL_ROOT} install
+else
+  printf "${RED}NPM / Node.JS not available; could not install test tool. We recommend installing Node.JS ( https://nodejs.org/ ), then re-running this init script.${NC}\n"
+fi


### PR DESCRIPTION
### Features
  - split test tool installation out of `init-example` script
  - invoke test tool installation script from terraform

Motivation is that I noticed that, since we're now building proxy from/within a git clone made by Terraform, and `init-example` was doing the `npm install` within that git clone, IF someone updates the version of the `modular-example` that they're using (such that git clone updates) but does not `init-example` again, the test tool is not longer "installed" within the clone.

### Change implications

 - dependencies added/changed? **yes** we weren't actually dependent on the `null` terraform provider previously; users of examples will have to `terraform init -upgrade` to install it
