### PR TITLE
support for custom_rest_rules, path prefixes in GCP

### DIFF
--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -22,6 +22,10 @@ terraform {
   #  }
 }
 
+provider "google" {
+  impersonate_service_account = var.gcp_terraform_sa_account_email
+}
+
 module "psoxy" {
   source = "../../modular-examples/gcp-google-workspace"
   # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=v0.4.18"

--- a/infra/examples-dev/gcp-google-workspace/variables.tf
+++ b/infra/examples-dev/gcp-google-workspace/variables.tf
@@ -3,6 +3,17 @@ variable "gcp_project_id" {
   description = "id of GCP project that will host psoxy instance; must exist"
 }
 
+variable "gcp_terraform_sa_account_email" {
+  type        = string
+  description = "Email of GCP service account that will be used to provision GCP resources. Leave 'null' to use application default for you environment."
+  default     = null
+
+  validation {
+    condition     = var.gcp_terraform_sa_account_email == null || can(regex(".*@.*\\.iam\\.gserviceaccount\\.com$", var.gcp_terraform_sa_account_email))
+    error_message = "The gcp_terraform_sa_account_email value should be a valid GCP service account email address."
+  }
+}
+
 variable "environment_name" {
   type        = string
   description = "qualifier to append to name of project that will host your psoxy instance"

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -32,6 +32,10 @@ provider "azuread" {
   tenant_id = var.msft_tenant_id
 }
 
+provider "google" {
+  impersonate_service_account = var.gcp_terraform_sa_account_email
+}
+
 module "psoxy" {
   source = "../../modular-examples/gcp"
   # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp?ref=v0.4.18"

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -41,9 +41,9 @@ module "psoxy" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp?ref=v0.4.18"
 
   gcp_project_id                 = var.gcp_project_id
-  environment_name               = var.environment_name
+  environment_id                 = var.environment_id
+  config_parameter_prefix        = var.config_parameter_prefix
   worklytics_sa_emails           = var.worklytics_sa_emails
-  connector_display_name_suffix  = var.connector_display_name_suffix
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
   gcp_region                     = var.gcp_region

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -46,6 +46,7 @@ module "psoxy" {
   replica_regions                = var.replica_regions
   enabled_connectors             = var.enabled_connectors
   non_production_connectors      = var.non_production_connectors
+  custom_rest_rules              = var.custom_rest_rules
   custom_bulk_connectors         = var.custom_bulk_connectors
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -90,6 +90,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 1805 # 5 years; intent is 'forever', but some upperbound in case bucket is forgotten
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -3,6 +3,17 @@ variable "gcp_project_id" {
   description = "id of GCP project that will host psoxy instance"
 }
 
+variable "gcp_terraform_sa_account_email" {
+  type        = string
+  description = "Email of GCP service account that will be used to provision GCP resources. Leave 'null' to use application default for you environment."
+  default     = null
+
+  validation {
+    condition     = var.gcp_terraform_sa_account_email == null || can(regex(".*@.*\\.iam\\.gserviceaccount\\.com$", var.gcp_terraform_sa_account_email))
+    error_message = "The gcp_terraform_sa_account_email value should be a valid GCP service account email address."
+  }
+}
+
 variable "environment_name" {
   type        = string
   description = "qualifier to append to name of project that will host your psoxy instance"

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -14,21 +14,26 @@ variable "gcp_terraform_sa_account_email" {
   }
 }
 
-variable "environment_name" {
+variable "environment_id" {
   type        = string
-  description = "qualifier to append to name of project that will host your psoxy instance"
+  description = "Qualifier to append to names/ids of resources for psoxy. If not empty, A-Za-z0-9 or - characters only. Max length 10. Useful to distinguish between deployments into same GCP project."
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[A-z0-9\\-]{0,12}$", var.environment_id))
+    error_message = "The environment_name must be 0-12 chars of [A-z0-9\\-] only."
+  }
+}
+
+variable "config_parameter_prefix" {
+  type        = string
+  description = "A prefix to give to all config parameters (GCP Secret Manager Secrets) created/consumed by this module. If omitted, and `environment_id` provided, that will be used."
   default     = ""
 }
 
 variable "worklytics_sa_emails" {
   type        = list(string)
   description = "service accounts for your organization's Worklytics instances (list supported for test/dev scenarios)"
-}
-
-variable "connector_display_name_suffix" {
-  type        = string
-  description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"
-  default     = ""
 }
 
 variable "psoxy_base_dir" {

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -280,7 +280,7 @@ module "psoxy-msft-connector" {
       IDENTITY_POOL_ID     = module.cognito_identity_pool[0].pool_id,
       IDENTITY_ID          = module.cognito_identity[0].identity_id[each.key]
       DEVELOPER_NAME_ID    = module.cognito_identity_pool[0].developer_provider_name
-      CUSTOM_RULES_SHA     = contains(var.custom_rest_rules, each.key) ? filesha1(var.custom_rest_rules[each.key]) : null
+      CUSTOM_RULES_SHA     = try(var.custom_rest_rules[each.key], null) != null ? filesha1(var.custom_rest_rules[each.key]) : null
     }
   )
 }
@@ -394,7 +394,7 @@ module "aws-psoxy-long-auth-connectors" {
     try(each.value.environment_variables, {}),
     {
       IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
-      CUSTOM_RULES_SHA     = contains(var.custom_rest_rules, each.key) ? filesha1(var.custom_rest_rules[each.key]) : null
+      CUSTOM_RULES_SHA     = try(var.custom_rest_rules[each.key], null) != null ? filesha1(var.custom_rest_rules[each.key]) : null
       PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
 
     }

--- a/infra/modular-examples/gcp/main.tf
+++ b/infra/modular-examples/gcp/main.tf
@@ -104,6 +104,7 @@ module "psoxy-google-workspace-connector" {
       BUNDLE_FILENAME      = module.psoxy.filename
       IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
       PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
+      CUSTOM_RULES_SHA     = contains(var.custom_rest_rules, each.key) ? filesha1(var.custom_rest_rules[each.key]) : null
     }
   )
 
@@ -208,6 +209,7 @@ module "connector-long-auth-function" {
       BUNDLE_FILENAME      = module.psoxy.filename
       PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
       IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
+      CUSTOM_RULES_SHA     = contains(var.custom_rest_rules, each.key) ? filesha1(var.custom_rest_rules[each.key]) : null
     }
   )
 }
@@ -236,6 +238,17 @@ module "worklytics-psoxy-connection-long-auth" {
   todo_step              = module.connector-long-auth-function[each.key].next_todo_step
 }
 # END LONG ACCESS AUTH CONNECTORS
+
+
+module "custom_rest_rules" {
+  source = "../../modules/gcp-sm-rules"
+
+  for_each = var.custom_rest_rules
+
+  prefix    = "PSOXY_${upper(replace(each.key, "-", "_"))}_"
+  file_path = each.value
+}
+
 
 # BEGIN BULK CONNECTORS
 module "psoxy-bulk" {

--- a/infra/modular-examples/gcp/variables.tf
+++ b/infra/modular-examples/gcp/variables.tf
@@ -3,10 +3,28 @@ variable "gcp_project_id" {
   description = "id of GCP project that will host psoxy instance"
 }
 
-variable "environment_name" {
+variable "environment_id" {
   type        = string
-  description = "qualifier to append to name of project that will host your psoxy instance"
+  description = "Qualifier to append to names/ids of resources for psoxy. If not empty, A-Za-z0-9 or - characters only. Max length 10. Useful to distinguish between deployments into same GCP project."
   default     = ""
+
+  validation {
+    condition     = can(regex("^[A-z0-9\\-]{0,12}$", var.environment_id))
+    error_message = "The environment_name must be 0-12 chars of [A-z0-9\\-] only."
+  }
+}
+
+variable "config_parameter_prefix" {
+  type        = string
+  description = "A prefix to give to all config parameters (GCP Secret Manager Secrets) created/consumed by this module. If omitted, and `environment_id` provided, that will be used."
+  default     = ""
+
+  # taken from https://cloud.google.com/secret-manager/docs/reference/rpc/google.cloud.secrets.v1beta1
+  # secret IDs can be up to 255 chars, so limit prefix to 120 gives plenty of leeway
+  validation {
+    condition     = can(regex("^[A-z0-9\\-_]{0,120}$", var.config_parameter_prefix))
+    error_message = "The config_parameter_prefix must be 0-120 chars of [A-z0-9\\-_] only."
+  }
 }
 
 variable "worklytics_sa_emails" {
@@ -14,9 +32,10 @@ variable "worklytics_sa_emails" {
   description = "service accounts for your organization's Worklytics instances (list supported for test/dev scenarios)"
 }
 
+# TODO: remove in 0.5; use `environment_name` instead
 variable "connector_display_name_suffix" {
   type        = string
-  description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"
+  description = "**DEPRECATED** suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"
   default     = ""
 }
 

--- a/infra/modular-examples/gcp/variables.tf
+++ b/infra/modular-examples/gcp/variables.tf
@@ -103,6 +103,12 @@ variable "bulk_sanitized_expiration_days" {
   default     = 720
 }
 
+variable "custom_rest_rules" {
+  type        = map(string)
+  description = "map of connector id --> YAML file with custom rules"
+  default     = {}
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind = string

--- a/infra/modules/gcp-oauth-secrets/main.tf
+++ b/infra/modules/gcp-oauth-secrets/main.tf
@@ -1,6 +1,6 @@
 resource "google_secret_manager_secret" "secret" {
   project   = var.project_id
-  secret_id = var.secret_name
+  secret_id = "${var.path_prefix}${var.secret_name}"
 
   replication {
     automatic = true

--- a/infra/modules/gcp-oauth-secrets/variables.tf
+++ b/infra/modules/gcp-oauth-secrets/variables.tf
@@ -12,3 +12,9 @@ variable "service_account_email" {
   type        = string
   description = "email of the service account that the cloud function will run as"
 }
+
+variable "path_prefix" {
+  type        = string
+  description = "A prefix to add to the secret path."
+  default     = ""
+}

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 locals {
-  function_name       = "psoxy-${substr(var.source_kind, 0, 24)}"
+  function_name       = "${var.environment_id_prefix}${substr(var.source_kind, 0, 30 - length(var.environment_id_prefix))}"
   command_npm_install = "npm --prefix ${var.psoxy_base_dir}tools/psoxy-test install"
 }
 
@@ -128,7 +128,9 @@ resource "google_cloudfunctions_function" "function" {
     OUTPUT_BUCKET = google_storage_bucket.output-bucket.name
     }),
     var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
-    var.environment_variables
+    var.environment_variables,
+    var.config_parameter_prefix == null ? {} : { PATH_TO_SHARED_CONFIG = var.config_parameter_prefix },
+    var.config_parameter_prefix == null ? {} : { PATH_TO_INSTANCE_CONFIG = "${var.config_parameter_prefix}${local.function_name}" },
   )
 
   dynamic "secret_environment_variables" {

--- a/infra/modules/gcp-psoxy-bulk/variables.tf
+++ b/infra/modules/gcp-psoxy-bulk/variables.tf
@@ -3,6 +3,18 @@ variable "project_id" {
   description = "id of GCP project that will host psoxy instance"
 }
 
+variable "environment_id_prefix" {
+  type        = string
+  description = "A prefix to give to all resources created/consumed by this module."
+  default     = "psoxy-"
+}
+
+variable "config_parameter_prefix" {
+  type        = string
+  description = "Prefix for psoxy config parameters"
+  default     = null
+}
+
 variable "worklytics_sa_emails" {
   type        = list(string)
   description = "service accounts for your organization's Worklytics instances (list supported for test/dev scenarios)"

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -53,7 +53,9 @@ resource "google_cloudfunctions_function" "function" {
   environment_variables = merge(
     local.required_env_vars,
     var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
-    var.environment_variables
+    var.environment_variables,
+    var.config_parameter_prefix == null ? {} : { PATH_TO_SHARED_CONFIG = var.config_parameter_prefix },
+    var.config_parameter_prefix == null ? {} : { PATH_TO_INSTANCE_CONFIG = "${var.config_parameter_prefix}${var.source_kind}" },
   )
 
   dynamic "secret_environment_variables" {

--- a/infra/modules/gcp-psoxy-rest/variables.tf
+++ b/infra/modules/gcp-psoxy-rest/variables.tf
@@ -14,6 +14,12 @@ variable "instance_id" {
   description = "kind of source (eg, 'gmail', 'google-chat', etc)"
 }
 
+variable "config_parameter_prefix" {
+  type        = string
+  description = "Prefix for psoxy config parameters"
+  default     = null
+}
+
 variable "service_account_email" {
   type        = string
   description = "email of the service account that the cloud function will run as"

--- a/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
+++ b/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
@@ -33,6 +33,7 @@ module "gcp-secrets" {
   source = "../gcp-secrets"
 
   secret_project  = var.secret_project
+  path_prefix     = var.path_prefix
   replica_regions = var.replica_regions
 
   secrets = {

--- a/infra/modules/gcp-sa-auth-key-secret-manager/variables.tf
+++ b/infra/modules/gcp-sa-auth-key-secret-manager/variables.tf
@@ -9,6 +9,12 @@ variable "secret_project" {
   description = "ID of project in which to store SA key as secret"
 }
 
+variable "path_prefix" {
+  type        = string
+  description = "A prefix to add to the secret path."
+  default     = ""
+}
+
 variable "secret_id" {
   type        = string
   description = "ID to give secret for SA key"

--- a/infra/modules/gcp-secret-fill-md/main.tf
+++ b/infra/modules/gcp-secret-fill-md/main.tf
@@ -7,26 +7,35 @@ variable "secret_id" {
   type        = string
   description = "id of the secret"
 }
+variable "path_prefix" {
+  type        = string
+  description = "A prefix to add to the secret path."
+  default     = ""
+}
+
+locals {
+  full_secret_id = "${var.path_prefix}${var.secret_id}"
+}
 
 output "todo_markdown" {
   value = <<EOT
-## Populate the token for ${var.secret_id} in GCP Secret Manager.
+## Populate the token for ${local.full_secret_id} in GCP Secret Manager.
 
 
 ### Using `gcloud`
 
 YMMV.
 ```shell
-gcloud secrets versions add ${var.secret_id} --project=${var.project_id} --data-file=/tmp/file-containing-accesstoken
+gcloud secrets versions add ${local.full_secret_id} --project=${local.full_secret_id} --data-file=/tmp/file-containing-accesstoken
 ```
 
 ```shell
-printf "YOUR_SECRET_VALUE_HERE" | gcloud secrets versions add ${var.secret_id} --project=${var.project_id} --data-file=-
+printf "YOUR_SECRET_VALUE_HERE" | gcloud secrets versions add ${local.full_secret_id} --project=${var.project_id} --data-file=-
 ```
 
 from macOS clipboard
 ```shell
-pbpaste | gcloud secrets versions add ${var.secret_id} --project=${var.project_id} --data-file=-
+pbpaste | gcloud secrets versions add ${local.full_secret_id} --project=${var.project_id} --data-file=-
 ```
 
 reference: https://cloud.google.com/sdk/gcloud/reference/secrets/versions/add
@@ -35,7 +44,7 @@ reference: https://cloud.google.com/sdk/gcloud/reference/secrets/versions/add
 
 1. Visit
 
-https://console.cloud.google.com/security/secret-manager/secret/${var.secret_id}/versions?project=${var.project_id}
+https://console.cloud.google.com/security/secret-manager/secret/${local.full_secret_id}/versions?project=${var.project_id}
 
 2. Click "+NEW VERSION"; paste your value or upload it as a file. Click 'ADD NEW VERSION' to upload it.
 

--- a/infra/modules/gcp-secrets/main.tf
+++ b/infra/modules/gcp-secrets/main.tf
@@ -7,7 +7,7 @@ resource "google_secret_manager_secret" "secret" {
   for_each = var.secrets
 
   project   = var.secret_project
-  secret_id = each.key
+  secret_id = "${var.path_prefix}${each.key}"
 
   replication {
     user_managed {

--- a/infra/modules/gcp-secrets/variables.tf
+++ b/infra/modules/gcp-secrets/variables.tf
@@ -21,3 +21,9 @@ variable "secret_project" {
   type        = string
   description = "ID of project in which to store SA key as secret"
 }
+
+variable "path_prefix" {
+  type        = string
+  description = "A prefix to add to the secret path."
+  default     = ""
+}

--- a/infra/modules/gcp-sm-rules/main.tf
+++ b/infra/modules/gcp-sm-rules/main.tf
@@ -1,0 +1,44 @@
+# stores Psoxy RULES as GCP Secret Manager Secret
+
+# not the 'right' solution, as this data isn't secret. But there's no "Config Parameter" service
+# solution in GCP really and this makes GCP setup most analogous to AWS.
+
+locals {
+  # size limits, in bytes
+  # see: https://cloud.google.com/secret-manager/quotas
+  secret_manager_size_limit = 65536
+
+  # read rules from file
+  rules_plain      = file(var.file_path)
+
+  # compress if necessary; but otherwise leave plain so human readable
+  rules_compressed = base64gzip(local.rules_plain)
+  use_compressed   = length(local.rules_plain) > local.secret_manager_size_limit
+  param_value      = local.use_compressed ? local.rules_compressed : local.rules_plain
+}
+
+resource "google_secret_manager_secret" "rules" {
+  secret_id = "${var.prefix}RULES"
+
+  replication {
+    automatic = true # why not? nothing secret about it
+  }
+}
+
+resource "google_secret_manager_secret_version" "rules" {
+  secret      = google_secret_manager_secret.rules.id
+  secret_data = local.param_value
+
+  lifecycle {
+    precondition {
+      condition     = length(local.param_value) > local.secret_manager_size_limit
+      error_message = "Rules on file ${var.file_path} are too big to store"
+    }
+  }
+}
+
+output "rules_hash" {
+  value = sha1(local.rules_plain)
+}
+
+

--- a/infra/modules/gcp-sm-rules/variables.tf
+++ b/infra/modules/gcp-sm-rules/variables.tf
@@ -1,0 +1,19 @@
+
+
+variable "prefix" {
+  type = string
+}
+
+variable "file_path" {
+  type = string
+
+  validation {
+    condition     = fileexists(var.file_path)
+    error_message = "The file path does not exist."
+  }
+
+  validation {
+    condition     = endswith(var.file_path, ".yaml")
+    error_message = "Rules should be plain .yaml file."
+  }
+}

--- a/infra/modules/gcp/variables.tf
+++ b/infra/modules/gcp/variables.tf
@@ -36,3 +36,15 @@ variable "psoxy_version" {
   description = "IGNORED; version of psoxy to deploy"
   default     = null
 }
+
+variable "environment_id_prefix" {
+  type        = string
+  description = "A prefix to give to all resources created/consumed by this module."
+  default     = ""
+}
+
+variable "config_parameter_prefix" {
+  type        = string
+  description = "A prefix to give to all config parameters (GCP Secret Manager Secrets) created/consumed by this module."
+  default     = ""
+}

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GcpModule.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GcpModule.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 public interface GcpModule {
 
 
+    //NOTE: this is just convention; `-` is allowed in GCP Secret Manager Secret IDs
     static String asSecretManagerNamespace(String functionName) {
         return functionName.toUpperCase().replace("-", "_");
     }


### PR DESCRIPTION
### Features
 - `custom_rest_rules` support in GCP
 - option to impersonate a GCP SA when deploying, rather than be auth'd directly
 - support to pass `environment_id` / `config_parameter_path`, to aid in deploying multiple Psoxy configurations within same GCP project (mainly dev use-case)

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204332867116146
  - https://app.asana.com/0/0/1204364771334903
  - https://app.asana.com/0/0/1203715901381860