### PR TITLE
gcp docs and IAM improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Working tracking of changes, updated as work done prior to release.  Please revi
 
 ## [0.4.20](https://github.com/Worklytics/psoxy/releases/tag/v0.4.20)
 
+Due to module refactoring, you will need a `terraform init`.
+
 Changes:
   * you may see grants of the role `iam.serviceAccountKeyAdmin` on individual GCP service accounts
     in your Terraform plan. These grants are required to allow terraform to create/manage service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Working tracking of changes, updated as work done prior to release.  Please revi
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.20](https://github.com/Worklytics/psoxy/releases/tag/v0.4.20)
+
+Changes:
+  * you may see grants of the role `iam.serviceAccountKeyAdmin` on individual GCP service accounts
+    in your Terraform plan. These grants are required to allow terraform to create/manage service
+    account keys, which is only needed for service accounts connecting to Google Workspace APIs.
+    Previously, this role was a pre-req expected to be granted at the project-level; this more
+    granular approach improves security. If you previously granted `iam.serviceAccountKeyAdmin` at
+    a GCP Project Level, you can now remove this.
+
 
 ## [v0.4.18](https://github.com/Worklytics/psoxy/releases/tag/v0.4.18)
 

--- a/docs/gcp/getting-started.md
+++ b/docs/gcp/getting-started.md
@@ -21,13 +21,13 @@ Service Account Keys and activate Google Workspace APIs.
       - we recommend a *dedicated* GCP project for your deployment, to provide an implicit security
         boundary around your infrastructure as well as simplify monitoring/cleanup
 
-  - a GCP (Google) user or Service Account with permissions to create Service Accounts, Secrets,
+  - a GCP (Google) user or Service Account with permissions to provision Service Accounts, Secrets,
     Storage Buckets, Cloud Functions, and enable APIs within that project. eg:
       * [Cloud Functions Admin](https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin) - proxy instances are deployed as GCP cloud functions
       * [Cloud Storage Admin](https://cloud.google.com/iam/docs/understanding-roles#storage.admin) - processing of bulk data (such as HRIS exports) uses GCS buckets
       * [IAM Role Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.roles.admin) - create custom roles for the proxy, to follow principle of least privilege
       * [Secret Manager Admin](https://cloud.google.com/iam/docs/understanding-roles#secretmanager.admin) - your API keys and pseudonymization salt is stored in Secret Manager
-      * [Service Account Creator](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountCreator) - create Service Accounts to personify Cloud Functions (aka, 'Create Service Accounts' in GCP console UX)
+      * [Service Account Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountAdmin) - admin Service Accounts that personify Cloud Functions or are used as Google Workspace API connections
       * [Service Usage Admin](https://cloud.google.com/iam/docs/understanding-roles#serviceusage.serviceUsageAdmin) - you will need to enable various GCP APIs
 
   - the following APIs enabled in the project: (via [GCP Console](https://console.cloud.google.com/projectselector2/apis/dashboard))

--- a/docs/gcp/getting-started.md
+++ b/docs/gcp/getting-started.md
@@ -22,6 +22,7 @@ Service Account Keys and activate Google Workspace APIs.
         boundary around your infrastructure as well as simplify monitoring/cleanup
   - the following APIs enabled in the project: (via [GCP Console](https://console.cloud.google.com/projectselector2/apis/dashboard))
       - [Service Usage API](https://console.cloud.google.com/apis/library/serviceusage.googleapis.com) (`serviceusage.googleapis.com`)
+      - [IAM Service Account Credentials API](https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com) (`iamcredentials.googleapis.com`) - generally needed to support authenticating Terraform. May not be needed if you're running `terraform` within a GCP environment.
   - a GCP (Google) user or Service Account with permissions to create Service Accounts, Secrets,
     Storage Buckets, Cloud Functions, and enable APIs within that project. eg:
      * [Service Account Creator](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountCreator) - create Service Accounts to personify Cloud Functions (aka, 'Create Service Accounts' in GCP console UX)

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -125,24 +125,14 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret"
   role      = "roles/secretmanager.secretAccessor"
 }
 
-
-data "google_client_openid_userinfo" "me" {
-
+module "tf_runner" {
+  source = "../../modules/gcp-tf-runner"
 }
-
-locals {
-  # hacky way to determine if Terraform running as a service account or not
-  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
-
-  tf_qualifier = local.tf_is_service_account ? "serviceAccount:" : "user:"
-  tf_principal = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
-}
-
 
 # to provision Cloud Function, TF must be able to act as the service account that the function will
 # run as
 resource "google_service_account_iam_member" "act_as" {
-  member             = local.tf_principal
+  member             = module.tf_runner.iam_principal
   role               = "roles/iam.serviceAccountUser"
   service_account_id = google_service_account.service-account.id
 }

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -37,16 +37,8 @@ locals {
   }
 }
 
-data "google_client_openid_userinfo" "me" {
-
-}
-
-locals {
-  # hacky way to determine if Terraform running as a service account or not
-  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
-
-  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
-  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+module "tf_runner" {
+  source = "../../modules/gcp-tf-runner"
 }
 
 data "google_service_account" "function" {
@@ -57,7 +49,7 @@ data "google_service_account" "function" {
 # to provision Cloud Function, TF must be able to act as the service account that the function will
 # run as
 resource "google_service_account_iam_member" "act_as" {
-  member             = local.tf_principal
+  member             = module.tf_runner.iam_principal
   role               = "roles/iam.serviceAccountUser"
   service_account_id = data.google_service_account.function.id
 }

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -37,6 +37,32 @@ locals {
   }
 }
 
+data "google_client_openid_userinfo" "me" {
+
+}
+
+locals {
+  # hacky way to determine if Terraform running as a service account or not
+  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
+
+  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
+  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+}
+
+data "google_service_account" "function" {
+  account_id = var.service_account_email
+}
+
+
+# to provision Cloud Function, TF must be able to act as the service account that the function will
+# run as
+resource "google_service_account_iam_member" "act_as" {
+  member             = local.tf_principal
+  role               = "roles/iam.serviceAccountUser"
+  service_account_id = data.google_service_account.function.id
+}
+
+
 resource "google_cloudfunctions_function" "function" {
   name        = "${var.environment_id_prefix}${var.instance_id}"
   description = "Psoxy Connector - ${var.source_kind}"
@@ -79,7 +105,8 @@ resource "google_cloudfunctions_function" "function" {
   }
 
   depends_on = [
-    google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret
+    google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret,
+    google_service_account_iam_member.act_as
   ]
 }
 

--- a/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
+++ b/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
@@ -8,22 +8,14 @@
 # TODO: extract this to its own repo or something, so can consume from our main infra repo. it's
 # similar to src/modules/google-workspace-dwd-connector/main.tf in the main infra repo
 
-data "google_client_openid_userinfo" "me" {
-
-}
-
-locals {
-  # hacky way to determine if Terraform running as a service account or not
-  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
-
-  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
-  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+module "tf_runner" {
+  source = "../../modules/gcp-tf-runner"
 }
 
 # grant this directly on SA, jit for when we know it is needed to create keys
 # (SA keys are needed only for SAs that are used to connect to Google Workspace APIs)
 resource "google_service_account_iam_member" "key_admin" {
-  member             = local.tf_principal
+  member             = module.tf_runner.iam_principal
   role               = "roles/iam.serviceAccountKeyAdmin"
   service_account_id = var.service_account_id
 }

--- a/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
+++ b/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
@@ -8,7 +8,25 @@
 # TODO: extract this to its own repo or something, so can consume from our main infra repo. it's
 # similar to src/modules/google-workspace-dwd-connector/main.tf in the main infra repo
 
+data "google_client_openid_userinfo" "me" {
 
+}
+
+locals {
+  # hacky way to determine if Terraform running as a service account or not
+  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
+
+  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
+  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+}
+
+# grant this directly on SA, jit for when we know it is needed to create keys
+# (SA keys are needed only for SAs that are used to connect to Google Workspace APIs)
+resource "google_service_account_iam_member" "key_admin" {
+  member             = local.tf_principal
+  role               = "roles/iam.serviceAccountKeyAdmin"
+  service_account_id = var.service_account_id
+}
 
 # note this requires the terraform to be run regularly
 resource "time_rotating" "sa-key-rotation" {
@@ -27,6 +45,10 @@ resource "google_service_account_key" "key" {
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [
+    google_service_account_iam_member.key_admin
+  ]
 }
 
 module "gcp-secrets" {

--- a/infra/modules/gcp-sa-auth-key/main.tf
+++ b/infra/modules/gcp-sa-auth-key/main.tf
@@ -4,6 +4,26 @@
 # note this requires the terraform to be run regularly
 # q: even a worthwhile module? it's just a key with rotation ...
 
+data "google_client_openid_userinfo" "me" {
+
+}
+
+locals {
+  # hacky way to determine if Terraform running as a service account or not
+  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
+
+  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
+  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+}
+
+# grant this directly on SA, jit for when we know it is needed to create keys
+# (SA keys are needed only for SAs that are used to connect to Google Workspace APIs)
+resource "google_service_account_iam_member" "key_admin" {
+  member             = local.tf_principal
+  role               = "roles/iam.serviceAccountKeyAdmin"
+  service_account_id = var.service_account_id
+}
+
 resource "time_rotating" "sa-key-rotation" {
   rotation_days = var.rotation_days
 }
@@ -20,4 +40,8 @@ resource "google_service_account_key" "key" {
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [
+    google_service_account_iam_member.key_admin
+  ]
 }

--- a/infra/modules/gcp-sa-auth-key/main.tf
+++ b/infra/modules/gcp-sa-auth-key/main.tf
@@ -4,22 +4,15 @@
 # note this requires the terraform to be run regularly
 # q: even a worthwhile module? it's just a key with rotation ...
 
-data "google_client_openid_userinfo" "me" {
 
-}
-
-locals {
-  # hacky way to determine if Terraform running as a service account or not
-  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
-
-  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
-  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+module "tf_runner" {
+  source = "../../modules/gcp-tf-runner"
 }
 
 # grant this directly on SA, jit for when we know it is needed to create keys
 # (SA keys are needed only for SAs that are used to connect to Google Workspace APIs)
 resource "google_service_account_iam_member" "key_admin" {
-  member             = local.tf_principal
+  member             = module.tf_runner.iam_principal
   role               = "roles/iam.serviceAccountKeyAdmin"
   service_account_id = var.service_account_id
 }

--- a/infra/modules/gcp-tf-runner/main.tf
+++ b/infra/modules/gcp-tf-runner/main.tf
@@ -1,0 +1,33 @@
+# logic to get (and determine) useful information about the GCP entity that Terraform is auth'd as
+#
+# NOTE: this is not *proper* Terraform style, as re-use of it will result in "deeper" Terraform
+# module structure, where modules call all modules in very hierarchical way. But it was repeated 4-5
+# times throughout the code base, and includes some hard-coded convention stuff that imho is better
+# to have in one place.
+
+data "google_client_openid_userinfo" "me" {
+
+}
+
+locals {
+  # hacky way to determine if Terraform running as a service account or not
+  tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
+
+  tf_qualifier          = local.tf_is_service_account ? "serviceAccount:" : "user:"
+  tf_principal          = "${local.tf_qualifier}${data.google_client_openid_userinfo.me.email}"
+}
+
+output "email" {
+  value       = data.google_client_openid_userinfo.me.email
+  description = "The email address of the Terraform runner"
+}
+
+output "is_service_account" {
+  value       = local.tf_is_service_account
+  description = "Whether Terraform is running as a service account or not"
+}
+
+output "iam_principal" {
+  value       = local.tf_principal
+  description = "The Terraform runner as a 'principal' for use in GCP IAM policies"
+}

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -6,16 +6,20 @@ locals {
 
 
 # activate required GCP service APIs
+# NOTE: used in lieu of 'google_project_services' because that resouce is *authorative*, so will
+# disable other APIs that are enabled in the project - which may not be what we want if shared
+# project, or if other services used to support (eg, monitoring APIs or somthing)
 resource "google_project_service" "gcp-infra-api" {
   for_each = toset([
     "cloudbuild.googleapis.com", # some modes of Cloud Functions seem to need this, so TBD
     "cloudfunctions.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com", # manage IAM via terraform (as of 2023-04-17, internal dev envs didn't have this; so really needed?)
     "secretmanager.googleapis.com",
     # "serviceusage.googleapis.com", # manage service APIs via terraform (prob already
   ])
 
-  service                    = each.key
+  service                   = each.key
   project                    = var.project_id
   disable_dependent_services = false
   disable_on_destroy         = false # disabling on destroy has potential to conflict with other uses of the project


### PR DESCRIPTION
### Fixes
  - **update prereq docs with roles, APIs** - now better tested as, per below, have experimented with runs via SA impersonation, which is a more rigorous test of perms
  - **`REST` psoxy case in GCP needs terraform runner to have `serviceAccountUser` on the cloud fucntion's SA.** previous attempt (#333) to grant `serviceAccountUser` role where needed got only the `bulk` case, not this `REST` case; missed this in testing because running Terraform as myself, I had `Owner` on the test GCP project so everything work. While testing other perms, ran Terraform as a restricted SA and found this problem.
  - **terraform runner need `serviceAccountKeyAdmin`** - this branch does it on each individual SA where needed, rather than rely on project-level grant which is less secure



### Change implications

 - dependencies added/changed? **no**
