### PR TITLE
poc of ParameterSpec on Endpoints

### DIFF
--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
@@ -24,7 +24,6 @@ public class Endpoint {
     String pathRegex;
 
     /**
-     * ALPHA FEATURE
      * path template, eg, /api/v1/{id}/foo/{bar}
      *
      * @see "https://swagger.io/docs/specification/paths-and-operations/"
@@ -33,6 +32,14 @@ public class Endpoint {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String pathTemplate;
+
+
+    /**
+     * if parameters appearing in pathTemplate appear in this, must validate against this to match
+     * the endpoint
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    List<ParameterSpec> pathParameterConstraints;
 
     //if provided, only query params in this list will be allowed
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ParameterSpec.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ParameterSpec.java
@@ -1,0 +1,37 @@
+package com.avaulta.gateway.rules;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParameterSpec {
+
+    String name;
+
+    ParameterSchema schema;
+
+    // subset of JsonSchema for now; in theory, *should* be the full thing but that starts to get
+    // a little crazy for PathParam/QueryParam use case
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ParameterSchema {
+
+        String type;
+
+        // in theory, `null`, numbers, or Strings all valid
+        // see: https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values
+        @JsonProperty("enum")
+        List<Object> enumValues;
+
+        static ParameterSchema type(String type) {
+            return ParameterSchema.builder().type(type).build();
+        }
+    }
+}


### PR DESCRIPTION
### Features
 - support putting constraints on path parameters, to allow `pathTemplate`s to cover more API cases without opening up wide permutations (eg, parameterize version in API paths, without opening ALL versions)

### Change implications

 - dependencies added/changed? **no**
