### PR TITLE
avoid problems if spaces in paths 

### DIFF
--- a/infra/modules/psoxy-package/build.sh
+++ b/infra/modules/psoxy-package/build.sh
@@ -9,7 +9,7 @@ JAVA_SOURCE_ROOT=$1
 IMPLEMENTATION=$2 # expected to be 'aws', 'gcp', etc ...
 FORCE_BUILD=$3
 
-VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout -f ${JAVA_SOURCE_ROOT}/pom.xml)
+VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout -f "${JAVA_SOURCE_ROOT}/pom.xml")
 ARTIFACT_FILE_NAME="psoxy-${IMPLEMENTATION}-${VERSION}.jar"
 PATH_TO_DEPLOYMENT_JAR="${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}/target/${ARTIFACT_FILE_NAME}"
 
@@ -21,15 +21,15 @@ if [ ! -f $PATH_TO_DEPLOYMENT_JAR ] || [ ! -z "$FORCE_BUILD" ] ; then
   TERRAFORM_CONFIG_PATH=`pwd`
   LOG_FILE=/tmp/psoxy-package.`date +%Y%m%d'T'%H%M%S`.log
 
-  ln -sf ${LOG_FILE} ${TERRAFORM_CONFIG_PATH}/last-build.log
+  ln -sf ${LOG_FILE} "${TERRAFORM_CONFIG_PATH}/last-build.log"
 
-  mvn clean -f ${JAVA_SOURCE_ROOT}/pom.xml > ${LOG_FILE} 2>&1
+  mvn clean -f "${JAVA_SOURCE_ROOT}/pom.xml" > ${LOG_FILE} 2>&1
 
-  mvn package install -f ${JAVA_SOURCE_ROOT}/gateway-core/pom.xml > ${LOG_FILE} 2>&1
+  mvn package install -f "${JAVA_SOURCE_ROOT}/gateway-core/pom.xml" > ${LOG_FILE} 2>&1
 
-  mvn package install -f ${JAVA_SOURCE_ROOT}/core/pom.xml >> ${LOG_FILE} 2>&1
+  mvn package install -f "${JAVA_SOURCE_ROOT}/core/pom.xml" >> ${LOG_FILE} 2>&1
 
-  mvn package -f ${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}/pom.xml >> ${LOG_FILE} 2>&1
+  mvn package -f "${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}/pom.xml" >> ${LOG_FILE} 2>&1
 fi
 
 # output back to Terraform (forces Terraform to be dependent on output)

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -11,10 +11,10 @@ set -e
 
 #TODO: validate prereqs?? (mvn??)
 
-mvn -f ${JAVA_SOURCE_ROOT}/pom.xml clean
+mvn -f "${JAVA_SOURCE_ROOT}/pom.xml" clean
 
-mvn package install -f ${JAVA_SOURCE_ROOT}/gateway-core/pom.xml
+mvn package install -f "${JAVA_SOURCE_ROOT}/gateway-core/pom.xml"
 
-mvn package install -f ${JAVA_SOURCE_ROOT}/core/pom.xml
+mvn package install -f "${JAVA_SOURCE_ROOT}/core/pom.xml"
 
-mvn package -f ${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}/pom.xml
+mvn package -f "${JAVA_SOURCE_ROOT}/impl/${IMPLEMENTATION}/pom.xml"

--- a/tools/init-bootstrap.sh
+++ b/tools/init-bootstrap.sh
@@ -10,7 +10,7 @@ TF_CONFIG_ROOT=`pwd`
 if [ ! -f terraform.tfvars ]; then
   TFVARS_FILE="${TF_CONFIG_ROOT}/terraform.tfvars"
 
-  cp ${TF_CONFIG_ROOT}/terraform.tfvars.example $TFVARS_FILE
+  cp "${TF_CONFIG_ROOT}/terraform.tfvars.example" "${TFVARS_FILE}"
 
   # give user some feedback
   printf "Init'd example terraform config. Please open ${BLUE}terraform.tfvars${NC} and customize it to your needs.\n"

--- a/tools/init-example.sh
+++ b/tools/init-example.sh
@@ -28,25 +28,25 @@ if [ $TF_INIT_EXIT_CODE -ne 0 ]; then
   exit 1
 fi
 
