### PR TITLE
fix GCP test

### DIFF
--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -200,7 +200,7 @@ Check that the Psoxy works as expected and it transforms the files of your input
 the rules you have defined:
 
 ```shell
-node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f ${local.example_file} -d GCP -i ${google_storage_bucket.input-bucket.name} -o ${module.output_bucket.bucket_name} -p ${var.project_id} -r ${var.region}
+node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f ${local.example_file} -d GCP -i ${google_storage_bucket.input-bucket.name} -o ${module.output_bucket.bucket_name}
 ```
 EOT
 }


### PR DESCRIPTION
### Fixes
 - args (added in 0.4.19) that don't seem to be needed (commit - https://github.com/Worklytics/psoxy/pull/332/commits/4898a235dce6cc6b50568c1e0d4ab23844bff970 - no idea why)

### Change implications

 - dependencies added/changed? **no**
