### PR TITLE
fix conflicting gcp SA ids by adding -fn qualifier

### DIFF
--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -17,7 +17,6 @@ locals {
 
 module "psoxy" {
   source = "../../modules/aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.25
 
   aws_account_id                 = var.aws_account_id
   region                         = data.aws_region.current.id
@@ -34,7 +33,6 @@ module "psoxy" {
 # secrets shared across all instances
 module "global_secrets" {
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.25
 
   path       = var.aws_ssm_param_root_path
   kms_key_id = var.aws_ssm_key_id
@@ -45,7 +43,6 @@ module "instance_secrets" {
   for_each = var.api_connectors
 
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.25"
   # other possibly implementations:
   # source = "../hashicorp-vault-secrets"
 
@@ -63,7 +60,6 @@ module "api_connector" {
   for_each = var.api_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.25"
 
   environment_name                = var.environment_name
   instance_id                     = each.key
@@ -107,7 +103,6 @@ module "bulk_connector" {
   for_each = var.bulk_connectors
 
   source = "../../modules/aws-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.25"
 
   aws_account_id                   = var.aws_account_id
   provision_iam_policy_for_testing = var.provision_testing_infra
@@ -144,7 +139,6 @@ module "lookup_output" {
   for_each = var.lookup_table_builders
 
   source = "../../modules/aws-psoxy-output-bucket"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=v0.4.25"
 
   environment_name              = var.environment_name
   instance_id                   = each.key

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -17,6 +17,12 @@ module "psoxy" {
   install_test_tool       = var.install_test_tool
 }
 
+# constants
+locals {
+  SA_NAME_MIN_LENGTH             = 6
+  SA_NAME_MAX_LENGTH             = 30
+}
+
 # BEGIN API CONNECTORS
 
 locals {
@@ -66,15 +72,23 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_updater_on_lockable
 locals {
   # sa account_ids must be at least 6 chars long; if api_connector keys are short, and environment_name
   # is also short (or empty), keys alone might not be long enough; so prepend in such cases
-  sa_prefix = length(local.environment_id_prefix) >= 6 ? local.environment_id_prefix : "psoxy-${local.environment_id_prefix}"
+
+  # distinguishes SA for Cloud Functions from SAs for connector OAuth Clients
+  function_qualifier = "fn-"
+
+  default_sa_prefix      = "${local.environment_id_prefix}${local.function_qualifier}"
+  long_default_sa_prefix = "psoxy-${local.environment_id_prefix}${local.function_qualifier}"
+
+  sa_prefix = length(local.default_sa_prefix) < local.SA_NAME_MIN_LENGTH ? local.long_default_sa_prefix : local.default_sa_prefix
 }
 
 resource "google_service_account" "api_connectors" {
   for_each = var.api_connectors
 
   project      = var.gcp_project_id
-  account_id   = "${local.sa_prefix}${replace(each.key, "_", "-")}"
-  display_name = "${local.environment_id_display_name_qualifier} ${each.key} REST Connector"
+  account_id   = substr("${local.sa_prefix}${replace(each.key, "_", "-")}", 0, local.SA_NAME_MAX_LENGTH)
+  display_name = "${local.environment_id_display_name_qualifier} ${each.key} API Connector Cloud Function"
+  description  = "Service account that cloud function for ${each.key} API Connector will run as"
 }
 
 module "api_connector" {

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -95,7 +95,6 @@ module "api_connector" {
   for_each = var.api_connectors
 
   source = "../../modules/gcp-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.25"
 
   project_id                            = var.gcp_project_id
   source_kind                           = each.value.source_kind
@@ -148,7 +147,6 @@ module "bulk_connector" {
   for_each = var.bulk_connectors
 
   source = "../../modules/gcp-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.25"
 
   project_id                    = var.gcp_project_id
   environment_id_prefix         = local.environment_id_prefix

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -179,7 +179,7 @@ variable "lookup_tables" {
     join_key_column               = string
     columns_to_include            = optional(list(string))
     sanitized_accessor_principals = optional(list(string))
-    expiration_days               = optional(number)
+    expiration_days               = optional(number, 5 * 365)
   }))
   description = "Lookup tables to build from same source input as another connector, output to a distinct bucket. The original `join_key_column` will be preserved, "
 

--- a/infra/modules/gcp-output-bucket/variables.tf
+++ b/infra/modules/gcp-output-bucket/variables.tf
@@ -55,8 +55,10 @@ variable "sanitizer_accessor_principals" {
   default     = []
 }
 
+# NOTE: while this value *can* be 0, that's the same as setting no expiration, which is OK except
+# that GCP will not persist the lifecycle rule for the expiration, so Terroform will always show change
 variable "expiration_days" {
   type        = number
-  description = "Number of days after which objects in the bucket will expire"
+  description = "Number of days after which objects in the bucket will expire. If 0, no expiration is set but terraform will always show change in your plan."
   default     = 365 * 5 # 5 years
 }

--- a/infra/modules/gcp-output-bucket/variables.tf
+++ b/infra/modules/gcp-output-bucket/variables.tf
@@ -56,7 +56,7 @@ variable "sanitizer_accessor_principals" {
 }
 
 # NOTE: while this value *can* be 0, that's the same as setting no expiration, which is OK except
-# that GCP will not persist the lifecycle rule for the expiration, so Terroform will always show change
+# that GCP will not persist the lifecycle rule for the expiration, so Terraform will always show change
 variable "expiration_days" {
   type        = number
   description = "Number of days after which objects in the bucket will expire. If 0, no expiration is set but terraform will always show change in your plan."

--- a/infra/modules/google-workspace-dwd-connection/main.tf
+++ b/infra/modules/google-workspace-dwd-connection/main.tf
@@ -25,7 +25,7 @@ locals {
 # service account to personify connector
 resource "google_service_account" "connector-sa" {
   project      = var.project_id
-  account_id   = var.connector_service_account_id
+  account_id   = local.sa_account_id
   display_name = var.display_name
   description  = var.description
 }

--- a/infra/modules/worklytics-connectors-google-workspace/main.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/main.tf
@@ -29,6 +29,7 @@ module "google_workspace_connection" {
   instance_id                  = each.key
   connector_service_account_id = "${local.environment_id_prefix}${substr(each.key, 0, 30 - length(local.environment_id_prefix))}"
   display_name                 = "Psoxy Connector - ${local.environment_id_display_name_qualifier}${each.value.display_name}"
+  description                  = "Google API OAuth Client for ${each.value.display_name}"
   apis_consumed                = each.value.apis_consumed
   oauth_scopes_needed          = each.value.oauth_scopes_needed
   todo_step                    = var.todo_step


### PR DESCRIPTION
### Fixes
 - since split of GCP host from Google Workspace as data source, potential for SA names used by both to conflict; this fixes that

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204771340174904