-if [ -d ${TF_CONFIG_ROOT}/.terraform/modules/psoxy/ ]; then
+if [ -d "${TF_CONFIG_ROOT}/.terraform/modules/psoxy/" ]; then
   # use checkout of repo done by Terraform
-  PSOXY_BASE_DIR=${TF_CONFIG_ROOT}/.terraform/modules/psoxy/
+  PSOXY_BASE_DIR="${TF_CONFIG_ROOT}/.terraform/modules/psoxy/"
 else
   # use checkout of repo on your local machine
   cd ../../..
   PSOXY_BASE_DIR="`pwd`/"
-  cd ${TF_CONFIG_ROOT}
+  cd "${TF_CONFIG_ROOT}"
 fi
 
 TFVARS_FILE="${TF_CONFIG_ROOT}/terraform.tfvars"
 
-if [ ! -f $TFVARS_FILE ]; then
+if [ ! -f "${TFVARS_FILE}" ]; then
   printf "Initializing ${BLUE}terraform.tfvars${NC} file for your configuration ...\n"
 
-  if [ -f ${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl ]; then
-    cp ${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl $TFVARS_FILE
+  if [ -f "${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl" ]; then
+    cp "${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl" "${TFVARS_FILE}"
   else
-    touch $TFVARS_FILE
+    touch "${TFVARS_FILE}"
   fi
 
   ${PSOXY_BASE_DIR}tools/init-tfvars.sh $TFVARS_FILE $PSOXY_BASE_DIR
@@ -74,9 +74,9 @@ if [ $AWS_HOSTED ]; then
 else
   HOST_PLATFORM="gcp"
 fi
-echo "${PSOXY_BASE_DIR}tools/build.sh $HOST_PLATFORM ${PSOXY_BASE_DIR}java" >> $BUILD_DEPLOYMENT_BUNDLE_SCRIPT
+echo "\"${PSOXY_BASE_DIR}tools/build.sh\" $HOST_PLATFORM \"${PSOXY_BASE_DIR}java\"" >> $BUILD_DEPLOYMENT_BUNDLE_SCRIPT
 chmod +x "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
 
 
 # Install test tool
-${PSOXY_BASE_DIR}tools/install-test-tool.sh ${PSOXY_BASE_DIR}tools
+${PSOXY_BASE_DIR}tools/install-test-tool.sh "${PSOXY_BASE_DIR}tools"

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -131,7 +131,7 @@ fi
 # NOTE: could be conditional based on google workspace, azure, etc - but as we expect future
 # examples to cover ALL connectors, and just vary by host platform, we'll just initialize all for
 # now and expect customers to remove them as needed
-AVAILABLE_CONNECTORS=$(echo "local.available_connector_ids" | terraform -chdir=${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs console)
+AVAILABLE_CONNECTORS=$(echo "local.available_connector_ids" | terraform -chdir="${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs" console)
 printf "# review following list of connectors to enable, and comment out what you don't want\n" >> $TFVARS_FILE
 printf "enabled_connectors = ${AVAILABLE_CONNECTORS}\n\n" >> $TFVARS_FILE
 

--- a/tools/install-test-tool.sh
+++ b/tools/install-test-tool.sh
@@ -8,7 +8,7 @@ GREEN='\e[0;32m'
 BLUE='\e[0;34m'
 NC='\e[0m' # No Color
 
-TEST_TOOL_ROOT=${PATH_TO_TOOLS}/psoxy-test
+TEST_TOOL_ROOT="${PATH_TO_TOOLS}/psoxy-test"
 
 if [ ! -d ${TEST_TOOL_ROOT} ]; then
   printf "${RED}No test tool source found at ${TEST_TOOL_ROOT}. Failed to install test tool.${NC}\n"
@@ -17,7 +17,7 @@ fi
 
 if npm -v &> /dev/null ; then
   printf "Installing ${BLUE}psoxy-test${NC} tool ...\n"
-  npm --no-audit --no-fund --prefix ${TEST_TOOL_ROOT} install
+  npm --no-audit --no-fund --prefix "${TEST_TOOL_ROOT}" install
 else
   printf "${RED}NPM / Node.JS not available; could not install test tool. We recommend installing Node.JS ( https://nodejs.org/ ), then re-running this init script.${NC}\n"
 fi


### PR DESCRIPTION
### Fixes
  - using values for `psoxy_base_path` with spaces causes scripts to fail

### Change implications

 - dependencies added/changed? **no**
