### PR TITLE
S147 AWS credentials sourcing for test tools

### DIFF
--- a/tools/psoxy-test/package-lock.json
+++ b/tools/psoxy-test/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.199.0",
         "@aws-sdk/client-s3": "^3.199.0",
+        "@aws-sdk/credential-providers": "^3.316.0",
         "@google-cloud/logging": "^10.4.0",
         "@google-cloud/storage": "^6.9.2",
         "aws4": "^1.11.0",
@@ -222,6 +223,927 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.316.0.tgz",
+      "integrity": "sha512-+x0FvG+zXwR40O/gmksxpMUc2DHTdezZZZjOMmd8Z413zb6JZEu4lBweA9pYjXiUYuYrLCd+MP70JI8xzjs17w==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.316.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.316.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.316.0.tgz",
+      "integrity": "sha512-wGXfIhR0lJGB8QTT0fwSwwklHePHxd2GW3IQt3trXnEYe0frmJ7vYRnVL5CSRKsikLDmaU7ll3SdsshMzQzo3w==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.316.0.tgz",
+      "integrity": "sha512-e2fvC7o42YV+LcZYfXCcvBn4L7NM9oNccnZ7T+pS6SFpHZlaqkw4uuQMRE6iUAof+Id7Mt7xDrz1x2yGlP+8GA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.316.0.tgz",
+      "integrity": "sha512-5SD59+DRVy1mKckGs/5J8OwWpRS3E5v4BX19XaX/s9JJ5Rw9aZd9DP4SZVpeNXztIPjkQSEzHgrUVlZFB1QJgg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.316.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-sdk-sts": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz",
+      "integrity": "sha512-ZADkpdEjFCAXyzEpYbCRENlZ/AQEwevWdPd2yshjNo7xvOcepv4pPIBpYd8h9LvRafSLGA7zlWDz84hkIt+HKA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.316.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.316.0.tgz",
+      "integrity": "sha512-oE1LTXP8XZp4bT8LhBeolMRiz0RwnmHDC2XpUmWO8LTmbDNrQO0mVzxEvXDLeKaN5BIFIJqNFlMgjWUMa9Kwcw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.316.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.316.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.316.0.tgz",
+      "integrity": "sha512-8/O2twlsoV1bDkZ9jd7JCMWsftfyoTyRT1UYscsKZGUDEgZRAxRkzS3GLYuLXEWNuxb1OB9rYk/cEJoxwy7T9g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.316.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/hash-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
+      "integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+      "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.316.0.tgz",
+      "integrity": "sha512-foJ2YmB8A/mtp52riO2zdmBgzA3IpASNgUhY9FZg1BKpGcjqLQDGYP+BY3BA0H7CFsMa4PCf13M5wWwn1onyBA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.316.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/url-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
+      "integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.211.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
@@ -431,6 +1353,43 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.316.0.tgz",
+      "integrity": "sha512-tHfYEhVfAwauEFkHCgqTWASm3AN8jD3C8ecbnBFIFuBKZFQG+QwlUrJc05jOMx2xRctA7NRm8lD3YmvWmfYw1g==",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.316.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
@@ -538,6 +1497,906 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.316.0.tgz",
+      "integrity": "sha512-PH5qpgVEcRTHnG/xJ01NlYu85YBhHr2ZTgPweuHS5RDNvzuEaoCH5U7BNC8CSfpHXaGACCNYalG8kjPSFiFmjA==",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.316.0",
+        "@aws-sdk/client-sso": "3.316.0",
+        "@aws-sdk/client-sts": "3.316.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.316.0",
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.316.0",
+        "@aws-sdk/credential-provider-node": "3.316.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.316.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.316.0.tgz",
+      "integrity": "sha512-wGXfIhR0lJGB8QTT0fwSwwklHePHxd2GW3IQt3trXnEYe0frmJ7vYRnVL5CSRKsikLDmaU7ll3SdsshMzQzo3w==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.316.0.tgz",
+      "integrity": "sha512-e2fvC7o42YV+LcZYfXCcvBn4L7NM9oNccnZ7T+pS6SFpHZlaqkw4uuQMRE6iUAof+Id7Mt7xDrz1x2yGlP+8GA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.316.0.tgz",
+      "integrity": "sha512-5SD59+DRVy1mKckGs/5J8OwWpRS3E5v4BX19XaX/s9JJ5Rw9aZd9DP4SZVpeNXztIPjkQSEzHgrUVlZFB1QJgg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.316.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-sdk-sts": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz",
+      "integrity": "sha512-ZADkpdEjFCAXyzEpYbCRENlZ/AQEwevWdPd2yshjNo7xvOcepv4pPIBpYd8h9LvRafSLGA7zlWDz84hkIt+HKA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.316.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.316.0.tgz",
+      "integrity": "sha512-oE1LTXP8XZp4bT8LhBeolMRiz0RwnmHDC2XpUmWO8LTmbDNrQO0mVzxEvXDLeKaN5BIFIJqNFlMgjWUMa9Kwcw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.316.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.316.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.316.0.tgz",
+      "integrity": "sha512-8/O2twlsoV1bDkZ9jd7JCMWsftfyoTyRT1UYscsKZGUDEgZRAxRkzS3GLYuLXEWNuxb1OB9rYk/cEJoxwy7T9g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.316.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/token-providers": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/hash-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/signature-v4": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
+      "integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+      "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/querystring-builder": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/property-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.316.0.tgz",
+      "integrity": "sha512-foJ2YmB8A/mtp52riO2zdmBgzA3IpASNgUhY9FZg1BKpGcjqLQDGYP+BY3BA0H7CFsMa4PCf13M5wWwn1onyBA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.316.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/shared-ini-file-loader": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/url-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
+      "integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.310.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/eventstream-codec": {
@@ -1240,6 +3099,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-stream-browser": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.208.0.tgz",
@@ -1309,6 +3188,18 @@
         }
       }
     },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
