### PR TITLE
custom REST rules, longer size, more features for rule building 

### DIFF
--- a/infra/examples-dev/.gitignore
+++ b/infra/examples-dev/.gitignore
@@ -1,0 +1,21 @@
+
+# ignore any rules files used in examples
+# ignore terraform variables / state for examples
+# NOTE: for prod use, you likely want to remove this and commit this file
+*/terraform.tfvars
+
+# NOTE: for prod use, you likely want to remove this and commit these file
+*/*.yaml
+
+# cache of Terraform providers/modules retrieved from remote sources
+# no need to commit this
+# (NOTE: this is redundant with the .gitignore in each example's directory)
+*/.terraform/**
+
+# Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
+# terraform state - not storing state on local disk / repo
+*/terraform.tfstate**
+*/.terraform.tfstate.lock.info
+*/.terraform.lock.hcl
+*/TODO*
+*/test*

--- a/infra/examples-dev/aws-google-workspace/.gitignore
+++ b/infra/examples-dev/aws-google-workspace/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -74,6 +74,7 @@ module "psoxy" {
   connector_display_name_suffix  = var.connector_display_name_suffix
   enabled_connectors             = var.enabled_connectors
   non_production_connectors      = var.non_production_connectors
+  custom_rest_rules              = var.custom_rest_rules
   custom_bulk_connectors         = var.custom_bulk_connectors
   lookup_table_builders          = var.lookup_table_builders
   gcp_project_id                 = data.google_project.psoxy-google-connectors.project_id

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -129,6 +129,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/examples-dev/aws-msft-365/.gitignore
+++ b/infra/examples-dev/aws-msft-365/.gitignore
@@ -15,3 +15,6 @@ terraform.tfstate**
 .terraform/**
 TODO*
 test*
+
+# example rules files
+*.yaml

--- a/infra/examples-dev/aws-msft-365/.gitignore
+++ b/infra/examples-dev/aws-msft-365/.gitignore
@@ -1,20 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*
-
-# example rules files
-*.yaml

--- a/infra/examples-dev/aws-msft-365/directory_no-app-ids.yaml
+++ b/infra/examples-dev/aws-msft-365/directory_no-app-ids.yaml
@@ -1,0 +1,112 @@
+---
+endpoints:
+  - pathRegex: "^/(v1.0|beta)/users(/p~[a-zA-Z0-9_-]+?)?[^/]*"
+    allowedQueryParams:
+      - "$top"
+      - "$select"
+      - "$skiptoken"
+      - "$orderBy"
+      - "$count"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..displayName"
+          - "$..aboutMe"
+          - "$..mySite"
+          - "$..preferredName"
+          - "$..givenName"
+          - "$..surname"
+          - "$..mailNickname"
+          - "$..proxyAddresses"
+          - "$..responsibilities"
+          - "$..skills"
+          - "$..faxNumber"
+          - "$..mobilePhone"
+          - "$..businessPhones[*]"
+          - "$..onPremisesExtensionAttributes"
+          - "$..onPremisesSecurityIdentifier"
+          - "$..securityIdentifier"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..employeeId"
+          - "$..userPrincipalName"
+          - "$..imAddresses[*]"
+          - "$..mail"
+          - "$..otherMails[*]"
+          - "$..onPremisesSamAccountName"
+          - "$..onPremisesUserPrincipalName"
+          - "$..onPremisesDistinguishedName"
+          - "$..onPremisesImmutableId"
+          - "$..identities[*].issuerAssignedId"
+        encoding: "JSON"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..id"
+        includeReversible: true
+        encoding: "URL_SAFE_TOKEN"
+  - pathRegex: "^/(v1.0|beta)/groups/?[^/]*"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..owners"
+          - "$..rejectedSenders"
+          - "$..acceptedSenders"
+          - "$..members"
+          - "$..membersWithLicenseErrors"
+          - "$..proxyAddresses"
+          - "$..mailNickname"
+          - "$..description"
+          - "$..resourceBehaviorOptions"
+          - "$..resourceProvisioningOptions"
+          - "$..onPremisesSamAccountName"
+          - "$..onPremisesSecurityIdentifier"
+          - "$..onPremisesProvisioningErrors"
+          - "$..securityIdentifier"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..mail"
+        includeOriginal: true
+        encoding: "JSON"
+  - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
+    allowedQueryParams:
+      - "$top"
+      - "$select"
+      - "$skiptoken"
+      - "$orderBy"
+      - "$count"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..displayName"
+          - "$..aboutMe"
+          - "$..mySite"
+          - "$..preferredName"
+          - "$..givenName"
+          - "$..surname"
+          - "$..mailNickname"
+          - "$..proxyAddresses"
+          - "$..responsibilities"
+          - "$..skills"
+          - "$..faxNumber"
+          - "$..mobilePhone"
+          - "$..businessPhones[*]"
+          - "$..onPremisesExtensionAttributes"
+          - "$..onPremisesSecurityIdentifier"
+          - "$..securityIdentifier"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..employeeId"
+          - "$..userPrincipalName"
+          - "$..imAddresses[*]"
+          - "$..mail"
+          - "$..otherMails[*]"
+          - "$..onPremisesSamAccountName"
+          - "$..onPremisesUserPrincipalName"
+          - "$..onPremisesDistinguishedName"
+          - "$..onPremisesImmutableId"
+          - "$..identities[*].issuerAssignedId"
+        encoding: "JSON"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..id"
+        encoding: "JSON"

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -65,6 +65,7 @@ module "psoxy" {
   non_production_connectors      = var.non_production_connectors
   connector_display_name_suffix  = var.connector_display_name_suffix
   custom_bulk_connectors         = var.custom_bulk_connectors
+  custom_rest_rules              = var.custom_rest_rules
   lookup_table_builders          = var.lookup_table_builders
   msft_tenant_id                 = var.msft_tenant_id
   msft_owners_email              = var.msft_owners_email

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -147,6 +147,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/examples-dev/aws/.gitignore
+++ b/infra/examples-dev/aws/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -71,6 +71,7 @@ module "psoxy" {
   non_production_connectors      = var.non_production_connectors
   connector_display_name_suffix  = var.connector_display_name_suffix
   custom_bulk_connectors         = var.custom_bulk_connectors
+  custom_rest_rules              = var.custom_rest_rules
   lookup_table_builders          = var.lookup_table_builders
   msft_tenant_id                 = var.msft_tenant_id
   msft_owners_email              = var.msft_owners_email

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -166,6 +166,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/examples-dev/gcp-google-workspace/.gitignore
+++ b/infra/examples-dev/gcp-google-workspace/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples/aws-google-workspace/.gitignore
+++ b/infra/examples/aws-google-workspace/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -72,6 +72,7 @@ module "psoxy" {
   connector_display_name_suffix  = var.connector_display_name_suffix
   enabled_connectors             = var.enabled_connectors
   non_production_connectors      = var.non_production_connectors
+  custom_rest_rules              = var.custom_rest_rules
   custom_bulk_connectors         = var.custom_bulk_connectors
   lookup_table_builders          = var.lookup_table_builders
   gcp_project_id                 = data.google_project.psoxy-google-connectors.project_id

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -117,6 +117,12 @@ variable "non_production_connectors" {
   default     = []
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "bulk_input_expiration_days" {
   type        = number
   description = "**alpha** Number of days after which objects in the bucket will expire. This could be as low as 1 day; longer aids debugging of issues."

--- a/infra/examples/aws-msft-365/.gitignore
+++ b/infra/examples/aws-msft-365/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -64,6 +64,7 @@ module "psoxy" {
   enabled_connectors             = var.enabled_connectors
   non_production_connectors      = var.non_production_connectors
   connector_display_name_suffix  = var.connector_display_name_suffix
+  custom_rest_rules              = var.custom_rest_rules
   custom_bulk_connectors         = var.custom_bulk_connectors
   lookup_table_builders          = var.lookup_table_builders
   msft_tenant_id                 = var.msft_tenant_id

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -147,6 +147,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/examples/gcp-bootstrap-cft/.gitignore
+++ b/infra/examples/gcp-bootstrap-cft/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples/gcp-bootstrap-simple/.gitignore
+++ b/infra/examples/gcp-bootstrap-simple/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples/gcp-google-workspace/.gitignore
+++ b/infra/examples/gcp-google-workspace/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/examples/msft-365/.gitignore
+++ b/infra/examples/msft-365/.gitignore
@@ -1,17 +1,8 @@
-# this .gitignore is to avoid committing various Terraform files to repo for examples/
-# when you copy example for actual use, you should delete this .gitignore file and
-# commit these to your repo
-
-# ignore terraform variables / state for examples
-# NOTE: for prod use, you likely want to remove this f
-terraform.tfvars
-
 # Terraform state - NOTE: for prod use, recommend you use a secure backend, such as S3/GCS for
 # terraform state - not storing state on local disk / repo
 terraform.tfstate**
 .terraform.tfstate.lock.info
 
-.terraform.lock.hcl
+# you don't need to commit this directory, even for dev use when you commit your `terraform.tfstate`
+# it is cache of Terraform providers/modules retrieved from remotes
 .terraform/**
-TODO*
-test*

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -139,6 +139,8 @@ module "psoxy-google-workspace-connector" {
     {
       BUNDLE_FILENAME     = module.psoxy-aws.filename
       IS_DEVELOPMENT_MODE = contains(var.non_production_connectors, each.key)
+      # trickery to force lambda restart so new rules seen
+      CUSTOM_RULES_SHA = contains(var.custom_rest_rules, each.key) ? filesha1(var.custom_rest_rules[each.key]) : null
     }
   )
 }
@@ -248,6 +250,8 @@ module "aws-psoxy-long-auth-connectors" {
     {
       BUNDLE_FILENAME     = module.psoxy-aws.filename
       IS_DEVELOPMENT_MODE = contains(var.non_production_connectors, each.key)
+      # trickery to force lambda restart so new rules seen
+      CUSTOM_RULES_SHA = contains(var.custom_rest_rules, each.key) ? filesha1(var.custom_rest_rules[each.key]) : null
     }
   )
 }
@@ -274,6 +278,15 @@ module "worklytics-psoxy-connection" {
 
 
 # END LONG ACCESS AUTH CONNECTORS
+
+module "custom_rest_rules" {
+  source = "../../modules/aws-ssm-rules"
+
+  for_each = var.custom_rest_rules
+
+  prefix    = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
+  file_path = each.value
+}
 
 # BEGIN BULK CONNECTORS
 

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -150,6 +150,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -162,6 +162,8 @@ module "psoxy-msft-connector" {
       IDENTITY_POOL_ID     = module.cognito-identity-pool.pool_id,
       IDENTITY_ID          = module.cognito-identity.identity_id[each.key]
       DEVELOPER_NAME_ID    = module.cognito-identity-pool.developer_provider_name
+      # trickery to force lambda restart so new rules seen
+      CUSTOM_RULES_SHA = try(module.custom_rest_rules[each.key].rules_hash, null)
     }
   )
 }
@@ -276,6 +278,8 @@ module "aws-psoxy-long-auth-connectors" {
       BUNDLE_FILENAME      = module.psoxy-aws.filename
       PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
       IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
+      # trickery to force lambda restart so new rules seen
+      CUSTOM_RULES_SHA = try(module.custom_rest_rules[each.key].rules_hash, null)
     }
   )
 }
@@ -300,6 +304,15 @@ module "worklytics-psoxy-connection-oauth-long-access" {
 }
 
 # END LONG ACCESS AUTH CONNECTORS
+
+module "custom_rest_rules" {
+  source = "../../modules/aws-ssm-rules"
+
+  for_each = var.custom_rest_rules
+
+  prefix    = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
+  file_path = each.value
+}
 
 # BEGIN BULK CONNECTORS
 

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -135,6 +135,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -126,6 +126,12 @@ variable "non_production_connectors" {
   default     = []
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -109,9 +109,7 @@ ${coalesce(join("\n", local.command_test_calls), "cd docs/example-api-calls/")}
 ```
 
 Feel free to try the above calls, and reference to the source's API docs for other parameters /
-endpoints to experiment with. If you spot any additional fields you believe should be
-redacted/pseudonymized, feel free to modify the rules in your local repo and re-deploy OR configure
-a RULES variable in the source.
+endpoints to experiment with.
 
 ### Check logs (AWS CloudWatch)
 

--- a/infra/modules/aws-ssm-rules/main.tf
+++ b/infra/modules/aws-ssm-rules/main.tf
@@ -27,7 +27,7 @@ locals {
   param_value      = local.use_compressed ? local.rules_compressed : local.rules_plain
 }
 
-resource "aws_ssm_parameter" "custom_rest_rules" {
+resource "aws_ssm_parameter" "rules" {
   name           = "${var.prefix}RULES"
   type           = "String"
   tier           = length(local.param_value) < 4096 ? "Standard" : "Advanced"

--- a/infra/modules/aws-ssm-rules/main.tf
+++ b/infra/modules/aws-ssm-rules/main.tf
@@ -1,0 +1,39 @@
+# custom REST rules as SSM parameter
+
+# as a module to get reusable
+# - variable validation
+# - length calculations
+
+# pros:
+#  - if small, human readable.  if large, can be gzipped
+#  - can be reviewed/managed via AWS console
+#  - rule changes readily visible in plan, not confused with source code changes
+#  - bundle the same for all lambdas; speeds build/package, reduces disk/mem footprint needed for
+#    deploy (concern if doing cloud shell)
+#
+# cons vs shipping with lambda's deployment as flat file:
+#  - lambda won't see rule changes unless restarted
+#  - another component to see/manage
+#  - less analogous to GCP; haven't implemented gcp yet, but we're using secret manager
+#  - need to worry about lambda's permissions to read the SSM param
+#  - need to worry about terraforms permissions to write the SSM param (if we're not otherwise
+#    writing SSMs, which as of Apr 2023 we are so not really concern)
+
+# compress if necessary; but otherwise leave plain so human readable
+locals {
+  rules_plain      = file(var.file_path)
+  rules_compressed = base64gzip(local.rules_plain)
+  use_compressed   = length(local.rules_plain) > 8192
+  param_value      = local.use_compressed ? local.rules_compressed : local.rules_plain
+}
+
+resource "aws_ssm_parameter" "custom_rest_rules" {
+  name           = "${var.prefix}RULES"
+  type           = "String"
+  tier           = length(local.param_value) < 4096 ? "Standard" : "Advanced"
+  insecure_value = local.param_value
+}
+
+output "rules_hash" {
+  value = sha1(local.rules_plain)
+}

--- a/infra/modules/aws-ssm-rules/variables.tf
+++ b/infra/modules/aws-ssm-rules/variables.tf
@@ -1,0 +1,19 @@
+
+
+variable "prefix" {
+  type = string
+}
+
+variable "file_path" {
+  type = string
+
+  validation {
+    condition     = fileexists(var.file_path)
+    error_message = "The file path does not exist."
+  }
+
+  validation {
+    condition     = endswith(var.file_path, ".yaml")
+    error_message = "Rules should be plain .yaml file."
+  }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/HealthCheckResult.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/HealthCheckResult.java
@@ -56,6 +56,8 @@ public class HealthCheckResult {
 
     Map<String, Instant> configPropertiesLastModified;
 
+    String rules;
+
 
     public boolean passed() {
         return getConfiguredSource() != null

--- a/java/core/src/main/java/co/worklytics/psoxy/HealthCheckResult.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/HealthCheckResult.java
@@ -56,6 +56,7 @@ public class HealthCheckResult {
 
     Map<String, Instant> configPropertiesLastModified;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     String rules;
 
 

--- a/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
@@ -23,7 +23,6 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
-import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 import dagger.Module;
 import dagger.Provides;
 import lombok.extern.java.Log;
@@ -164,9 +163,8 @@ public class PsoxyModule {
         ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper);
 
-        return new JsonSchemaFilterUtils(objectMapper, jsonSchemaGenerator);
+        return new JsonSchemaFilterUtils(objectMapper);
     }
 
     @Provides

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/RulesUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/RulesUtils.java
@@ -35,7 +35,12 @@ public class RulesUtils {
 
     @SneakyThrows
     public String sha(RuleSet rules) {
-        return DigestUtils.sha1Hex(yamlMapper.writeValueAsString(rules));
+        return DigestUtils.sha1Hex(asYaml(rules));
+    }
+
+    @SneakyThrows
+    public String asYaml(RuleSet rules) {
+        return yamlMapper.writeValueAsString(rules);
     }
 
     /**

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/RulesUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/RulesUtils.java
@@ -7,7 +7,9 @@ import co.worklytics.psoxy.storage.StorageHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.ByteStreams;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -16,11 +18,13 @@ import org.apache.commons.codec.digest.DigestUtils;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.zip.GZIPInputStream;
 
 @Log
 @NoArgsConstructor(onConstructor_ = @Inject)
@@ -45,17 +49,33 @@ public class RulesUtils {
         Optional<String> configuredRules = config.getConfigPropertyAsOptional(ProxyConfigProperty.RULES);
 
         if (configuredRules.isPresent()) {
-            String yamlEncodedRules;
-            try {
-                yamlEncodedRules = new String(Base64.getDecoder().decode(configuredRules.get()));
-                log.info("RULES configured as base64-encoded YAML");
-            } catch (IllegalArgumentException e) {
-                yamlEncodedRules = configuredRules.get();
-            }
+            String yamlEncodedRules = decodeToYaml(configuredRules.get());
             return Optional.of(parse(yamlEncodedRules));
         } else {
             return Optional.empty();
         }
+    }
+
+    @VisibleForTesting
+    String decodeToYaml(String valueFromConfig) {
+        //possible encodings: 1) base64-encoded YAML, 2) plain YAML, 3) base64-encoded gzipped YAML
+        String yamlEncodedRules;
+        try {
+            byte[] raw = Base64.getDecoder().decode(valueFromConfig);
+
+            try {
+                raw = ByteStreams.toByteArray(new GZIPInputStream(new ByteArrayInputStream(raw)));
+                log.info("RULES configured as base64-encoded gzipped YAML");
+            } catch (IOException e) {
+                //not gzipped
+                log.info("RULES configured as base64-encoded YAML");
+            }
+            yamlEncodedRules = new String(raw);
+        } catch (IllegalArgumentException e) {
+            log.info("RULES configured as YAML");
+            yamlEncodedRules = valueFromConfig;
+        }
+        return yamlEncodedRules;
     }
 
     @VisibleForTesting
@@ -91,5 +111,7 @@ public class RulesUtils {
             return new ArrayList<>();
         }
     }
+
+
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/Validator.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/Validator.java
@@ -7,6 +7,7 @@ import com.google.common.base.Preconditions;
 import com.jayway.jsonpath.JsonPath;
 import lombok.NonNull;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.regex.Pattern;
@@ -39,7 +40,13 @@ public class Validator {
         rules.getEndpoints().forEach(Validator::validate);
     }
     static void validate(@NonNull Endpoint endpoint) {
-        Pattern.compile(endpoint.getPathRegex());
+        if (StringUtils.isBlank(endpoint.getPathTemplate())) {
+            if (StringUtils.isBlank(endpoint.getPathRegex())) {
+                throw new Error("Endpoint must have either pathTemplate or pathRegex. pass `/` as pathTemplate if you want base path.");
+            }
+            Pattern.compile(endpoint.getPathRegex());
+        }
+
         endpoint.getTransforms().forEach(Validator::validate);
     }
 

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -424,4 +424,18 @@ class RESTApiSanitizerImplTest {
 
         assertEquals(expected, r);
     }
+
+    @CsvSource(
+        value = {
+            "/,^/$",
+            "/api/v1/users,^/api/v1/users$",
+            "/api/v1/users/{id},^/api/v1/users/[^/]+$",
+            "/api/v1/mail/{accountId}/messages/{id},^/api/v1/mail/[^/]+/messages/[^/]+$",
+        }
+    )
+    @ParameterizedTest
+    void effectiveRegex_templates(String template, String expectedPattern) {
+        String effectiveRegex = sanitizer.effectiveRegex(Endpoint.builder().pathTemplate(template).build());
+        assertEquals(expectedPattern, effectiveRegex);
+    }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
@@ -4,10 +4,8 @@ import co.worklytics.psoxy.*;
 import co.worklytics.psoxy.impl.RESTApiSanitizerImpl;
 import co.worklytics.test.MockModules;
 import co.worklytics.test.TestUtils;
-import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
 import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
-import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.transforms.Transform;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -18,13 +16,11 @@ import lombok.*;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import scala.concurrent.impl.FutureConvertersImpl;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Stream;
 

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
@@ -140,7 +140,8 @@ abstract public class RulesBaseTestCase {
     @Test
     void yamlLengthCompressed() {
         int rulesLengthInChars = TestUtils.asBase64Gzipped(yamlMapper.writeValueAsString(getRulesUnderTest())).length();
-        assertTrue(rulesLengthInChars < REGULAR_SSM_PARAM_LIMIT, "YAML rules " + rulesLengthInChars + " chars long; want < " + REGULAR_SSM_PARAM_LIMIT + " chars to fit as AWS SSM param");
+        assertTrue(rulesLengthInChars < REGULAR_SSM_PARAM_LIMIT,
+            "YAML rules " + rulesLengthInChars + " chars long; want < " + REGULAR_SSM_PARAM_LIMIT + " chars to fit as AWS SSM param");
     }
 
     @SneakyThrows

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesBaseTestCase.java
@@ -126,14 +126,21 @@ abstract public class RulesBaseTestCase {
     }
 
     // regular param --> 4096
-    // advanced param --> 8000
-    int CHAR_LIMIT = 8000;
+    int REGULAR_SSM_PARAM_LIMIT = 4096;
+    int ADVANCED_SSM_PARAM_LIMIT = 8192;
 
     @SneakyThrows
     @Test
     void yamlLength() {
         int rulesLengthInChars = yamlMapper.writeValueAsString(getRulesUnderTest()).length();
-        assertTrue(rulesLengthInChars < CHAR_LIMIT, "YAML rules " + rulesLengthInChars + " chars long; want < " + CHAR_LIMIT + " chars to fit as AWS SSM param");
+        assertTrue(rulesLengthInChars < ADVANCED_SSM_PARAM_LIMIT, "YAML rules " + rulesLengthInChars + " chars long; want < " + ADVANCED_SSM_PARAM_LIMIT + " chars to fit as AWS SSM param");
+    }
+
+    @SneakyThrows
+    @Test
+    void yamlLengthCompressed() {
+        int rulesLengthInChars = TestUtils.asBase64Gzipped(yamlMapper.writeValueAsString(getRulesUnderTest())).length();
+        assertTrue(rulesLengthInChars < REGULAR_SSM_PARAM_LIMIT, "YAML rules " + rulesLengthInChars + " chars long; want < " + REGULAR_SSM_PARAM_LIMIT + " chars to fit as AWS SSM param");
     }
 
     @SneakyThrows

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableList;
 import dagger.Component;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -123,6 +124,7 @@ class RulesUtilsTest {
 
     // if you change YAML_REST, this test will fail; you can copy-paste the expected value to
     // BASE64_YAML_REST_COMPRESSED
+    @Disabled // useless, and weirdly seems to fail via maven ... serialization issue?
     @Test
     void verifyCompression() {
         assertEquals(BASE64_YAML_REST_COMPRESSED,

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
@@ -5,7 +5,7 @@ import co.worklytics.psoxy.gateway.BulkModeConfigProperty;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.psoxy.storage.StorageHandler;
-import com.avaulta.gateway.rules.ColumnarRules;
+import co.worklytics.test.TestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +47,8 @@ class RulesUtilsTest {
         container.inject(this);
     }
 
-    static final String BASE64_YAML_REST = "YWxsb3dBbGxFbmRwb2ludHM6IGZhbHNlCmVuZHBvaW50czoKICAtIHBhdGhSZWdleDogL2NhbGVuZGFyL3YzL2NhbGVuZGFycy8uKi9ldmVudHMuKgogICAgdHJhbnNmb3JtczoKICAgICAgLSAhPHBzZXVkb255bWl6ZT4KICAgICAgICBqc29uUGF0aHM6CiAgICAgICAgICAtICQuLmVtYWlsCiAgICAgIC0gITxyZWRhY3Q+CiAgICAgICAganNvblBhdGhzOgogICAgICAgICAgLSAkLi5kaXNwbGF5TmFtZQogICAgICAgICAgLSAkLml0ZW1zWypdLmV4dGVuZGVkUHJvcGVydGllcy5wcml2YXRlCg==";
+    static final String BASE64_YAML_REST = "YWxsb3dBbGxFbmRwb2ludHM6IGZhbHNlCmVuZHBvaW50czoKICAtIHBhdGhSZWdleDogIl4vKHYxLjB8YmV0YSkvdXNlcnMvP1teL10qIgogICAgdHJhbnNmb3JtczoKICAgIC0gITxyZWRhY3Q+CiAgICAgIGpzb25QYXRoczoKICAgICAgLSAiJC4uZGlzcGxheU5hbWUiCiAgICAgIC0gIiQuLmVtcGxveWVlSWQiCg==";
+    static final String BASE64_YAML_REST_COMPRESSED = "H4sIAAAAAAAAAFWMPQvCQBBE+/yK9bBQwZy2QRQLCxsRWzGwepsY2dwdt+dHwB9vEkSwnJn3Bpndc828sca7ykbJoEAWSuhXJABT8BivByrplYHK9egxT2fvM0Uc67tQEL065vo0US0LEANaKVyoe7ezB4tABi9x2WeAmzi7bx+/QIeoYZqaSjxjs8Oa1N9AtWfXEG2NSj7mG4K5sgAAAA==";
     static final String YAML_REST =
             "allowAllEndpoints: false\n" +
             "endpoints:\n" +
@@ -106,5 +107,25 @@ class RulesUtilsTest {
             utils.parseAdditionalTransforms(config).get(0).getDestinationBucketName());
         assertEquals("something",
             ((CsvRules) utils.parseAdditionalTransforms(config).get(0).getRules()).getColumnsToPseudonymize().get(0));
+    }
+
+    @SneakyThrows
+    @ValueSource(strings = {
+        YAML_REST,
+        BASE64_YAML_REST,
+        BASE64_YAML_REST_COMPRESSED,
+    })
+    @ParameterizedTest
+    void decodeToYaml(String encoded) {
+        String decoded = utils.decodeToYaml(encoded);
+        assertEquals(YAML_REST, decoded);
+    }
+
+    // if you change YAML_REST, this test will fail; you can copy-paste the expected value to
+    // BASE64_YAML_REST_COMPRESSED
+    @Test
+    void verifyCompression() {
+        assertEquals(BASE64_YAML_REST_COMPRESSED,
+            TestUtils.asBase64Gzipped(YAML_REST));
     }
 }

--- a/java/core/src/test/java/co/worklytics/test/TestUtils.java
+++ b/java/core/src/test/java/co/worklytics/test/TestUtils.java
@@ -1,10 +1,16 @@
 package co.worklytics.test;
 
+import lombok.SneakyThrows;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.zip.GZIPOutputStream;
 
 public class TestUtils {
 
@@ -28,5 +34,23 @@ public class TestUtils {
         } catch (IOException | URISyntaxException e) {
             throw new Error(e);
         }
+    }
+
+    /**
+     * helper if you need more test examples, or want to test compressed length of rules
+     *
+     * meant to be equivalent to Terraform's base64gzip function
+     *
+     * @see "https://developer.hashicorp.com/terraform/language/functions/base64gzip"
+     */
+    @SneakyThrows
+    public static String asBase64Gzipped(String value) {
+        ByteArrayOutputStream s = new ByteArrayOutputStream();
+        GZIPOutputStream compressedStream = new GZIPOutputStream(s);
+        compressedStream.write(value.getBytes(StandardCharsets.UTF_8));
+        compressedStream.finish();
+        compressedStream.close();
+
+        return new String(Base64.getEncoder().encode(s.toByteArray()));
     }
 }

