### PR TITLE
JSON filter 2

### DIFF
--- a/docs/json-filter.md
+++ b/docs/json-filter.md
@@ -1,0 +1,28 @@
+# JSON Filter
+
+JSON Filter is inspired by [JSON Schema](https://json-schema.org/), but with the goal to **filter**
+documents rather than **validate**.  As such, the basic idea is that data nodes that do not match
+the filter schema are removed, rather than the whole document failing validation.
+
+The goal of JsonFilter is that only data elements specified in the filter pass through.
+
+Some differences:
+   - `required` properties are ignored.  While in JSON schema, an object that was missing a
+     "required" property is invalid, objects missing "required" properties in a filter will be
+      preserved.
+   -  `{ }` , eg, a schema without a type, is interpreted as any valid leaf node (eg, unconstrained
+      leaf; everything that's not 'array' or 'object') - rather than any valid JSON.
+
+Compatibility goals:
+  - a valid JSON Schema is convertible to valid JSON filter (with JSON schema features not supported
+    by JSON filter ignored)
+
+
+## Motivations
+
+### `{ }` as "any valid leaf node"
+
+  1. compactness, esp when encoding filter as YAML.  can put `{ }` instead of `{ "type": "string" }`
+  2. flexibility; for filtering use-case, often you just care about which properties are/aren't
+     passed, rather than 'string' vs 'number' vs 'integer'
+  3. "any valid JSON" is more common use case in validation than in filtering.

--- a/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
@@ -7,7 +7,7 @@ import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrateg
 import co.worklytics.psoxy.storage.BulkDataSanitizerFactory;
 import co.worklytics.psoxy.storage.impl.BulkDataSanitizerFactoryImpl;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
-import com.avaulta.gateway.rules.SchemaRuleUtils;
+import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
 import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
@@ -160,13 +160,13 @@ public class PsoxyModule {
 
 
     @Provides @Singleton
-    SchemaRuleUtils schemaRuleUtils() {
+    JsonSchemaFilterUtils schemaRuleUtils() {
         ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper);
 
-        return new SchemaRuleUtils(objectMapper, jsonSchemaGenerator);
+        return new JsonSchemaFilterUtils(objectMapper, jsonSchemaGenerator);
     }
 
     @Provides

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -95,7 +95,9 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     JsonSchemaFilterUtils.JsonSchemaFilter getRootDefinitions() {
         if (rootDefinitions == null) {
             synchronized ($writeLock) {
-                rootDefinitions = JsonSchemaFilterUtils.JsonSchemaFilter.builder().definitions(rules.getDefinitions()).build();
+  if (rootDefinitions == null) {
+          rootDefinitions = JsonSchemaFilterUtils.JsonSchemaFilter.builder().definitions(rules.getDefinitions()).build();
+  }
             }
         }
         return rootDefinitions;

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -3,11 +3,11 @@ package co.worklytics.psoxy.impl;
 import co.worklytics.psoxy.*;
 import co.worklytics.psoxy.rules.RESTRules;
 import com.avaulta.gateway.rules.Endpoint;
+import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 import com.avaulta.gateway.rules.transforms.Transform;
 import co.worklytics.psoxy.utils.URLUtils;
 import com.avaulta.gateway.pseudonyms.*;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
-import com.avaulta.gateway.rules.SchemaRuleUtils;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -58,7 +58,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     List<Pair<Pattern, Endpoint>> compiledEndpointRules;
     Map<Transform, List<JsonPath>> compiledTransforms = new ConcurrentHashMap<>();
 
-    SchemaRuleUtils.JsonSchemaFilter rootDefinitions;
+    JsonSchemaFilterUtils.JsonSchemaFilter rootDefinitions;
 
 
     @AssistedInject
@@ -79,7 +79,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
 
 
     @Inject
-    SchemaRuleUtils schemaRuleUtils;
+    JsonSchemaFilterUtils jsonSchemaFilterUtils;
 
     Map<Endpoint, Pattern> getCompiledAllowedEndpoints() {
         if (compiledAllowedEndpoints == null) {
@@ -92,10 +92,10 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
         return compiledAllowedEndpoints;
     }
 
-    SchemaRuleUtils.JsonSchemaFilter getRootDefinitions() {
+    JsonSchemaFilterUtils.JsonSchemaFilter getRootDefinitions() {
         if (rootDefinitions == null) {
             synchronized ($writeLock) {
-                rootDefinitions = SchemaRuleUtils.JsonSchemaFilter.builder().definitions(rules.getDefinitions()).build();
+                rootDefinitions = JsonSchemaFilterUtils.JsonSchemaFilter.builder().definitions(rules.getDefinitions()).build();
             }
         }
         return rootDefinitions;
@@ -163,7 +163,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
                 .map(schema -> {
                     //q: this read
                     try {
-                        return schemaRuleUtils.filterJsonBySchema(jsonResponse, schema, getRootDefinitions());
+                        return jsonSchemaFilterUtils.filterJsonBySchema(jsonResponse, schema, getRootDefinitions());
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/RESTRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/RESTRules.java
@@ -1,7 +1,7 @@
 package co.worklytics.psoxy.rules;
 
 import com.avaulta.gateway.rules.Endpoint;
-import com.avaulta.gateway.rules.SchemaRuleUtils;
+import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 
 import java.io.Serializable;
 import java.util.List;
@@ -17,7 +17,7 @@ public interface RESTRules extends RuleSet, Serializable {
     /**
      * root definitions, to be in scope across all endpoints
      */
-    Map<String, SchemaRuleUtils.JsonSchemaFilter> getDefinitions();
+    Map<String, JsonSchemaFilterUtils.JsonSchemaFilter> getDefinitions();
 
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/Rules2.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/Rules2.java
@@ -2,14 +2,13 @@ package co.worklytics.psoxy.rules;
 
 
 import com.avaulta.gateway.rules.Endpoint;
-import com.avaulta.gateway.rules.SchemaRuleUtils;
+import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 import com.avaulta.gateway.rules.transforms.Transform;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
 import lombok.extern.java.Log;
 
-import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,7 +45,7 @@ public class Rules2 implements RESTRules {
 
 
 
-    Map<String, SchemaRuleUtils.JsonSchemaFilter> definitions;
+    Map<String, JsonSchemaFilterUtils.JsonSchemaFilter> definitions;
 
 
     /**

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/salesforce/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/salesforce/PrebuiltSanitizerRules.java
@@ -4,7 +4,7 @@ import co.worklytics.psoxy.rules.RESTRules;
 import co.worklytics.psoxy.rules.Rules2;
 import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
 import com.avaulta.gateway.rules.Endpoint;
-import com.avaulta.gateway.rules.SchemaRuleUtils;
+import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 import com.avaulta.gateway.rules.transforms.Transform;
 import com.google.common.collect.Lists;
 
@@ -48,92 +48,92 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..records[*].Id")
                     .build());
 
-    private final static SchemaRuleUtils.JsonSchemaFilter ID_QUERY_RESULT_JSON_SCHEMA = SchemaRuleUtils.JsonSchemaFilter.builder()
+    private final static JsonSchemaFilterUtils.JsonSchemaFilter ID_QUERY_RESULT_JSON_SCHEMA = JsonSchemaFilterUtils.JsonSchemaFilter.builder()
             .type("object")
             .properties(Map.of(
-                    "Id", SchemaRuleUtils.JsonSchemaFilter.builder()
+                    "Id", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("string")
                             .build()))
             .build();
 
-    private final static SchemaRuleUtils.JsonSchemaFilter USER_BY_QUERY_RESULT_JSON_SCHEMA = SchemaRuleUtils.JsonSchemaFilter.builder()
+    private final static JsonSchemaFilterUtils.JsonSchemaFilter USER_BY_QUERY_RESULT_JSON_SCHEMA = JsonSchemaFilterUtils.JsonSchemaFilter.builder()
             .type("object")
             .properties(new LinkedHashMap<>() {{
-                            put("Alias", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("AccountId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("ContactId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("CreatedDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("CreatedById", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("Email", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("EmailEncodingKey", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("Id", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("IsActive", SchemaRuleUtils.JsonSchemaFilter.builder().type("boolean").build());
-                            put("LastLoginDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("LastModifiedDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("ManagerId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("Name", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("TimeZoneSidKey", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("Username", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("UserRoleId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                            put("UserType", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("Alias", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("AccountId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("ContactId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("CreatedDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("CreatedById", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("Email", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("EmailEncodingKey", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("Id", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("IsActive", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("boolean").build());
+                            put("LastLoginDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("LastModifiedDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("ManagerId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("Name", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("TimeZoneSidKey", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("Username", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("UserRoleId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                            put("UserType", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
                         }}
             )
             .build();
 
-    private final static SchemaRuleUtils.JsonSchemaFilter ACTIVITY_HISTORIES_QUERY_RESULT_SCHEMA = SchemaRuleUtils.JsonSchemaFilter.builder()
+    private final static JsonSchemaFilterUtils.JsonSchemaFilter ACTIVITY_HISTORIES_QUERY_RESULT_SCHEMA = JsonSchemaFilterUtils.JsonSchemaFilter.builder()
             .type("object")
             .properties(Map.of(
-                    "ActivityHistories", jsonSchemaForQueryResult(SchemaRuleUtils.JsonSchemaFilter.builder()
+                    "ActivityHistories", jsonSchemaForQueryResult(JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("object")
                             .properties(new LinkedHashMap<>() {
                                 {
-                                    put("AccountId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("ActivityDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("ActivityDateTime", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("ActivitySubtype", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("ActivityType", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("CallDurationInSeconds", SchemaRuleUtils.JsonSchemaFilter.builder().type("integer").build());
-                                    put("CallType", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("CreatedDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("CreatedById", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("DurationInMinutes", SchemaRuleUtils.JsonSchemaFilter.builder().type("integer").build());
-                                    put("EndDateTime", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("Id", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("IsAllDayEvent", SchemaRuleUtils.JsonSchemaFilter.builder().type("boolean").build());
-                                    put("IsDeleted", SchemaRuleUtils.JsonSchemaFilter.builder().type("boolean").build());
-                                    put("IsHighPriority", SchemaRuleUtils.JsonSchemaFilter.builder().type("boolean").build());
-                                    put("IsTask", SchemaRuleUtils.JsonSchemaFilter.builder().type("boolean").build());
-                                    put("LastModifiedDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("LastModifiedById", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("OwnerId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("Priority", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("StartDateTime", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("Status", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("WhatId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                                    put("WhoId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("AccountId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("ActivityDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("ActivityDateTime", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("ActivitySubtype", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("ActivityType", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("CallDurationInSeconds", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("integer").build());
+                                    put("CallType", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("CreatedDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("CreatedById", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("DurationInMinutes", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("integer").build());
+                                    put("EndDateTime", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("Id", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("IsAllDayEvent", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("boolean").build());
+                                    put("IsDeleted", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("boolean").build());
+                                    put("IsHighPriority", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("boolean").build());
+                                    put("IsTask", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("boolean").build());
+                                    put("LastModifiedDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("LastModifiedById", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("OwnerId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("Priority", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("StartDateTime", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("Status", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("WhatId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                                    put("WhoId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
                                 }
                             })
                             .build())))
             .build();
 
-    private final static SchemaRuleUtils.JsonSchemaFilter ACCOUNT_QUERY_RESULT_SCHEMA = SchemaRuleUtils.JsonSchemaFilter.builder()
+    private final static JsonSchemaFilterUtils.JsonSchemaFilter ACCOUNT_QUERY_RESULT_SCHEMA = JsonSchemaFilterUtils.JsonSchemaFilter.builder()
             .type("object")
             .properties(new LinkedHashMap<>() {{
-                put("Id", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("AnnualRevenue", SchemaRuleUtils.JsonSchemaFilter.builder().type("number").build());
-                put("CreatedDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("CreatedById", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("IsDeleted", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("LastActivityDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("LastModifiedDate", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("LastModifiedById", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("NumberOfEmployees", SchemaRuleUtils.JsonSchemaFilter.builder().type("integer").build());
-                put("OwnerId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("Ownership", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("ParentId", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("Rating", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("Sic", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
-                put("Type", SchemaRuleUtils.JsonSchemaFilter.builder().type("string").build());
+                put("Id", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("AnnualRevenue", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("number").build());
+                put("CreatedDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("CreatedById", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("IsDeleted", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("LastActivityDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("LastModifiedDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("LastModifiedById", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("NumberOfEmployees", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("integer").build());
+                put("OwnerId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("Ownership", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("ParentId", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("Rating", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("Sic", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
+                put("Type", JsonSchemaFilterUtils.JsonSchemaFilter.builder().type("string").build());
             }})
             .build();
 
@@ -226,22 +226,22 @@ public class PrebuiltSanitizerRules {
             .endpoint(QUERY_FOR_ACTIVITY_HISTORIES_ENDPOINT)
             .build();
 
-    private static SchemaRuleUtils.JsonSchemaFilter jsonSchemaForQueryResult(SchemaRuleUtils.JsonSchemaFilter recordSchema) {
-        return SchemaRuleUtils.JsonSchemaFilter.builder()
+    private static JsonSchemaFilterUtils.JsonSchemaFilter jsonSchemaForQueryResult(JsonSchemaFilterUtils.JsonSchemaFilter recordSchema) {
+        return JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                 .type("object")
                 // Using LinkedHashMap to keep the order to support same
                 // YAML serialization result
                 .properties(new LinkedHashMap<>() {{
-                    put("totalSize", SchemaRuleUtils.JsonSchemaFilter.builder()
+                    put("totalSize", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("integer")
                             .build());
-                    put("done", SchemaRuleUtils.JsonSchemaFilter.builder()
+                    put("done", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("boolean")
                             .build());
-                    put("nextRecordsUrl", SchemaRuleUtils.JsonSchemaFilter.builder()
+                    put("nextRecordsUrl", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("string")
                             .build());
-                    put("records", SchemaRuleUtils.JsonSchemaFilter.builder()
+                    put("records", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("array")
                             .items(recordSchema)
                             .build());

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -5,12 +5,12 @@ import co.worklytics.psoxy.gateway.ConfigService;
 import com.avaulta.gateway.rules.Endpoint;
 import co.worklytics.psoxy.rules.PrebuiltSanitizerRules;
 import co.worklytics.psoxy.rules.Rules2;
+import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 import com.avaulta.gateway.rules.transforms.Transform;
 import co.worklytics.test.MockModules;
 import co.worklytics.test.TestUtils;
 import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
-import com.avaulta.gateway.rules.SchemaRuleUtils;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
@@ -49,7 +49,7 @@ class RESTApiSanitizerImplTest {
     protected UrlSafeTokenPseudonymEncoder pseudonymEncoder;
 
     @Inject
-    protected SchemaRuleUtils schemaRuleUtils;
+    protected JsonSchemaFilterUtils jsonSchemaFilterUtils;
 
     @Inject
     protected PseudonymizerImplFactory pseudonymizerImplFactory;
@@ -328,47 +328,47 @@ class RESTApiSanitizerImplTest {
 
         assertTrue(sanitized.contains("historyId"));
 
-        SchemaRuleUtils.JsonSchemaFilter jsonSchemaFilter = SchemaRuleUtils.JsonSchemaFilter.builder()
+        JsonSchemaFilterUtils.JsonSchemaFilter jsonSchemaFilter = JsonSchemaFilterUtils.JsonSchemaFilter.builder()
             .type("object")
-            .properties(Map.<String, SchemaRuleUtils.JsonSchemaFilter>of(
-                "id", SchemaRuleUtils.JsonSchemaFilter.builder()
+            .properties(Map.<String, JsonSchemaFilterUtils.JsonSchemaFilter>of(
+                "id", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                     .type("string")
                     .build(),
-                "threadId", SchemaRuleUtils.JsonSchemaFilter.builder()
+                "threadId", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                     .type("string")
                     .build(),
-                "labelIds", SchemaRuleUtils.JsonSchemaFilter.builder()
+                "labelIds", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                     .type("array")
-                    .items(SchemaRuleUtils.JsonSchemaFilter.builder()
+                    .items(JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                         .type("string")
                         .build())
                     .build(),
-                "payload", SchemaRuleUtils.JsonSchemaFilter.builder()
+                "payload", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                     .type("object")
-                    .properties(Map.<String, SchemaRuleUtils.JsonSchemaFilter>of(
-                        "headers", SchemaRuleUtils.JsonSchemaFilter.builder()
+                    .properties(Map.<String, JsonSchemaFilterUtils.JsonSchemaFilter>of(
+                        "headers", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("array")
-                            .items(SchemaRuleUtils.JsonSchemaFilter.builder()
+                            .items(JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                                 .type("object")
-                                .properties(Map.<String, SchemaRuleUtils.JsonSchemaFilter>of(
-                                    "name", SchemaRuleUtils.JsonSchemaFilter.builder()
+                                .properties(Map.<String, JsonSchemaFilterUtils.JsonSchemaFilter>of(
+                                    "name", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                                         .type("string")
                                         .build(),
-                                    "value", SchemaRuleUtils.JsonSchemaFilter.builder()
+                                    "value", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                                         .type("string")
                                         .build()
                                 ))
                                 .build())
                             .build(),
-                        "partId", SchemaRuleUtils.JsonSchemaFilter.builder()
+                        "partId", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                             .type("string")
                             .build()
                     ))
                     .build(),
-                "sizeEstimate", SchemaRuleUtils.JsonSchemaFilter.builder()
+                "sizeEstimate", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                     .type("integer")
                     .build(),
-                "internalDate", SchemaRuleUtils.JsonSchemaFilter.builder()
+                "internalDate", JsonSchemaFilterUtils.JsonSchemaFilter.builder()
                     .type("string")
                     .build()
                 ))

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
@@ -43,10 +43,10 @@ public class Endpoint {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    SchemaRuleUtils.JsonSchemaFilter responseSchema;
+    JsonSchemaFilterUtils.JsonSchemaFilter responseSchema;
 
     @JsonIgnore
-    public Optional<SchemaRuleUtils.JsonSchemaFilter> getResponseSchemaOptional() {
+    public Optional<JsonSchemaFilterUtils.JsonSchemaFilter> getResponseSchemaOptional() {
         return Optional.ofNullable(responseSchema);
     }
 

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -10,7 +10,7 @@ import java.util.*;
 
 @NoArgsConstructor(access = AccessLevel.PACKAGE) //for tests
 @AllArgsConstructor
-public class SchemaRuleUtils {
+public class JsonSchemaFilterUtils {
 
     ObjectMapper objectMapper;
     JsonSchemaGenerator jsonSchemaGenerator;
@@ -26,7 +26,7 @@ public class SchemaRuleUtils {
      * @param clazz
      * @return
      */
-    public JsonSchemaFilter generateJsonSchema(Class<?> clazz) {
+    public JsonSchemaFilter generateJsonSchemaFilter(Class<?> clazz) {
         JsonNode schema = jsonSchemaGenerator.generateJsonSchema(clazz);
         return objectMapper.convertValue(schema, JsonSchemaFilter.class);
     }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -231,22 +231,20 @@ public class JsonSchemaFilterUtils {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonIgnoreProperties({
         "title",
-        "required" // not relevant to 'filter' use case
+        "required", // not relevant to 'filter' use case
+        "additionalProperties", // not currently supported
+        "$schema", // not helpful in filter use-case, although maybe should include in future
     })
     public static class JsonSchemaFilter {
 
-        //q: should we drop this? only makes sense at root of schema
-        @JsonProperty("$schema")
-        String schema;
+        //dropped for now
+        //@JsonProperty("$schema")
+        //String schema;
 
         String type;
 
         @JsonProperty("$ref")
         String ref;
-
-        //only applicable if type==object
-        Boolean additionalProperties;
-
 
         //only applicable if type==String
         String format;

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -55,12 +55,21 @@ public class JsonSchemaFilterUtils {
      */
     void compact(JsonSchemaFilter filter) {
         if (filter.isArray()) {
-            compact(filter.getItems());
+            if (filter.getItems() != null) {
+                compact(filter.getItems());
+                filter.setType(null); // existence of items implies type=array
+            }
         } else if (filter.isObject()) {
-            filter.getProperties().forEach((k, v) -> compact(v));
+            if (filter.getProperties() != null) {
+                filter.getProperties().forEach((k, v) -> compact(v));
+                filter.setType(null); // existence of properties implies type=object
+            }
         } else if (filter.hasType()) { // as non-complex type
             filter.setType(null);
         }
+
+        // TODO: we could omit type=array / type=object if there are properties/items defined, as
+        // existence of those properties implies the type
 
         // also compact any definitions
         if (filter.getDefinitions() != null) {
@@ -312,12 +321,12 @@ public class JsonSchemaFilterUtils {
 
         @JsonIgnore
         public boolean isObject() {
-            return Objects.equals(type, "object");
+            return Objects.equals(type, "object") || (type == null && properties != null);
         }
 
         @JsonIgnore
         public boolean isArray() {
-            return Objects.equals(type, "array");
+            return Objects.equals(type, "array") || (type == null && items != null);
         }
 
         @JsonIgnore

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -205,6 +205,15 @@ class JsonSchemaFilterUtilsTest {
 
         assertEquals(ComplexPojo.EXPECTED_COMPACT_SCHEMA,
             objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(compactCopy));
+
+        // just to illustrate - compaction gave us ~25% reduction in size (pretty-printed)
+        assertEquals(604, ComplexPojo.EXPECTED_SCHEMA.length());
+        assertEquals(440, ComplexPojo.EXPECTED_COMPACT_SCHEMA.length());
+
+        // and 30% reduction in yaml size
+        assertEquals(404, yamlMapper.writeValueAsString(schemaWithRefs).length());
+        assertEquals(286, yamlMapper.writeValueAsString(compactCopy).length());
+
     }
 
     @Builder
@@ -244,13 +253,11 @@ class JsonSchemaFilterUtilsTest {
             "  }\n" +
             "}";
         public static final String EXPECTED_COMPACT_SCHEMA = "{\n" +
-            "  \"type\" : \"object\",\n" +
             "  \"properties\" : {\n" +
             "    \"simplePojo\" : {\n" +
             "      \"$ref\" : \"#/definitions/SimplePojo\"\n" +
             "    },\n" +
             "    \"additionalSimplePojos\" : {\n" +
-            "      \"type\" : \"array\",\n" +
             "      \"items\" : {\n" +
             "        \"$ref\" : \"#/definitions/SimplePojo\"\n" +
             "      }\n" +
@@ -258,7 +265,6 @@ class JsonSchemaFilterUtilsTest {
             "  },\n" +
             "  \"definitions\" : {\n" +
             "    \"SimplePojo\" : {\n" +
-            "      \"type\" : \"object\",\n" +
             "      \"properties\" : {\n" +
             "        \"someString\" : { },\n" +
             "        \"date\" : {\n" +

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Singular;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -79,7 +80,7 @@ class JsonSchemaFilterUtilsTest {
             .someListItem("list-item-1")
             .build();
 
-        Object filteredToSimplePlus = jsonSchemaFilterUtils.filterObjectBySchema(simplePlus,
+        Pair<Object, List<String>> filteredToSimplePlus = jsonSchemaFilterUtils.filterObjectBySchema(simplePlus,
             jsonSchemaFilterUtils.generateJsonSchemaFilter(SimplePojoPlus.class));
 
 
@@ -89,10 +90,10 @@ class JsonSchemaFilterUtilsTest {
                 "  \"someListItems\" : [ \"list-item-1\" ],\n" +
                 "  \"timestamp\" : \"2023-01-16T05:12:34Z\"\n" +
                 "}",
-            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(filteredToSimplePlus));
+            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(filteredToSimplePlus.getLeft()));
 
 
-        Object filteredToSimple = jsonSchemaFilterUtils.filterObjectBySchema(simplePlus,
+        Pair<Object, List<String>> filteredToSimple = jsonSchemaFilterUtils.filterObjectBySchema(simplePlus,
             jsonSchemaFilterUtils.generateJsonSchemaFilter(SimplePojo.class));
 
         assertEquals("{\n" +
@@ -100,7 +101,10 @@ class JsonSchemaFilterUtilsTest {
                 "  \"someString\" : \"some-string\",\n" +
                 "  \"timestamp\" : \"2023-01-16T05:12:34Z\"\n" +
                 "}",
-            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(filteredToSimple));
+            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(filteredToSimple.getLeft()));
+
+        assertEquals(1, filteredToSimple.getRight().size());
+        assertEquals("$.someListItems", filteredToSimple.getRight().get(0));
 
     }
 
@@ -192,7 +196,7 @@ class JsonSchemaFilterUtilsTest {
             objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonSchemaFilterUtils.filterObjectBySchema(ComplexPojoPlus.builder()
                 .simplePojo(simplePlus)
                 .additionalSimplePojo(simplePlus)
-                .build(), schemaWithRefs)));
+                .build(), schemaWithRefs).getLeft()));
 
     }
 

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -21,15 +21,15 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class SchemaRuleUtilsTest {
+class JsonSchemaFilterUtilsTest {
 
-    SchemaRuleUtils schemaRuleUtils;
+    JsonSchemaFilterUtils jsonSchemaFilterUtils;
     ObjectMapper objectMapper;
     ObjectMapper yamlMapper;
 
     @BeforeEach
     void setup() {
-        schemaRuleUtils = new SchemaRuleUtils();
+        jsonSchemaFilterUtils = new JsonSchemaFilterUtils();
 
         objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
@@ -39,8 +39,8 @@ class SchemaRuleUtilsTest {
             .registerModule(new JavaTimeModule())
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
-        schemaRuleUtils.objectMapper = objectMapper;
-        schemaRuleUtils.jsonSchemaGenerator = new JsonSchemaGenerator(schemaRuleUtils.objectMapper,
+        jsonSchemaFilterUtils.objectMapper = objectMapper;
+        jsonSchemaFilterUtils.jsonSchemaGenerator = new JsonSchemaGenerator(jsonSchemaFilterUtils.objectMapper,
             JsonSchemaConfig
                 //.nullableJsonSchemaDraft4() // uses oneOf [ { type: null }, ... ] everywhere, which is verbose
                 .vanillaJsonSchemaDraft4()
@@ -52,7 +52,7 @@ class SchemaRuleUtilsTest {
     @SneakyThrows
     @Test
     void generateJsonSchema() {
-        SchemaRuleUtils.JsonSchemaFilter jsonSchemaFilter = schemaRuleUtils.generateJsonSchema(SimplePojo.class);
+        JsonSchemaFilterUtils.JsonSchemaFilter jsonSchemaFilter = jsonSchemaFilterUtils.generateJsonSchemaFilter(SimplePojo.class);
 
         String jsonSchemaAsString = objectMapper
             .writerWithDefaultPrettyPrinter()
@@ -79,8 +79,8 @@ class SchemaRuleUtilsTest {
             .someListItem("list-item-1")
             .build();
 
-        Object filteredToSimplePlus = schemaRuleUtils.filterObjectBySchema(simplePlus,
-            schemaRuleUtils.generateJsonSchema(SimplePojoPlus.class));
+        Object filteredToSimplePlus = jsonSchemaFilterUtils.filterObjectBySchema(simplePlus,
+            jsonSchemaFilterUtils.generateJsonSchemaFilter(SimplePojoPlus.class));
 
 
         assertEquals("{\n" +
@@ -92,8 +92,8 @@ class SchemaRuleUtilsTest {
             objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(filteredToSimplePlus));
 
 
-        Object filteredToSimple = schemaRuleUtils.filterObjectBySchema(simplePlus,
-            schemaRuleUtils.generateJsonSchema(SimplePojo.class));
+        Object filteredToSimple = jsonSchemaFilterUtils.filterObjectBySchema(simplePlus,
+            jsonSchemaFilterUtils.generateJsonSchemaFilter(SimplePojo.class));
 
         assertEquals("{\n" +
                 "  \"date\" : \"2023-01-16\",\n" +
@@ -167,8 +167,8 @@ class SchemaRuleUtilsTest {
     @Test
     void filterBySchema_refs() {
 
-        SchemaRuleUtils.JsonSchemaFilter schemaWithRefs =
-            schemaRuleUtils.generateJsonSchema(ComplexPojo.class);
+        JsonSchemaFilterUtils.JsonSchemaFilter schemaWithRefs =
+            jsonSchemaFilterUtils.generateJsonSchemaFilter(ComplexPojo.class);
 
         SimplePojoPlus simplePlus = SimplePojoPlus.builder()
             .someString("some-string")
@@ -193,7 +193,7 @@ class SchemaRuleUtilsTest {
                 "    \"timestamp\" : \"2023-01-16T05:12:34Z\"\n" +
                 "  }\n" +
                 "}",
-            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(schemaRuleUtils.filterObjectBySchema(ComplexPojoPlus.builder()
+            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonSchemaFilterUtils.filterObjectBySchema(ComplexPojoPlus.builder()
                 .simplePojo(simplePlus)
                 .additionalSimplePojo(simplePlus)
                 .build(), schemaWithRefs)));

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -200,11 +200,57 @@ class JsonSchemaFilterUtilsTest {
 
     }
 
+    @SneakyThrows
+    @Test
+    public void compactCopy() {
+        JsonSchemaFilterUtils.JsonSchemaFilter schemaWithRefs =
+            jsonSchemaFilterUtils.generateJsonSchemaFilter(ComplexPojo.class);
+        JsonSchemaFilterUtils.JsonSchemaFilter compactCopy = jsonSchemaFilterUtils.compactCopy(schemaWithRefs);
+
+        assertEquals(ComplexPojo.EXPECTED_COMPACT_SCHEMA,
+            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(compactCopy));
+    }
+
     @Builder
     @Data
     static class ComplexPojo {
 
         public static final String EXPECTED_SCHEMA = "{\n" +
+            "  \"$schema\" : \"http://json-schema.org/draft/2019-09/schema#\",\n" +
+            "  \"type\" : \"object\",\n" +
+            "  \"additionalProperties\" : false,\n" +
+            "  \"properties\" : {\n" +
+            "    \"simplePojo\" : {\n" +
+            "      \"$ref\" : \"#/definitions/SimplePojo\"\n" +
+            "    },\n" +
+            "    \"additionalSimplePojos\" : {\n" +
+            "      \"type\" : \"array\",\n" +
+            "      \"items\" : {\n" +
+            "        \"$ref\" : \"#/definitions/SimplePojo\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"definitions\" : {\n" +
+            "    \"SimplePojo\" : {\n" +
+            "      \"type\" : \"object\",\n" +
+            "      \"additionalProperties\" : false,\n" +
+            "      \"properties\" : {\n" +
+            "        \"someString\" : {\n" +
+            "          \"type\" : \"string\"\n" +
+            "        },\n" +
+            "        \"date\" : {\n" +
+            "          \"type\" : \"string\",\n" +
+            "          \"format\" : \"date\"\n" +
+            "        },\n" +
+            "        \"timestamp\" : {\n" +
+            "          \"type\" : \"string\",\n" +
+            "          \"format\" : \"date-time\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+        public static final String EXPECTED_COMPACT_SCHEMA = "{\n" +
             "  \"$schema\" : \"http://json-schema.org/draft/2019-09/schema#\",\n" +
             "  \"type\" : \"object\",\n" +
             "  \"additionalProperties\" : false,\n" +

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -206,14 +206,16 @@ class JsonSchemaFilterUtilsTest {
         assertEquals(ComplexPojo.EXPECTED_COMPACT_SCHEMA,
             objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(compactCopy));
 
-        // just to illustrate - compaction gave us ~25% reduction in size (pretty-printed)
-        assertEquals(604, ComplexPojo.EXPECTED_SCHEMA.length());
-        assertEquals(440, ComplexPojo.EXPECTED_COMPACT_SCHEMA.length());
-
-        // and 30% reduction in yaml size
+        // 30% reduction in yaml size
         assertEquals(404, yamlMapper.writeValueAsString(schemaWithRefs).length());
         assertEquals(286, yamlMapper.writeValueAsString(compactCopy).length());
 
+        // non-pretty JSON is actually more compact than the yaml (pretty JSON is a lot less compact)
+        // (so if going to give up on human readability by base64gzip'ing the schema, might as well
+        //  do that with the JSON)
+        // eg, https://developer.hashicorp.com/terraform/language/functions/base64gzip
+        assertEquals(351, objectMapper.writeValueAsString(schemaWithRefs).length());
+        assertEquals(257, objectMapper.writeValueAsString(compactCopy).length());
     }
 
     @Builder

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -129,9 +129,7 @@ class JsonSchemaFilterUtilsTest {
         Instant timestamp;
 
         static final String EXPECTED_SCHEMA = "{\n" +
-            "  \"$schema\" : \"http://json-schema.org/draft/2019-09/schema#\",\n" +
             "  \"type\" : \"object\",\n" +
-            "  \"additionalProperties\" : false,\n" +
             "  \"properties\" : {\n" +
             "    \"someString\" : {\n" +
             "      \"type\" : \"string\"\n" +
@@ -148,9 +146,7 @@ class JsonSchemaFilterUtilsTest {
             "}";
 
         static final String EXPECTED_SCHEMA_YAML = "---\n" +
-            "$schema: \"http://json-schema.org/draft/2019-09/schema#\"\n" +
             "type: \"object\"\n" +
-            "additionalProperties: false\n" +
             "properties:\n" +
             "  someString:\n" +
             "    type: \"string\"\n" +
@@ -216,9 +212,7 @@ class JsonSchemaFilterUtilsTest {
     static class ComplexPojo {
 
         public static final String EXPECTED_SCHEMA = "{\n" +
-            "  \"$schema\" : \"http://json-schema.org/draft/2019-09/schema#\",\n" +
             "  \"type\" : \"object\",\n" +
-            "  \"additionalProperties\" : false,\n" +
             "  \"properties\" : {\n" +
             "    \"simplePojo\" : {\n" +
             "      \"$ref\" : \"#/definitions/SimplePojo\"\n" +
@@ -233,7 +227,6 @@ class JsonSchemaFilterUtilsTest {
             "  \"definitions\" : {\n" +
             "    \"SimplePojo\" : {\n" +
             "      \"type\" : \"object\",\n" +
-            "      \"additionalProperties\" : false,\n" +
             "      \"properties\" : {\n" +
             "        \"someString\" : {\n" +
             "          \"type\" : \"string\"\n" +
@@ -251,9 +244,7 @@ class JsonSchemaFilterUtilsTest {
             "  }\n" +
             "}";
         public static final String EXPECTED_COMPACT_SCHEMA = "{\n" +
-            "  \"$schema\" : \"http://json-schema.org/draft/2019-09/schema#\",\n" +
             "  \"type\" : \"object\",\n" +
-            "  \"additionalProperties\" : false,\n" +
             "  \"properties\" : {\n" +
             "    \"simplePojo\" : {\n" +
             "      \"$ref\" : \"#/definitions/SimplePojo\"\n" +
@@ -268,17 +259,12 @@ class JsonSchemaFilterUtilsTest {
             "  \"definitions\" : {\n" +
             "    \"SimplePojo\" : {\n" +
             "      \"type\" : \"object\",\n" +
-            "      \"additionalProperties\" : false,\n" +
             "      \"properties\" : {\n" +
-            "        \"someString\" : {\n" +
-            "          \"type\" : \"string\"\n" +
-            "        },\n" +
+            "        \"someString\" : { },\n" +
             "        \"date\" : {\n" +
-            "          \"type\" : \"string\",\n" +
             "          \"format\" : \"date\"\n" +
             "        },\n" +
             "        \"timestamp\" : {\n" +
-            "          \"type\" : \"string\",\n" +
             "          \"format\" : \"date-time\"\n" +
             "        }\n" +
             "      }\n" +


### PR DESCRIPTION
### Features
 - omit `type` field from schema filters
 - omit `type: array`/`type: object` where implicit
 - omit `additionalProperties`; ignored anyways

(general goal here is to improve human readability while also shrinking size to keep RULES under SSM size limits)

### Change implications

 - dependencies added/changed? **no**