### PR TITLE
fix zoom token update

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -584,6 +584,8 @@ locals {
   enabled_oauth_long_access_connectors_todos = { for k, v in local.enabled_oauth_long_access_connectors : k => v if v.external_token_todo != null }
   # list of pair of [(conn1, secret1), (conn1, secret2), ... (connN, secretM)]
 
+  # NOTE: advantage of creating these, even if we expect customer to fill them manually, is that
+  # will be deleted if `terraform destroy`
   enabled_oauth_secrets_to_create = distinct(flatten([
     for k, v in local.enabled_oauth_long_access_connectors : [
       for secret_var in v.secured_variables : {

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -56,6 +56,9 @@ public class ParameterStoreConfigService implements ConfigService {
         String key = parameterName(property);
         try {
             PutParameterRequest parameterRequest = PutParameterRequest.builder()
+                //TODO: determine proper 'type' here based on ConfigProperty attribute?
+                // (as of 2023-03, we don't update any params that *aren't* secrets, so not really issue)
+                .type(ParameterType.SECURE_STRING) // in case parameter doesn't exist yet, SSM rejects PUT w/o type
                 .name(key)
                 .value(value)
                 // if property exists, which should always be created first, this flags needs to be set


### PR DESCRIPTION

### Fixes
 - zoom token update fails bc no type (in practice, no one *should* be impacted if using our default TF examples, as they all create initial value with a type; and updating existing parameter doesn't seem to fail if no type)


### Change implications

 - dependencies added/changed? **no**