--- a/java/gateway-core/pom.xml
+++ b/java/gateway-core/pom.xml
@@ -95,13 +95,6 @@
             <version>${dependency.jackson.version}</version>
         </dependency>
 
-        <!-- https://github.com/mbknor/mbknor-jackson-jsonSchema -->
-        <dependency>
-            <groupId>com.kjetland</groupId>
-            <artifactId>mbknor-jackson-jsonschema_2.13</artifactId>
-            <version>1.0.39</version>
-        </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
@@ -20,7 +20,19 @@ import java.util.stream.Collectors;
 @Getter
 public class Endpoint {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     String pathRegex;
+
+    /**
+     * ALPHA FEATURE
+     * path template, eg, /api/v1/{id}/foo/{bar}
+     *
+     * @see "https://swagger.io/docs/specification/paths-and-operations/"
+     *
+     * if provided, has the effect of pathRegex = "^/api/v1/[^/]+/foo/[^/]+$"
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String pathTemplate;
 
     //if provided, only query params in this list will be allowed
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 @JsonPropertyOrder({"pathRegex", "allowedQueryParams", "transforms"})
 @Builder(toBuilder = true)
+@With
 @AllArgsConstructor //for builder
 @NoArgsConstructor //for Jackson
 @Getter

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -20,11 +20,13 @@ public class JsonSchemaFilterUtils {
 
     /**
      * Generates a JSON schema for the given class.
-     * <p>q
+     * <p>
      * use case: in client code bases, can generate rules for a given expected result class; perhaps
      * eventually as a build step, eg maven plugin, that writes rules out somewhere
      * <p>
      * eg,  schemaRuleUtils.generateSchema(ExampleResult.class)
+     *
+     * TODO: this really doesn't need to be bundled into proxy; it's just used to generate rules
      *
      * @param clazz
      * @return
@@ -34,51 +36,6 @@ public class JsonSchemaFilterUtils {
         return objectMapper.convertValue(schema, JsonSchemaFilter.class);
     }
 
-    /**
-     *
-     * TODO: really doesn't need to be in proxy codebase; it's just for rule generation
-     *
-     * @param filter to compact
-     * @return a compact copy of the schema filter
-     */
-    @SneakyThrows
-    public JsonSchemaFilter compactCopy(JsonSchemaFilter filter) {
-        //quick, lame approach to have a deep copy of schema
-        JsonSchemaFilter copy = objectMapper.readerFor(JsonSchemaFilter.class)
-            .readValue(objectMapper.writeValueAsString(filter));
-
-        compact(copy);
-
-        return copy;
-    }
-
-    /**
-     * mutating compaction - removes all simple-type information from filter
-     * @param filter
-     */
-    void compact(JsonSchemaFilter filter) {
-        if (filter.isArray()) {
-            if (filter.getItems() != null) {
-                compact(filter.getItems());
-                filter.setType(null); // existence of items implies type=array
-            }
-        } else if (filter.isObject()) {
-            if (filter.getProperties() != null) {
-                filter.getProperties().forEach((k, v) -> compact(v));
-                filter.setType(null); // existence of properties implies type=object
-            }
-        } else if (filter.hasType()) { // as non-complex type
-            filter.setType(null);
-        }
-
-        // TODO: we could omit type=array / type=object if there are properties/items defined, as
-        // existence of those properties implies the type
-
-        // also compact any definitions
-        if (filter.getDefinitions() != null) {
-            filter.getDefinitions().forEach((k, v) -> compact(v));
-        }
-    }
 
     /**
      * filter object by properties defined in schema, recursively filtering them by any schema

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -212,7 +212,8 @@ public class JsonSchemaFilterUtils {
         }
     }
 
-    @Builder
+    @With
+    @Builder(toBuilder = true)
     @NoArgsConstructor
     @AllArgsConstructor // for builder
     @Data

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -3,7 +3,6 @@ package com.avaulta.gateway.rules;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 import lombok.*;
 import lombok.extern.java.Log;
 import org.apache.commons.lang3.tuple.Pair;
@@ -16,26 +15,6 @@ import java.util.*;
 public class JsonSchemaFilterUtils {
 
     ObjectMapper objectMapper;
-    JsonSchemaGenerator jsonSchemaGenerator;
-
-    /**
-     * Generates a JSON schema for the given class.
-     * <p>
-     * use case: in client code bases, can generate rules for a given expected result class; perhaps
-     * eventually as a build step, eg maven plugin, that writes rules out somewhere
-     * <p>
-     * eg,  schemaRuleUtils.generateSchema(ExampleResult.class)
-     *
-     * TODO: this really doesn't need to be bundled into proxy; it's just used to generate rules
-     *
-     * @param clazz
-     * @return
-     */
-    public JsonSchemaFilter generateJsonSchemaFilter(Class<?> clazz) {
-        JsonNode schema = jsonSchemaGenerator.generateJsonSchema(clazz);
-        return objectMapper.convertValue(schema, JsonSchemaFilter.class);
-    }
-
 
     /**
      * filter object by properties defined in schema, recursively filtering them by any schema

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaFilterUtilsTest.java
@@ -200,27 +200,6 @@ class JsonSchemaFilterUtilsTest {
 
     }
 
-    @SneakyThrows
-    @Test
-    public void compactCopy() {
-        JsonSchemaFilterUtils.JsonSchemaFilter schemaWithRefs =
-            jsonSchemaFilterUtils.generateJsonSchemaFilter(ComplexPojo.class);
-        JsonSchemaFilterUtils.JsonSchemaFilter compactCopy = jsonSchemaFilterUtils.compactCopy(schemaWithRefs);
-
-        assertEquals(ComplexPojo.EXPECTED_COMPACT_SCHEMA,
-            objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(compactCopy));
-
-        // 30% reduction in yaml size
-        assertEquals(404, yamlMapper.writeValueAsString(schemaWithRefs).length());
-        assertEquals(286, yamlMapper.writeValueAsString(compactCopy).length());
-
-        // non-pretty JSON is actually more compact than the yaml (pretty JSON is a lot less compact)
-        // (so if going to give up on human readability by base64gzip'ing the schema, might as well
-        //  do that with the JSON)
-        // eg, https://developer.hashicorp.com/terraform/language/functions/base64gzip
-        assertEquals(351, objectMapper.writeValueAsString(schemaWithRefs).length());
-        assertEquals(257, objectMapper.writeValueAsString(compactCopy).length());
-    }
 
     @Builder
     @Data


### PR DESCRIPTION
### Features
  - compact stuff will move to client project
  - support for gzipped rules
  - support for pathTemplate in endpoints
  - custom rules deployed via Terraform (rather than hand copy-paste via AWS console, although that should still work)
  - remove dep on json-schema

### Change implications

 - dependencies added/changed? **yes, removed**
