### PR TITLE
more AWS caller types, generalize testing support

### DIFF
--- a/docs/sources/zoom.md
+++ b/docs/sources/zoom.md
@@ -11,22 +11,26 @@ mode, no need to publish).
 
 1. Go to https://marketplace.zoom.us/develop/create and create an app of type "Server to Server OAuth"
 2. After creation, it will show the App Credentials. Share them with the AWS/GCP administrator, the
-   following secret values must be filled in the Secret Manager for the Proxy with the appropriate values:
+   following values must be filled in the AWS Systems Manager Parameter Store / GCP Secret Manager
+   for use by the proxy when authenticating with the Zoom API::
 
     - `PSOXY_ZOOM_CLIENT_ID`
     - `PSOXY_ZOOM_ACCOUNT_ID`
     - `PSOXY_ZOOM_CLIENT_SECRET`
-    - Note: Anytime the *client secret* is regenerated it needs to be updated in the Proxy too.
+
+    - NOTE: Anytime the *client secret* is regenerated it needs to be updated in the Proxy too.
+    - NOTE: *client secret* should be handled according to your organization's security policies for
+      API keys/secrets as, in combination with the above, allows access to your organization's data.
 
 3. Fill the information section
 
 4. Fill the scopes section, enabling the following:
 
     - Users / View all user information / `user:read:admin`
-        - To be able to gather information about the zoom users
+        - List information about the zoom user acounts, for enumeration / linking
     - Meetings / View all user meetings / `meeting:read:admin`
-        - Allows us to list all user meeting
+        - Listing all user meetings (work events / items)
     - Report / View report data / `report:read:admin`
-        - Last 6 months view for user meetings
+        - List historical (previous 6 months) user meetings (work events / items)
 
 5. Activate the app

--- a/infra/README.md
+++ b/infra/README.md
@@ -21,3 +21,4 @@ Please review the `README.md` within each provider's module for pre-reqs and usa
     the interfaces of these modules between minor patch versions (eg, `0.4.z` variants should not
     break).
 
+

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -72,6 +72,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
+  enable_testing                 = var.enable_testing
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -72,7 +72,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_testing                 = var.enable_testing
+  enable_deployment_testing      = var.enable_deployment_testing
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -72,7 +72,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_deployment_testing      = var.enable_deployment_testing
+  provision_testing_infra        = var.provision_testing_infra
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -69,9 +69,9 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for arn in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", arn)) > 0)
     ])
-    error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
+    error_message = "The values of caller_aws_arns should be AWS Resource Names for principals; something like 'arn:aws:iam::914358739851:root'."
   }
 }
 

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -49,7 +49,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "whether to provision infra needed to support testing of deployment"
   default     = false

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -49,7 +49,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "whether to provision infra needed to support testing of deployment"
   default     = false