@@ -1324,6 +3215,29 @@
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4817,9 +6731,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -5369,6 +7283,777 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.316.0.tgz",
+      "integrity": "sha512-+x0FvG+zXwR40O/gmksxpMUc2DHTdezZZZjOMmd8Z413zb6JZEu4lBweA9pYjXiUYuYrLCd+MP70JI8xzjs17w==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.316.0",
+        "@aws-sdk/config-resolver": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.316.0",
+        "@aws-sdk/fetch-http-handler": "3.310.0",
+        "@aws-sdk/hash-node": "3.310.0",
+        "@aws-sdk/invalid-dependency": "3.310.0",
+        "@aws-sdk/middleware-content-length": "3.310.0",
+        "@aws-sdk/middleware-endpoint": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.310.0",
+        "@aws-sdk/middleware-logger": "3.310.0",
+        "@aws-sdk/middleware-recursion-detection": "3.310.0",
+        "@aws-sdk/middleware-retry": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-user-agent": "3.310.0",
+        "@aws-sdk/node-config-provider": "3.310.0",
+        "@aws-sdk/node-http-handler": "3.310.0",
+        "@aws-sdk/protocol-http": "3.310.0",
+        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+        "@aws-sdk/util-defaults-mode-node": "3.316.0",
+        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.310.0",
+        "@aws-sdk/util-user-agent-node": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.316.0.tgz",
+          "integrity": "sha512-wGXfIhR0lJGB8QTT0fwSwwklHePHxd2GW3IQt3trXnEYe0frmJ7vYRnVL5CSRKsikLDmaU7ll3SdsshMzQzo3w==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.316.0.tgz",
+          "integrity": "sha512-e2fvC7o42YV+LcZYfXCcvBn4L7NM9oNccnZ7T+pS6SFpHZlaqkw4uuQMRE6iUAof+Id7Mt7xDrz1x2yGlP+8GA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.316.0.tgz",
+          "integrity": "sha512-5SD59+DRVy1mKckGs/5J8OwWpRS3E5v4BX19XaX/s9JJ5Rw9aZd9DP4SZVpeNXztIPjkQSEzHgrUVlZFB1QJgg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-node": "3.316.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-sdk-sts": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "fast-xml-parser": "4.1.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+          "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+          "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+          "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz",
+          "integrity": "sha512-ZADkpdEjFCAXyzEpYbCRENlZ/AQEwevWdPd2yshjNo7xvOcepv4pPIBpYd8h9LvRafSLGA7zlWDz84hkIt+HKA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.316.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.316.0.tgz",
+          "integrity": "sha512-oE1LTXP8XZp4bT8LhBeolMRiz0RwnmHDC2XpUmWO8LTmbDNrQO0mVzxEvXDLeKaN5BIFIJqNFlMgjWUMa9Kwcw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-ini": "3.316.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.316.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+          "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.316.0.tgz",
+          "integrity": "sha512-8/O2twlsoV1bDkZ9jd7JCMWsftfyoTyRT1UYscsKZGUDEgZRAxRkzS3GLYuLXEWNuxb1OB9rYk/cEJoxwy7T9g==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.316.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/token-providers": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+          "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+          "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+          "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+          "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+          "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+          "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+          "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+          "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+          "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "tslib": "^2.5.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+          "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+          "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+          "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/signature-v4": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+          "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
+          "integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+          "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+          "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+          "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+          "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+          "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+          "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.316.0.tgz",
+          "integrity": "sha512-foJ2YmB8A/mtp52riO2zdmBgzA3IpASNgUhY9FZg1BKpGcjqLQDGYP+BY3BA0H7CFsMa4PCf13M5wWwn1onyBA==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.316.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+          "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+          "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+          "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
+          "integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+          "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+          "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+          "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
     "@aws-sdk/client-s3": {
       "version": "3.211.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
@@ -5563,6 +8248,36 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.316.0.tgz",
+      "integrity": "sha512-tHfYEhVfAwauEFkHCgqTWASm3AN8jD3C8ecbnBFIFuBKZFQG+QwlUrJc05jOMx2xRctA7NRm8lD3YmvWmfYw1g==",
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.316.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
     "@aws-sdk/credential-provider-env": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
@@ -5649,6 +8364,756 @@
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.316.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.316.0.tgz",
+      "integrity": "sha512-PH5qpgVEcRTHnG/xJ01NlYu85YBhHr2ZTgPweuHS5RDNvzuEaoCH5U7BNC8CSfpHXaGACCNYalG8kjPSFiFmjA==",
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.316.0",
+        "@aws-sdk/client-sso": "3.316.0",
+        "@aws-sdk/client-sts": "3.316.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.316.0",
+        "@aws-sdk/credential-provider-env": "3.310.0",
+        "@aws-sdk/credential-provider-imds": "3.310.0",
+        "@aws-sdk/credential-provider-ini": "3.316.0",
+        "@aws-sdk/credential-provider-node": "3.316.0",
+        "@aws-sdk/credential-provider-process": "3.310.0",
+        "@aws-sdk/credential-provider-sso": "3.316.0",
+        "@aws-sdk/credential-provider-web-identity": "3.310.0",
+        "@aws-sdk/property-provider": "3.310.0",
+        "@aws-sdk/types": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+          "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.316.0.tgz",
+          "integrity": "sha512-wGXfIhR0lJGB8QTT0fwSwwklHePHxd2GW3IQt3trXnEYe0frmJ7vYRnVL5CSRKsikLDmaU7ll3SdsshMzQzo3w==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.316.0.tgz",
+          "integrity": "sha512-e2fvC7o42YV+LcZYfXCcvBn4L7NM9oNccnZ7T+pS6SFpHZlaqkw4uuQMRE6iUAof+Id7Mt7xDrz1x2yGlP+8GA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.316.0.tgz",
+          "integrity": "sha512-5SD59+DRVy1mKckGs/5J8OwWpRS3E5v4BX19XaX/s9JJ5Rw9aZd9DP4SZVpeNXztIPjkQSEzHgrUVlZFB1QJgg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-node": "3.316.0",
+            "@aws-sdk/fetch-http-handler": "3.310.0",
+            "@aws-sdk/hash-node": "3.310.0",
+            "@aws-sdk/invalid-dependency": "3.310.0",
+            "@aws-sdk/middleware-content-length": "3.310.0",
+            "@aws-sdk/middleware-endpoint": "3.310.0",
+            "@aws-sdk/middleware-host-header": "3.310.0",
+            "@aws-sdk/middleware-logger": "3.310.0",
+            "@aws-sdk/middleware-recursion-detection": "3.310.0",
+            "@aws-sdk/middleware-retry": "3.310.0",
+            "@aws-sdk/middleware-sdk-sts": "3.310.0",
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/middleware-user-agent": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/node-http-handler": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/smithy-client": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.316.0",
+            "@aws-sdk/util-defaults-mode-node": "3.316.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "@aws-sdk/util-user-agent-browser": "3.310.0",
+            "@aws-sdk/util-user-agent-node": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "fast-xml-parser": "4.1.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+          "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+          "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+          "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz",
+          "integrity": "sha512-ZADkpdEjFCAXyzEpYbCRENlZ/AQEwevWdPd2yshjNo7xvOcepv4pPIBpYd8h9LvRafSLGA7zlWDz84hkIt+HKA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.316.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.316.0.tgz",
+          "integrity": "sha512-oE1LTXP8XZp4bT8LhBeolMRiz0RwnmHDC2XpUmWO8LTmbDNrQO0mVzxEvXDLeKaN5BIFIJqNFlMgjWUMa9Kwcw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/credential-provider-ini": "3.316.0",
+            "@aws-sdk/credential-provider-process": "3.310.0",
+            "@aws-sdk/credential-provider-sso": "3.316.0",
+            "@aws-sdk/credential-provider-web-identity": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+          "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.316.0.tgz",
+          "integrity": "sha512-8/O2twlsoV1bDkZ9jd7JCMWsftfyoTyRT1UYscsKZGUDEgZRAxRkzS3GLYuLXEWNuxb1OB9rYk/cEJoxwy7T9g==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.316.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/token-providers": "3.316.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+          "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
+          "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+          "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+          "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+          "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+          "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/url-parser": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+          "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+          "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+          "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+          "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/service-error-classification": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-retry": "3.310.0",
+            "tslib": "^2.5.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+          "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+          "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+          "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/signature-v4": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+          "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
+          "integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-endpoints": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+          "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+          "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.310.0",
+            "@aws-sdk/protocol-http": "3.310.0",
+            "@aws-sdk/querystring-builder": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+          "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
+          "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
+          "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+          "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+          "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+          "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.310.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+          "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.316.0.tgz",
+          "integrity": "sha512-foJ2YmB8A/mtp52riO2zdmBgzA3IpASNgUhY9FZg1BKpGcjqLQDGYP+BY3BA0H7CFsMa4PCf13M5wWwn1onyBA==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.316.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/shared-ini-file-loader": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+          "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+          "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+          "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+          "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+          "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+          "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+          "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.316.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+          "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.310.0",
+            "@aws-sdk/credential-provider-imds": "3.310.0",
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/property-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
+          "integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+          "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+          "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+          "requires": {
+            "@aws-sdk/types": "3.310.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+          "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.310.0",
+            "@aws-sdk/types": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
       }
     },
     "@aws-sdk/eventstream-codec": {
@@ -6199,6 +9664,22 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-retry": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/service-error-classification": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+          "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
+        }
+      }
+    },
     "@aws-sdk/util-stream-browser": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.208.0.tgz",
