### PR TITLE
S149 Improve logging: display exception's extended message; explicit `region` param for signing method

### DIFF
--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -60,7 +60,8 @@ async function call(options = {}) {
   const credentials = await getAWSCredentials(options.role, options.region);
 
   logger.verbose('Signing request');
-  const signed = signAWSRequestURL(url, method, credentials);
+
+  const signed = signAWSRequestURL(url, method, credentials, options.region);
   const headers = {
     ...getCommonHTTPHeaders(options),
     ...signed.headers,

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -126,15 +126,20 @@ function requestWrapper(url, method = 'GET', headers) {
 
 /**
  * Simple wrapper around `aws4` to ease testing.
+ * 
+ * TODO aws4 is not able to resolve region nor service (see how we try to 
+ *  resolve the "service" here)from the URL for our use cases, so we need to 
+ *  improve the resolution of those values
  *
  * Ref: https://github.com/mhart/aws4#api
  *
  * @param {URL} url
  * @param {String} method
  * @param {Object} credentials
+ * @param {String} region
  * @return {Object}
  */
-function signAWSRequestURL(url, method = 'GET', credentials) {
+function signAWSRequestURL(url, method = 'GET', credentials, region) {
   // According to aws4 docs, search params should be part of the "path"
   const params = url.searchParams.toString();
 
@@ -142,6 +147,7 @@ function signAWSRequestURL(url, method = 'GET', credentials) {
     host: url.host,
     path: url.pathname + (params !== '' ? `?${params}` : ''),
     method: method,
+    region: region,
   };
 
   // Closer look at aws4 source code: region and service are calculated from

--- a/tools/psoxy-test/psoxy-test-call.js
+++ b/tools/psoxy-test/psoxy-test-call.js
@@ -124,6 +124,13 @@ export default async function (options = {}) {
         }
       } else if (result.headers['x-amzn-errortype']) {
         errorMessage += `: AWS ${result.headers['x-amzn-errortype']}`;
+        if (!_.isUndefined(result.data)) {
+          let extendedErrorMessage = '';
+          try {
+            extendedErrorMessage = JSON.parse(result.data).message;
+            errorMessage += ` ${extendedErrorMessage}`;
+          } catch(e) {logger.verbose(e.message);}
+        }
       } else if (result.headers['www-authenticate']) {
         errorMessage += `: GCP ${result.headers['www-authenticate']}`
       }

--- a/tools/psoxy-test/psoxy-test-call.js
+++ b/tools/psoxy-test/psoxy-test-call.js
@@ -127,7 +127,7 @@ export default async function (options = {}) {
         if (!_.isUndefined(result.data)) {
           let extendedErrorMessage = '';
           try {
-            extendedErrorMessage = JSON.parse(result.data).message;
+            extendedErrorMessage = JSON.parse(result.data)?.message ?? '';
             errorMessage += ` ${extendedErrorMessage}`;
           } catch(e) {logger.verbose(e.message);}
         }

--- a/tools/psoxy-test/test/aws.test.js
+++ b/tools/psoxy-test/test/aws.test.js
@@ -46,7 +46,8 @@ test.beforeEach(async (t) => {
     t.context.utils.signAWSRequestURL(
       td.matchers.isA(URL),
       td.matchers.contains('GET'),
-      credentials
+      credentials,
+      options.region,
     )
   ).thenReturn(signedRequest);
 });


### PR DESCRIPTION
### Fixes
- Follow up of [bug: InvalidSignature with v0.4.23](https://app.asana.com/0/1201039336231823/1204686540835807/f): ~it doesn't fix the bug (more details in task's comments)~ `aws4` lib wasn't resolving the `region` correctly from the lambda's URL (as happened before with the `service` option)

### Features
.

### Change implications

 - dependencies added/changed? **no**