--- a/infra/examples-dev/aws-google-workspace/variables.tf
+++ b/infra/examples-dev/aws-google-workspace/variables.tf
@@ -49,6 +49,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "caller_gcp_service_account_ids" {
   type        = list(string)
   description = "ids of GCP service accounts allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -59,6 +59,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
+  enable_testing                 = var.enable_testing
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -59,7 +59,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_deployment_testing      = var.enable_deployment_testing
+  provision_testing_infra        = var.provision_testing_infra
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -59,7 +59,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_testing                 = var.enable_testing
+  enable_deployment_testing      = var.enable_deployment_testing
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -102,7 +102,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "whether to provision infra needed to support testing of deployment"
   default     = false

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -51,7 +51,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
   }

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -102,6 +102,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/examples-dev/aws-msft-365/variables.tf
+++ b/infra/examples-dev/aws-msft-365/variables.tf
@@ -102,7 +102,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "whether to provision infra needed to support testing of deployment"
   default     = false

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -65,7 +65,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   install_test_tool              = var.install_test_tool
-  enable_testing                 = var.enable_testing
+  enable_deployment_testing      = var.enable_deployment_testing
   force_bundle                   = var.force_bundle
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -65,6 +65,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   install_test_tool              = var.install_test_tool
+  enable_testing                 = var.enable_testing
   force_bundle                   = var.force_bundle
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -65,7 +65,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   install_test_tool              = var.install_test_tool
-  enable_deployment_testing      = var.enable_deployment_testing
+  provision_testing_infra        = var.provision_testing_infra
   force_bundle                   = var.force_bundle
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -121,7 +121,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "whether to provision infra needed to support testing of deployment"
   default     = false

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -121,6 +121,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "install_test_tool" {
   type        = bool
   description = "whether to install the test tool (can be 'false' if Terraform not running from a machine where you intend to run tests of your Psoxy deployment)"

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -121,7 +121,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "whether to provision infra needed to support testing of deployment"
   default     = false

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -70,7 +70,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_deployment_testing      = var.enable_deployment_testing
+  provision_testing_infra        = var.provision_testing_infra
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -70,6 +70,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
+  enable_testing                 = var.enable_testing
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -70,7 +70,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_testing                 = var.enable_testing
+  enable_deployment_testing      = var.enable_deployment_testing
   caller_aws_arns                = var.caller_aws_arns
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   environment_name               = var.environment_name

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -49,7 +49,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -49,7 +49,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -75,7 +75,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
   }

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -49,6 +49,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "caller_gcp_service_account_ids" {
   type        = list(string)
   description = "ids of GCP service accounts allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"

--- a/infra/examples/aws-google-workspace/variables.tf
+++ b/infra/examples/aws-google-workspace/variables.tf
@@ -51,7 +51,7 @@ variable "force_bundle" {
 
 variable "enable_testing" {
   type        = bool
-  description = "whether to provision infra needed to support testing of deployment"
+  description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false
 }
 

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -59,6 +59,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
+  enable_testing                 = var.enable_testing
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -59,7 +59,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_deployment_testing      = var.enable_deployment_testing
+  provision_testing_infra        = var.provision_testing_infra
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -50,8 +50,8 @@ provider "azuread" {
 }
 
 module "psoxy" {
-  # source = "../../modular-examples/aws-msft-365"
-  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-msft-365?ref=v0.4.22"
+  source = "../../modular-examples/aws-msft-365"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-msft-365?ref=v0.4.22"
 
   aws_account_id                 = var.aws_account_id
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)
@@ -59,7 +59,7 @@ module "psoxy" {
   aws_ssm_param_root_path        = var.aws_ssm_param_root_path
   psoxy_base_dir                 = var.psoxy_base_dir
   force_bundle                   = var.force_bundle
-  enable_testing                 = var.enable_testing
+  enable_deployment_testing      = var.enable_deployment_testing
   caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
   caller_aws_arns                = var.caller_aws_arns
   enabled_connectors             = var.enabled_connectors

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -102,7 +102,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -102,7 +102,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -104,7 +104,7 @@ variable "force_bundle" {
 
 variable "enable_testing" {
   type        = bool
-  description = "whether to provision infra needed to support testing of deployment"
+  description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false
 }
 

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -51,7 +51,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
   }

--- a/infra/examples/aws-msft-365/variables.tf
+++ b/infra/examples/aws-msft-365/variables.tf
@@ -102,6 +102,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -297,23 +297,25 @@ module "psoxy-bulk" {
   source = "../../modules/aws-psoxy-bulk"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.22"
 
-  aws_account_id                  = var.aws_account_id
-  aws_assume_role_arn             = var.aws_assume_role_arn
-  instance_id                     = each.key
-  source_kind                     = each.value.source_kind
-  aws_region                      = var.aws_region
-  path_to_function_zip            = module.psoxy-aws.path_to_deployment_jar
-  function_zip_hash               = module.psoxy-aws.deployment_package_hash
-  psoxy_base_dir                  = var.psoxy_base_dir
-  rules                           = each.value.rules
-  global_parameter_arns           = module.global_secrets.secret_arns
-  path_to_instance_ssm_parameters = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
-  ssm_kms_key_ids                 = local.ssm_key_ids
-  sanitized_accessor_role_names   = [module.psoxy-aws.api_caller_role_name]
-  memory_size_mb                  = 1024
-  log_retention_days              = var.log_retention_days
-  sanitized_expiration_days       = var.bulk_sanitized_expiration_days
-  input_expiration_days           = var.bulk_input_expiration_days
+  aws_account_id                   = var.aws_account_id
+  aws_assume_role_arn              = var.aws_assume_role_arn
+  aws_role_to_assume_when_testing  = module.psoxy-aws.api_caller_role_arn
+  provision_iam_policy_for_testing = var.enable_testing
+  instance_id                      = each.key
+  source_kind                      = each.value.source_kind
+  aws_region                       = var.aws_region
+  path_to_function_zip             = module.psoxy-aws.path_to_deployment_jar
+  function_zip_hash                = module.psoxy-aws.deployment_package_hash
+  psoxy_base_dir                   = var.psoxy_base_dir
+  rules                            = each.value.rules
+  global_parameter_arns            = module.global_secrets.secret_arns
+  path_to_instance_ssm_parameters  = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
+  ssm_kms_key_ids                  = local.ssm_key_ids
+  sanitized_accessor_role_names    = [module.psoxy-aws.api_caller_role_name]
+  memory_size_mb                   = 1024
+  log_retention_days               = var.log_retention_days
+  sanitized_expiration_days        = var.bulk_sanitized_expiration_days
+  input_expiration_days            = var.bulk_input_expiration_days
 
   example_file = try(each.value.example_file, null)
 

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -299,8 +299,8 @@ module "psoxy-bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = var.enable_deployment_testing ? module.psoxy-aws.api_caller_role_arn : null
-  provision_iam_policy_for_testing = var.enable_deployment_testing
+  aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy-aws.api_caller_role_arn : null
+  provision_iam_policy_for_testing = var.provision_testing_infra
   instance_id                      = each.key
   source_kind                      = each.value.source_kind
   aws_region                       = var.aws_region

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -299,8 +299,8 @@ module "psoxy-bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy-aws.api_caller_role_arn : null
-  provision_iam_policy_for_testing = var.enable_testing
+  aws_role_to_assume_when_testing  = var.enable_deployment_testing ? module.psoxy-aws.api_caller_role_arn : null
+  provision_iam_policy_for_testing = var.enable_deployment_testing
   instance_id                      = each.key
   source_kind                      = each.value.source_kind
   aws_region                       = var.aws_region

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -299,7 +299,7 @@ module "psoxy-bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = module.psoxy-aws.api_caller_role_arn
+  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy-aws.api_caller_role_arn : null
   provision_iam_policy_for_testing = var.enable_testing
   instance_id                      = each.key
   source_kind                      = each.value.source_kind

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -107,7 +107,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -62,7 +62,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
   }

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -107,6 +107,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -107,7 +107,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -109,7 +109,7 @@ variable "force_bundle" {
 
 variable "enable_testing" {
   type        = bool
-  description = "whether to provision infra needed to support testing of deployment"
+  description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false
 }
 

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -351,8 +351,8 @@ module "psoxy-bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = var.enable_deployment_testing ? module.psoxy-aws.api_caller_role_arn : null
-  provision_iam_policy_for_testing = var.enable_deployment_testing
+  aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy-aws.api_caller_role_arn : null
+  provision_iam_policy_for_testing = var.provision_testing_infra
   instance_id                      = each.key
   source_kind                      = each.value.source_kind
   aws_region                       = var.aws_region

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -349,25 +349,27 @@ module "psoxy-bulk" {
   source = "../../modules/aws-psoxy-bulk"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.22"
 
-  aws_account_id                  = var.aws_account_id
-  aws_assume_role_arn             = var.aws_assume_role_arn
-  instance_id                     = each.key
-  source_kind                     = each.value.source_kind
-  aws_region                      = var.aws_region
-  path_to_function_zip            = module.psoxy-aws.path_to_deployment_jar
-  function_zip_hash               = module.psoxy-aws.deployment_package_hash
-  api_caller_role_arn             = module.psoxy-aws.api_caller_role_arn
-  api_caller_role_name            = module.psoxy-aws.api_caller_role_name
-  memory_size_mb                  = 1024
-  psoxy_base_dir                  = var.psoxy_base_dir
-  rules                           = each.value.rules
-  global_parameter_arns           = module.global_secrets.secret_arns
-  path_to_instance_ssm_parameters = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
-  ssm_kms_key_ids                 = local.ssm_key_ids
-  example_file                    = try(each.value.example_file, null)
-  log_retention_days              = var.log_retention_days
-  sanitized_expiration_days       = var.bulk_sanitized_expiration_days
-  input_expiration_days           = var.bulk_input_expiration_days
+  aws_account_id                   = var.aws_account_id
+  aws_assume_role_arn              = var.aws_assume_role_arn
+  aws_role_to_assume_when_testing  = module.psoxy-aws.api_caller_role_arn
+  provision_iam_policy_for_testing = var.enable_testing
+  instance_id                      = each.key
+  source_kind                      = each.value.source_kind
+  aws_region                       = var.aws_region
+  path_to_function_zip             = module.psoxy-aws.path_to_deployment_jar
+  function_zip_hash                = module.psoxy-aws.deployment_package_hash
+  api_caller_role_arn              = module.psoxy-aws.api_caller_role_arn
+  api_caller_role_name             = module.psoxy-aws.api_caller_role_name
+  memory_size_mb                   = 1024
+  psoxy_base_dir                   = var.psoxy_base_dir
+  rules                            = each.value.rules
+  global_parameter_arns            = module.global_secrets.secret_arns
+  path_to_instance_ssm_parameters  = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
+  ssm_kms_key_ids                  = local.ssm_key_ids
+  example_file                     = try(each.value.example_file, null)
+  log_retention_days               = var.log_retention_days
+  sanitized_expiration_days        = var.bulk_sanitized_expiration_days
+  input_expiration_days            = var.bulk_input_expiration_days
 
   sanitized_accessor_role_names = [
     module.psoxy-aws.api_caller_role_name

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -351,8 +351,8 @@ module "psoxy-bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy-aws.api_caller_role_arn : null
-  provision_iam_policy_for_testing = var.enable_testing
+  aws_role_to_assume_when_testing  = var.enable_deployment_testing ? module.psoxy-aws.api_caller_role_arn : null
+  provision_iam_policy_for_testing = var.enable_deployment_testing
   instance_id                      = each.key
   source_kind                      = each.value.source_kind
   aws_region                       = var.aws_region

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -351,7 +351,7 @@ module "psoxy-bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = module.psoxy-aws.api_caller_role_arn
+  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy-aws.api_caller_role_arn : null
   provision_iam_policy_for_testing = var.enable_testing
   instance_id                      = each.key
   source_kind                      = each.value.source_kind

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -62,7 +62,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
   }

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -88,6 +88,11 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
 
 variable "connector_display_name_suffix" {
   type        = string

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -88,7 +88,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -88,7 +88,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -90,7 +90,7 @@ variable "force_bundle" {
 
 variable "enable_testing" {
   type        = bool
-  description = "whether to provision infra needed to support testing of deployment"
+  description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false
 }
 

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -446,7 +446,7 @@ module "aws_psoxy_long_auth_connectors" {
   path_to_config                  = null
   aws_account_id                  = var.aws_account_id
   aws_assume_role_arn             = var.aws_assume_role_arn
-  aws_role_to_assume_for_tests    = module.psoxy-aws.api_caller_role_arn
+  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy-aws.api_caller_role_arn : null
   api_caller_role_arn             = module.psoxy_aws.api_caller_role_arn
   source_kind                     = each.value.source_kind
   path_to_repo_root               = var.psoxy_base_dir

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -444,8 +444,9 @@ module "aws_psoxy_long_auth_connectors" {
   path_to_function_zip            = module.psoxy_aws.path_to_deployment_jar
   function_zip_hash               = module.psoxy_aws.deployment_package_hash
   path_to_config                  = null
-  aws_assume_role_arn             = var.aws_assume_role_arn
   aws_account_id                  = var.aws_account_id
+  aws_assume_role_arn             = var.aws_assume_role_arn
+  aws_role_to_assume_for_tests    = module.psoxy-aws.api_caller_role_arn
   api_caller_role_arn             = module.psoxy_aws.api_caller_role_arn
   source_kind                     = each.value.source_kind
   path_to_repo_root               = var.psoxy_base_dir

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -526,8 +526,8 @@ module "psoxy_bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  provision_iam_policy_for_testing = var.enable_deployment_testing
-  aws_role_to_assume_when_testing  = var.enable_deployment_testing ? module.psoxy_aws.api_caller_role_arn : null
+  provision_iam_policy_for_testing = var.provision_testing_infra
+  aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy_aws.api_caller_role_arn : null
   instance_id                      = each.key
   source_kind                      = each.value.source_kind
   aws_region                       = var.aws_region

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -526,8 +526,8 @@ module "psoxy_bulk" {
 
   aws_account_id                   = var.aws_account_id
   aws_assume_role_arn              = var.aws_assume_role_arn
-  provision_iam_policy_for_testing = var.enable_testing
-  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy_aws.api_caller_role_arn : null
+  provision_iam_policy_for_testing = var.enable_deployment_testing
+  aws_role_to_assume_when_testing  = var.enable_deployment_testing ? module.psoxy_aws.api_caller_role_arn : null
   instance_id                      = each.key
   source_kind                      = each.value.source_kind
   aws_region                       = var.aws_region

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -446,7 +446,6 @@ module "aws_psoxy_long_auth_connectors" {
   path_to_config                  = null
   aws_account_id                  = var.aws_account_id
   aws_assume_role_arn             = var.aws_assume_role_arn
-  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy-aws.api_caller_role_arn : null
   api_caller_role_arn             = module.psoxy_aws.api_caller_role_arn
   source_kind                     = each.value.source_kind
   path_to_repo_root               = var.psoxy_base_dir
@@ -525,23 +524,25 @@ module "psoxy_bulk" {
   source = "../../modules/aws-psoxy-bulk"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.22"
 
-  aws_account_id                  = var.aws_account_id
-  aws_assume_role_arn             = var.aws_assume_role_arn
-  instance_id                     = each.key
-  source_kind                     = each.value.source_kind
-  aws_region                      = var.aws_region
-  path_to_function_zip            = module.psoxy_aws.path_to_deployment_jar
-  function_zip_hash               = module.psoxy_aws.deployment_package_hash
-  psoxy_base_dir                  = var.psoxy_base_dir
-  rules                           = each.value.rules
-  global_parameter_arns           = module.global_secrets.secret_arns
-  path_to_instance_ssm_parameters = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
-  ssm_kms_key_ids                 = local.ssm_key_ids
-  sanitized_accessor_role_names   = [module.psoxy_aws.api_caller_role_name]
-  memory_size_mb                  = 1024
-  sanitized_expiration_days       = var.bulk_sanitized_expiration_days
-  input_expiration_days           = var.bulk_input_expiration_days
-  example_file                    = each.value.example_file
+  aws_account_id                   = var.aws_account_id
+  aws_assume_role_arn              = var.aws_assume_role_arn
+  provision_iam_policy_for_testing = var.enable_testing
+  aws_role_to_assume_when_testing  = var.enable_testing ? module.psoxy_aws.api_caller_role_arn : null
+  instance_id                      = each.key
+  source_kind                      = each.value.source_kind
+  aws_region                       = var.aws_region
+  path_to_function_zip             = module.psoxy_aws.path_to_deployment_jar
+  function_zip_hash                = module.psoxy_aws.deployment_package_hash
+  psoxy_base_dir                   = var.psoxy_base_dir
+  rules                            = each.value.rules
+  global_parameter_arns            = module.global_secrets.secret_arns
+  path_to_instance_ssm_parameters  = "${var.aws_ssm_param_root_path}PSOXY_${upper(replace(each.key, "-", "_"))}_"
+  ssm_kms_key_ids                  = local.ssm_key_ids
+  sanitized_accessor_role_names    = [module.psoxy_aws.api_caller_role_name]
+  memory_size_mb                   = 1024
+  sanitized_expiration_days        = var.bulk_sanitized_expiration_days
+  input_expiration_days            = var.bulk_input_expiration_days
+  example_file                     = each.value.example_file
 
   environment_variables = merge(
     var.general_environment_variables,

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -102,7 +102,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_testing" {
+variable "enable_deployment_testing" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -56,7 +56,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::914358739851:root'."
   }

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -102,7 +102,7 @@ variable "force_bundle" {
   default     = false
 }
 
-variable "enable_deployment_testing" {
+variable "provision_testing_infra" {
   type        = bool
   description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -104,7 +104,7 @@ variable "force_bundle" {
 
 variable "enable_testing" {
   type        = bool
-  description = "whether to provision infra needed to support testing of deployment"
+  description = "Whether to provision infra needed to support testing of deployment. If false, it's left to you to ensure the AWS principal you use when running test scripts has the correct permissions."
   default     = false
 }
 

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -102,6 +102,12 @@ variable "force_bundle" {
   default     = false
 }
 
+variable "enable_testing" {
+  type        = bool
+  description = "whether to provision infra needed to support testing of deployment"
+  default     = false
+}
+
 variable "install_test_tool" {
   type        = bool
   description = "whether to install the test tool (can be 'false' if Terraform not running from a machine where you intend to run tests of your Psoxy deployment)"

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -71,6 +71,23 @@ variable "path_to_config" {
   default     = null
 }
 
+variable "aws_role_to_assume_when_testing" {
+  type        = string
+  description = "ARN of role to assume when testing instance. Leave blank to use default credentials of location from which you'll run tests (which must be for a principal with sufficient privileges, or use `provision_iam_policy_for_testing`)."
+  default     = null
+
+  validation {
+    condition     = var.aws_role_to_assume_when_testing == null || can(regex("^arn:aws:iam::\\d{12}:role/.*$", var.aws_role_to_assume_when_testing))
+    error_message = "if provided, aws_role_to_assume_when_testing must be a valid ARN of an IAM Role"
+  }
+}
+
+variable "provision_iam_policy_for_testing" {
+  type        = bool
+  description = "Whether to provision IAM policy and attach it to `aws_role_to_assume_when_testing`."
+  default     = false
+}
+
 variable "api_caller_role_arn" {
   type        = string
   description = "DEPRECATED; arn of role which can be assumed to call API"

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -95,7 +95,7 @@ ${local.command_npm_install}
 ```
    - ensure the location you're running from is authenticated as an AWS principal which can assume
      the role `${var.api_caller_role_arn}` ( `aws sts get-caller-identity` to determine who you're
-     authenticated as; if necessary, as this ARN to the `caller_aws_arns` list in the
+     authenticated as; if necessary, add this ARN to the `caller_aws_arns` list in the
      `terraform.tfvars` file of your configuration to allow it to assume that role)
 
 ### Make "test calls"

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -50,7 +50,7 @@ variable "caller_aws_arns" {
 
   validation {
     condition = alltrue([
-      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:\\w+$", i)) > 0)
+      for i in var.caller_aws_arns : (length(regexall("^arn:aws:iam::\\d{12}:((role|user)\\/)?\\w+$", i)) > 0)
     ])
     error_message = "The values of caller_aws_arns should be AWS Resource Names, something like 'arn:aws:iam::123123123123:root'."
   }

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -68,6 +68,7 @@ variable "install_test_tool" {
   default     = true
 }
 
+
 variable "deployment_id" {
   type        = string
   description = "unique identifier for this deployment (used to differentiate resource names)"

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -21,7 +21,7 @@ echo "# root directory of a clone of the psoxy repo " >> $TFVARS_FILE
 echo "#  - by default, it points to .terraform, where terraform clones the main psoxy repo" >> $TFVARS_FILE
 echo "#  - if you have a local clone of the psoxy repo you prefer to use, change this to point there" >> $TFVARS_FILE
 printf "psoxy_base_dir = \"${PSOXY_BASE_DIR}\"\n" >> $TFVARS_FILE
-printf "enable_testing = true\n" >> $TFVARS_FILE
+printf "provision_testing_infra = true\n" >> $TFVARS_FILE
 printf "\n" >> $TFVARS_FILE
 
 # pattern used to grep for provider at top-level of Terraform configuration

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -20,7 +20,9 @@ printf "# -- initialized with ${RELEASE_VERSION} of tools/init-tfvars.sh -- \n\n
 echo "# root directory of a clone of the psoxy repo " >> $TFVARS_FILE
 echo "#  - by default, it points to .terraform, where terraform clones the main psoxy repo" >> $TFVARS_FILE
 echo "#  - if you have a local clone of the psoxy repo you prefer to use, change this to point there" >> $TFVARS_FILE
-printf "psoxy_base_dir = \"${PSOXY_BASE_DIR}\"\n\n" >> $TFVARS_FILE
+printf "psoxy_base_dir = \"${PSOXY_BASE_DIR}\"\n" >> $TFVARS_FILE
+printf "enable_testing = true\n" >> $TFVARS_FILE
+printf "\n" >> $TFVARS_FILE
 
 # pattern used to grep for provider at top-level of Terraform configuration
 TOP_LEVEL_PROVIDER_PATTERN="^├── provider\[registry.terraform.io/hashicorp"
@@ -41,16 +43,17 @@ if test $AWS_PROVIDER_COUNT -ne 0; then
     printf "\taws_region=${BLUE}\"${AWS_REGION}\"${NC}\n"
 
     AWS_ARN=$(aws sts get-caller-identity --query Arn --output text)
-    printf "# AWS IAM role to assume when deploying your Psoxy infrastructure via Terraform\n" >> $TFVARS_FILE
-    printf "# - in most cases, this will be an AWS IAM role within the AWS account listed above\n" >> $TFVARS_FILE
-    printf "# - if your machine is already authenticated as an AWS principal with sufficient permissions, this can be omitted (or set to null)\n" >> $TFVARS_FILE
+    printf "# AWS IAM role to assume when deploying your Psoxy infrastructure via Terraform, if needed\n" >> $TFVARS_FILE
+    printf "# - this variable is used when you are authenticated as an AWS user which can assume the AWS role which actually has the requisite permissions to provision your infrastructure\n" >> $TFVARS_FILE
+    printf "#   (this is approach is good practice, as minimizes the privileges of the AWS user you habitually use and easily supports multi-account scenarios) \n" >> $TFVARS_FILE
+    printf "# - if you are already authenticated as a sufficiently privileged AWS Principal, you can omit this variable\n" >> $TFVARS_FILE
+    printf "# - often, this will be the default 'super-admin' role in the target AWS account, eg something like 'arn:aws:iam::123456789012:role/Admin'\n" >> $TFVARS_FILE
     printf "# - see https://github.com/Worklytics/psoxy/blob/${RELEASE_VERSION}/docs/aws/getting-started.md for details on required permissions\n" >> $TFVARS_FILE
-    printf "aws_assume_role_arn=\"${AWS_ARN}\" #(double-check this; perhaps needs to be a role within target account) \n\n" >> $TFVARS_FILE
-    printf "\taws_assume_role_arn=${BLUE}\"${AWS_ARN}\"${NC} (double-check this; perhaps needs to be a role within target account) \n\n"
+    printf "# aws_assume_role_arn=\"${AWS_ARN}\" #(double-check this; perhaps needs to be a role within target account) \n\n" >> $TFVARS_FILE
 
     printf "# AWS principals in the following list will be explicitly authorized to invoke your proxy instances\n" >> $TFVARS_FILE
     printf "#  - this is for initial testing/development; it can (and should) be empty for production-use\n" >> $TFVARS_FILE
-    printf "caller_aws_arns = [\n  # include your own here if desired for testing\n]\n\n" >> $TFVARS_FILE
+    printf "caller_aws_arns = [\n  \"${AWS_ARN}\" # for testing; can remove once prod-ready\n]\n\n" >> $TFVARS_FILE
 
     printf "# GCP service accounts with ids in the list below will be allowed to invoke your proxy instances\n" >> $TFVARS_FILE
     printf "#  - for initial testing/deployment, it can be empty list; it needs to be filled only once you're ready to authorize Worklytics to access your data\n" >> $TFVARS_FILE

--- a/tools/psoxy-test/cli-call.js
+++ b/tools/psoxy-test/cli-call.js
@@ -19,7 +19,7 @@ const { version } = require('./package.json');
     .requiredOption('-u, --url <url>', 'URL to call')
     .option('-f, --force <type>', 'Force deploy type: AWS or GCP')
     .option('-i, --impersonate <user>', 'User to impersonate, needed for certain connectors')
-    .option('-r, --role <arn>', 'AWS role to assume, use its ARN')
+    .option('-r, --role <arn>', 'ARN of AWS role to assume; if omitted, AWS CLI must be authenticated as a principal with perms to invoke the function directly')
     .option('-s, --save-to-file', 'Save test results to file', false)
     .option('--skip',
       'Skip sanitization rules, only works if function deployed in development mode',

--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -29,7 +29,7 @@ const { version } = require('./package.json');
     .requiredOption('-i, --input <bucketName>', 'Input bucket\'s name')
     .requiredOption('-f, --file <path/to/file>', 'Path of the file to be processed')
     .requiredOption('-o, --output <bucketName>', 'Output bucket\'s name')
-    .option('-r, --role <arn>', 'AWS role to assume, use its ARN')
+    .option('-r, --role <arn>', 'ARN of AWS role to assume; if omitted, AWS CLI must be authenticated as a principal with perms to write to input bucket and read from output bucket')
     .option('-re, --region <region>', 'AWS region of the buckets (input/output)',
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)

--- a/tools/psoxy-test/cli-logs.js
+++ b/tools/psoxy-test/cli-logs.js
@@ -21,7 +21,7 @@ const { version } = require('./package.json');
     .option('-p --project-id <projectId>', 'GCP: Name of the project that hosts the cloud function (Psoxy instance)')
     .option('-f --function-name <functionName>', 'GCP: Name of the cloud function from which to list entries')
     .option('-l, --log-group-name <logGroupName>', 'AWS: Log group to display')
-    .option('-r, --role <arn>', 'AWS: role to assume, use its ARN')
+    .option('-r, --role <arn>', 'AWS: ARN of IAM role to assume; if omitted, AWS CLI must be authenticated as a principal with perms to read from log group')
     .option('-re, --region <region>', 'AWS: region of your Psoxy instance',
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)


### PR DESCRIPTION
generally, a bunch of test examples were coupled to our IAM approach, eg AWS CLI auth'd as AWS user, which would assume a *super* admin role in the target AWS account when deploying/testing.

### Fixes
 - our test commands for bulk cases presumed Terraform running as a 'super admin' role that could read/write to all buckets
 - our test commands for REST cases defaulted to assumption of Terraform role, which again needed to be the 'super admin' to be able to 'invoke' the lambdas; while this worked for many customers in practice, these examples won't work in more rigorous IAM policy setups. (eg, there's no reason why the role that's applying the terraform configuration should be able to invoke lambdas)
 - initialization of `terraform.tfvars` worked in way that's only appropriate for the 'super admin' role approach

### Features
  - option to provisioning TestingPolicy and attach it to a testing role to better support bulk case (as `PsoxyCaller` role will never be able to test uploads)


### Change implications

 - dependencies added/changed? **no**