@@ -6249,6 +9730,34 @@
         "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+          "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -8833,9 +12342,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.199.0",
     "@aws-sdk/client-s3": "^3.199.0",
+    "@aws-sdk/credential-providers": "^3.316.0",
     "@google-cloud/logging": "^10.4.0",
     "@google-cloud/storage": "^6.9.2",
     "aws4": "^1.11.0",

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -28,7 +28,7 @@ async function testAWS(options, logger) {
   if (options.role) {
     logger.verbose(`Assuming role ${options.role}`);
   }
-  const client = aws.createS3Client(options.role, options.region);
+  const client = await aws.createS3Client(options.role, options.region);
 
 
   const parsedBucketInputOption = parseBucketOption(options.input);

--- a/tools/psoxy-test/psoxy-test-logs.js
+++ b/tools/psoxy-test/psoxy-test-logs.js
@@ -21,7 +21,7 @@ async function getAWSLogs(options = {}, logger) {
   if (options.role) {
     logger.verbose(`Assuming role ${options.role}`);
   }
-  const client = aws.createCloudWatchClient(options.role, options.region);
+  const client = await aws.createCloudWatchClient(options.role, options.region);
 
   logger.verbose(`Getting logs for ${options.logGroupName}`);
 


### PR DESCRIPTION
### Fixes
- [don't require AWS role in test tool](https://app.asana.com/0/1201039336231823/1204221882013002/f)

### Features
.

### Change implications

 - dependencies added/changed? **yes** [npm package](https://www.npmjs.com/package/@aws-sdk/credential-providers) `@aws-sdk/credential-providers`  -> Replaces AWS CLI for credentials sourcing (needed to sign Psoxy calls and instantiate CloudWatch and S3 clients).
 
