### PR TITLE
S151 aws cloud shell

### DIFF
--- a/docs/aws/cloud-shell.md
+++ b/docs/aws/cloud-shell.md
@@ -1,7 +1,9 @@
 # AWS - Getting Started with Cloud Shell
 
-**YMMV; we've found people often hit AWS's 1GB limit for cloud shell disk size. In such a scenario,
-use your local machine, or a VM/container elsewhere in AWS**
+**YMMV; as of June 2023, AWS's 1GB limit on cloud shell persistent storage is too low for real world
+proxy deployments, which typically require install gcloud CLI / Azure CLI to connect to sources**
+
+**So use use your local machine, or a VM/container elsewhere in AWS (EC2, AWS CLoud9, etc**
 
 1. clone the repo
 ```shell

--- a/docs/aws/cloud-shell.md
+++ b/docs/aws/cloud-shell.md
@@ -1,8 +1,7 @@
 # AWS - Getting Started with Cloud Shell
 
-**YMMV; we've found that as of Aug 2022, this is not a great option as people will often hit AWS's
-1GB limit for cloudshell. In such a scenario, use your local machine, or a VM/container elsewhere
- in AWS**
+**YMMV; we've found people often hit AWS's 1GB limit for cloud shell disk size. In such a scenario,
+use your local machine, or a VM/container elsewhere in AWS**
 
 1. clone the repo
 ```shell
@@ -36,10 +35,10 @@ tfenv use latest
 
 4. if using Google Workspace data sources, [install Google Cloud CLI](https://cloud.google.com/sdk/docs/install#linux) and authenticate.
 ```shell
-curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-384.0.0-linux-x86_64.tar.gz
-tar -xvf google-cloud-cli-384.0.0-linux-x86_64.tar.gz
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-435.0.1-linux-x86_64.tar.gz
+tar -xvf google-cloud-cli-435.0.1-linux-x86_64.tar.gz
 sudo ./google-cloud-sdk/install.sh
-rm google-cloud-cli-384.0.0-linux-x86_64.tar.gz
+rm google-cloud-cli-435.0.1-linux-x86_64.tar.gz
 ```
 
 6. if using Microsoft 365 data sources, install Azure CLI and authenticate.

--- a/docs/aws/cloud-shell.md
+++ b/docs/aws/cloud-shell.md
@@ -15,11 +15,6 @@ git clone https://github.com/Worklytics/psoxy.git
 # install Maven (and, via dependency, java)
 sudo yum -y install maven
 
-# install AWS Curl (used for testing)
-sudo yum -y install pip
-pip install awscurl
-
-
 # GCloud SDK (if using Google Workspace data sources)
 # The next line updates PATH for the Google Cloud SDK.
 if [ -f '/home/cloudshell-user/google-cloud-sdk/path.bash.inc' ]; then . '/home/cloudshell-user/google-cloud-sdk/path.bash.inc'; fi
@@ -53,3 +48,17 @@ https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
 
 You should now be ready for the general instructions in the [README.md](../../README.md).
+
+
+## Other stuff
+
+If default NodeJS tooling doesn't work for you, legacy testing tools use python/awscurl, installed
+via pip. See example below:
+
+```shell
+
+# install AWS Curl (used for testing)
+sudo yum -y install pip
+pip install awscurl
+
+```


### PR DESCRIPTION
### Features
  - update docs to confirm aws cloud shell STILL not working, despite improvements to limit space use

### Change implications

 - dependencies added/changed? **yes** bump gcloud CLI for aws cloud shell, remove pip/awscurl
