### PR TITLE
improve lookup table configs

### DIFF
--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -122,11 +122,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -151,12 +151,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string)
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -140,11 +140,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -169,12 +169,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string)
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {
@@ -184,7 +184,7 @@ variable "lookup_table_builders" {
     #        # ADD LIST OF NAMES OF YOUR AWS ROLES WHICH CAN READ LOOKUP TABLE
     #      ],
     #      rules       = {
-    #        pseudonym_format = "URL_SAFE_TOKEN"
+    #        pseudonymFormat = "URL_SAFE_TOKEN"
     #        columnsToRedact       = [
     #          "employee_email",
     #          "manager_id",

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -159,11 +159,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -189,12 +189,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -122,11 +122,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -151,12 +151,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {
@@ -166,7 +166,7 @@ variable "lookup_table_builders" {
     #        # ADD LIST OF NAMES OF YOUR AWS ROLES WHICH CAN READ LOOKUP TABLE
     #      ],
     #      rules       = {
-    #        pseudonym_format = "URL_SAFE_TOKEN"
+    #        pseudonymFormat = "URL_SAFE_TOKEN"
     #        columnsToRedact       = [
     #          "employee_email",
     #          "manager_id",

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -140,11 +140,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -169,12 +169,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {
@@ -184,7 +184,7 @@ variable "lookup_table_builders" {
     #        # ADD LIST OF NAMES OF YOUR AWS ROLES WHICH CAN READ LOOKUP TABLE
     #      ],
     #      rules       = {
-    #        pseudonym_format = "URL_SAFE_TOKEN"
+    #        pseudonymFormat = "URL_SAFE_TOKEN"
     #        columnsToRedact       = [
     #          "employee_email",
     #          "manager_id",

--- a/infra/examples/gcp-google-workspace/variables.tf
+++ b/infra/examples/gcp-google-workspace/variables.tf
@@ -102,11 +102,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -172,12 +172,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string)
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {
@@ -187,7 +187,7 @@ variable "lookup_table_builders" {
     #        # ADD LIST OF NAMES OF YOUR AWS ROLES WHICH CAN READ LOOKUP TABLE
     #      ],
     #      rules       = {
-    #        pseudonym_format = "URL_SAFE_TOKEN"
+    #        pseudonymFormat = "URL_SAFE_TOKEN"
     #        columnsToRedact       = [
     #          "employee_email",
     #          "manager_id",

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -128,11 +128,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -157,12 +157,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string)
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {
@@ -172,7 +172,7 @@ variable "lookup_table_builders" {
     #        # ADD LIST OF NAMES OF YOUR AWS ROLES WHICH CAN READ LOOKUP TABLE
     #      ],
     #      rules       = {
-    #        pseudonym_format = "URL_SAFE_TOKEN"
+    #        pseudonymFormat = "URL_SAFE_TOKEN"
     #        columnsToRedact       = [
     #          "employee_email",
     #          "manager_id",

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -131,11 +131,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))
@@ -160,12 +160,12 @@ variable "lookup_table_builders" {
     input_connector_id            = string
     sanitized_accessor_role_names = list(string)
     rules = object({
-      pseudonymFormat       = string
-      columnsToRedact       = list(string)
-      columnsToInclude      = list(string)
-      columnsToPseudonymize = list(string)
-      columnsToDuplicate    = map(string)
-      columnsToRename       = map(string)
+      pseudonymFormat       = optional(string)
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
   }))
   default = {

--- a/infra/modular-examples/gcp-google-workspace/variables.tf
+++ b/infra/modular-examples/gcp-google-workspace/variables.tf
@@ -90,11 +90,11 @@ variable "custom_bulk_connectors" {
     source_kind = string
     rules = object({
       pseudonymFormat       = optional(string)
-      columnsToRedact       = optional(list(string), [])
-      columnsToInclude      = optional(list(string), [])
-      columnsToPseudonymize = optional(list(string), [])
-      columnsToDuplicate    = optional(map(string), {})
-      columnsToRename       = optional(map(string), {})
+      columnsToRedact       = optional(list(string))
+      columnsToInclude      = optional(list(string))
+      columnsToPseudonymize = optional(list(string))
+      columnsToDuplicate    = optional(map(string))
+      columnsToRename       = optional(map(string))
     })
     settings_to_provide = optional(map(string), {})
   }))

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -102,24 +102,17 @@ variable "environment_variables" {
 
 variable "rules" {
   type = object({
-    # TODO: various fields supported by proxy, but if make explicit in Terraform variables validate
-    # will break existing invocations of this module
-
-    # pseudonymFormat       = string
-    columnsToRedact = list(string)
-    # columnsToInclude      = list(string)
-    columnsToPseudonymize = list(string)
-    # columnsToDuplicate    = map(string)
-    # columnsToRename       = map(string)
+    # NOTE: use `optional()` in variables.tf of modules that wrap this one, but omit the default
+    # value so that the one here prevails (unless should really be different for your use-case)
+    pseudonymFormat       = optional(string, "JSON") # TODO: change to URL_SAFE_TOKEN in v0.5
+    columnsToRedact       = optional(list(string), [])
+    columnsToInclude      = optional(list(string), null)
+    columnsToPseudonymize = optional(list(string), [])
+    columnsToDuplicate    = optional(map(string), {})
+    columnsToRename       = optional(map(string), {})
   })
   description = "Rules to apply to a columnar flat file during transformation"
   default = {
-    # pseudonymFormat       = "URL_SAFE_TOKEN"
-    columnsToRedact = []
-    # columnsToInclude      = null
-    columnsToPseudonymize = []
-    # columnsToDuplicate    = {}
-    # columnsToRename       = {}
   }
 }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/ConfigRulesModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ConfigRulesModule.java
@@ -57,7 +57,10 @@ public class ConfigRulesModule {
             config.getConfigPropertyAsOptional(ProxyConfigProperty.PSEUDONYMIZE_APP_IDS)
                 .map(Boolean::parseBoolean).orElse(false);
 
-        String source = config.getConfigPropertyOrError(ProxyConfigProperty.SOURCE);
+        String source = config.getConfigPropertyAsOptional(ProxyConfigProperty.SOURCE)
+            .orElseThrow( () -> new RuntimeException(
+                String.format("No source specified, so can't determine default rules. Configure '%s' or '%s' to avoid this error.",
+                    ProxyConfigProperty.SOURCE.name(), ProxyConfigProperty.RULES.name())));
 
         String rulesIdSuffix = pseudonymizeAppIds ? NO_APP_IDS_SUFFIX : "";
 

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ColumnarRules.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ColumnarRules.java
@@ -41,6 +41,8 @@ public class ColumnarRules implements BulkDataRules {
 
     /**
      * columns (fields) to duplicate
+     *
+     * NOTE: duplicates, if any, are applied BEFORE pseudonymization
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY) //this works ...
     @Builder.Default
@@ -49,9 +51,10 @@ public class ColumnarRules implements BulkDataRules {
 
 
     //if we encode these as URL_SAFE_TOKEN, but not reversible then encoder won'd prefix with 'p~'
-    // and then not easy to tell difference bw pseudonym and the original  employee_id value (but maybe we don't care ...)
+    // and then not easy to tell difference bw pseudonym and the original employee_id value (but maybe we don't care ...)
     @Builder.Default
-    protected PseudonymEncoder.Implementations pseudonymFormat = PseudonymEncoder.Implementations.JSON;
+    protected PseudonymEncoder.Implementations pseudonymFormat =
+        PseudonymEncoder.Implementations.JSON;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @NonNull


### PR DESCRIPTION
### Fixes
 - expose all rules properties for bulk cases, so can be configured (if omit from schema, recent versions of terraform omit the properties when passing object down to bulk module, so properties never set)

### Features
  - make more rules stuff optional throughout stack


### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204283878498527