### PR TITLE
support AWS cmeks for lambda env, ssm params, cloudwatch log groups; add s3 example

### DIFF
--- a/docs/aws/encryption-keys.md
+++ b/docs/aws/encryption-keys.md
@@ -1,0 +1,75 @@
+# Encryption Keys in AWS
+
+As of June 2023, the following resources provisioned by Psoxy modules support use of CMEKs:
+  - Lambda function environment variables
+  - SSM Parameters
+  - Cloud Watch Log Groups
+
+## Pre-existing Key
+The `psoxy-example-aws` example provides a `project_aws_key_arn` variable, that, if provided, will
+be set as the encryption key for these resources. A few caveats:
+  - The AWS principal your Terraform is running as must have permissions to encrypt/decrypt with the
+    key (it needs to be able to read/write the lambda env, ssm params, etc)
+  - The key should be in the same AWS region you're deploying to.
+
+## Provisioning a Key
+
+```hcl
+
+resource "aws_kms_key" "key" {
+  description             = "KMS key for Psoxy"
+  enable_key_rotation     = true
+  is_enabled              = true
+}
+
+# then replace all use of `var.project_aws_key_arn` with `aws_kms_key.key.arn` in your `main.tf`
+```
+
+Be sure to allow Cloud Watch to use it, as described in [AWS CloudWatch docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)
+
+A key policy like the following should work, but please adapt to your environment and scope as needed
+to follow your security policies, such as principle of least privilege. In particular, note that the
+first statement must be set to restrict who can manage the CMEK, without locking out your Terraform's
+AWS principal.
+
+```hcl
+resource "aws_kms_key_policy" "key_policy_including_cloudwatch" {
+    key_id = var.project_aws_kms_key_arn
+    policy = jsonencode(
+        {
+            "Version" : "2012-10-17",
+            "Id" : "key-default-1",
+            "Statement" : [
+                {
+                    "Sid": "Allow IAM Users to Manage Key",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::${var.aws_account_id}:root"
+                    },
+                    "Action": "kms:*",
+                    "Resource": "*"
+                },
+                {
+                    "Effect" : "Allow",
+                    "Principal" : {
+                        "Service" : "logs.${var.aws_region}.amazonaws.com"
+                    },
+                    "Action" : [
+                        "kms:Encrypt",
+                        "kms:Decrypt",
+                        "kms:ReEncrypt",
+                        "kms:GenerateDataKey",
+                        "kms:Describe"
+                    ],
+                    "Resource" : "*"
+                }
+            ]
+        })
+}
+```
+
+
+## More options
+
+If you need more granular control of CMEK by resource type, review the `main.tf` and variables
+exposed by the `aws-host` module for some options.

--- a/docs/aws/protips.md
+++ b/docs/aws/protips.md
@@ -4,32 +4,8 @@ Some ideas on how to support scenarios and configuration requirements beyond wha
 examples show:
 
 
-## Using an AWS KMS Key to encrypt SSM Parameters
-
-If you want to use an existing AWS KMS key to encrypt SSM parameters created by the proxy, or create
-a key for this purpose, adapt the following:
-
-```hcl
-resource "aws_kms_key" "key" {
-  description             = "KMS key for Psoxy"
-  enable_key_rotation     = true
-  is_enabled              = true
-}
-
-# pass it's id to example
-module "psoxy-aws-google-workspace" {
-  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=v0.4.12"
-
-  # ... other variables omitted for brevity
-
-  aws_ssm_key_id                 = aws_kms_key.key.key_id
-}
-# NOTE: if you use this, likely will have to first apply with -target=aws_kms_key.key, before doing
-# the general `terraform apply`, as some module `for_each` values will depend on the key_id
-```
-
-Our modules will give each proxy's role perms to decrypt using that key.  The role you're using to
-run terraform will need to have perms to grant such permissions.
+## Encryption Keys
+see [encryption-keys.md](encryption-keys.md)
 
 ## Tagging ALL infra created by your Terraform Configuration
 

--- a/infra/examples-dev/aws-all/kms-cmek.tf
+++ b/infra/examples-dev/aws-all/kms-cmek.tf
@@ -1,0 +1,37 @@
+
+# uncomment to test this
+
+
+#resource "aws_kms_key_policy" "key_policy_including_cloudwatch" {
+#  key_id = var.project_aws_kms_key_arn
+#  policy = jsonencode(
+#    {
+#      "Version" : "2012-10-17",
+#      "Id" : "key-default-1",
+#      "Statement" : [
+#        {
+#          "Sid": "Allow IAM Users to Manage Key",
+#          "Effect": "Allow",
+#          "Principal": {
+#            "AWS": "arn:aws:iam::${var.aws_account_id}:root"
+#          },
+#          "Action": "kms:*",
+#          "Resource": "*"
+#        },
+#        {
+#          "Effect" : "Allow",
+#          "Principal" : {
+#            "Service" : "logs.${var.aws_region}.amazonaws.com"
+#          },
+#          "Action" : [
+#            "kms:Encrypt",
+#            "kms:Decrypt",
+#            "kms:ReEncrypt",
+#            "kms:GenerateDataKey",
+#            "kms:Describe"
+#          ],
+#          "Resource" : "*"
+#        }
+#      ]
+#    })
+#}

--- a/infra/examples-dev/aws-all/kms-cmek.tf
+++ b/infra/examples-dev/aws-all/kms-cmek.tf
@@ -1,37 +1,101 @@
 
-# uncomment to test this
+# uncomment to use encryption for S3 buckets and have it work properly for Cloud Watch Logs
 
 
-#resource "aws_kms_key_policy" "key_policy_including_cloudwatch" {
+#locals {
+#  # TODO: can eliminate this if test tool doesn't assume role when uploading to bucket
+#  testing_policy_statements = var.provision_testing_infra ? [
+#    {
+#      "Sid": "Allow Test Users to Use Key",
+#      "Effect": "Allow",
+#      "Principal": { # tests
+#        "AWS": "arn:aws:iam::${var.aws_account_id}:role/${module.psoxy.caller_role_name}"
+#      },
+#      "Action": "kms:*",
+#      "Resource": "*"
+#    }
+#  ] : []
+#
+#  # S3 bucket policy statements for bulk writer instances
+#  # explicitly allow each instance's exec role to use the key to encrypt, as it needs to write to
+#  # the output buckets
+#  bulk_writer_policy_statements = [
+#    for instance in module.psoxy.bulk_connector_instances : {
+#      "Effect" : "Allow",
+#      "Principal" : {
+#         "AWS" : instance.instance_role_arn
+#      },
+#      "Action" : [
+#        "kms:Encrypt",
+#        "kms:GenerateDataKey",
+#      ],
+#      "Resource" : "*"
+#    }
+#  ]
+#}
+#
+#resource "aws_kms_key_policy" "psoxy" {
 #  key_id = var.project_aws_kms_key_arn
 #  policy = jsonencode(
 #    {
 #      "Version" : "2012-10-17",
-#      "Id" : "key-default-1",
-#      "Statement" : [
-#        {
-#          "Sid": "Allow IAM Users to Manage Key",
-#          "Effect": "Allow",
-#          "Principal": {
-#            "AWS": "arn:aws:iam::${var.aws_account_id}:root"
+#      "Id" : "psoxy-key-policy",
+#      "Statement" : concat(
+#        [
+#          # to allow Terraform to manage the key
+#          {
+#            "Sid": "Allow IAM Users to Manage Key",
+#            "Effect": "Allow",
+#            "Principal": {
+#              "AWS": "arn:aws:iam::${var.aws_account_id}:root"
+#            },
+#            "Action": "kms:*",
+#            "Resource": "*"
 #          },
-#          "Action": "kms:*",
-#          "Resource": "*"
-#        },
-#        {
-#          "Effect" : "Allow",
-#          "Principal" : {
-#            "Service" : "logs.${var.aws_region}.amazonaws.com"
-#          },
-#          "Action" : [
-#            "kms:Encrypt",
-#            "kms:Decrypt",
-#            "kms:ReEncrypt",
-#            "kms:GenerateDataKey",
-#            "kms:Describe"
-#          ],
-#          "Resource" : "*"
-#        }
-#      ]
+#          # to use for Cloud Watch Logs
+#          {
+#            "Effect" : "Allow",
+#            "Principal" : {
+#              "Service" : "logs.${var.aws_region}.amazonaws.com"
+#            },
+#            "Action" : [
+#              "kms:Encrypt",
+#              "kms:Decrypt",
+#              "kms:ReEncrypt",
+#              "kms:GenerateDataKey",
+#              "kms:Describe"
+#            ],
+#            "Resource" : "*"
+#          }
+#      ],
+#      local.bulk_writer_policy_statements,
+#      local.testing_policy_statements
+#      )
 #    })
+#}
+#
+#resource "aws_s3_bucket_server_side_encryption_configuration" "input_bucket_encryption" {
+#  for_each = module.psoxy.bulk_connector_instances
+#
+#  bucket = each.value.input_bucket
+#
+#  rule {
+#    apply_server_side_encryption_by_default {
+#      sse_algorithm = "aws:kms"
+#      kms_master_key_id = var.project_aws_kms_key_arn
+#    }
+#  }
+#}
+#
+#resource "aws_s3_bucket_server_side_encryption_configuration" "sanitized_bucket_encryption" {
+#  for_each = module.psoxy.bulk_connector_instances
+#
+#  bucket = each.value.sanitized_bucket
+#
+#  rule {
+#    apply_server_side_encryption_by_default {
+#      sse_algorithm = "aws:kms"
+#      kms_master_key_id = var.project_aws_kms_key_arn
+#    }
+#  }
 #}

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -116,6 +116,8 @@ module "psoxy" {
   custom_api_connector_rules     = var.custom_api_connector_rules
   lookup_table_builders          = var.lookup_table_builders
   general_environment_variables  = var.general_environment_variables
+  function_env_kms_key_arn       = var.project_aws_kms_key_arn
+  aws_ssm_key_id                 = var.project_aws_kms_key_arn
   bulk_sanitized_expiration_days = var.bulk_sanitized_expiration_days
   bulk_input_expiration_days     = var.bulk_input_expiration_days
   api_connectors                 = local.api_connectors

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -117,6 +117,7 @@ module "psoxy" {
   lookup_table_builders          = var.lookup_table_builders
   general_environment_variables  = var.general_environment_variables
   function_env_kms_key_arn       = var.project_aws_kms_key_arn
+  logs_kms_key_arn               = var.project_aws_kms_key_arn
   aws_ssm_key_id                 = var.project_aws_kms_key_arn
   bulk_sanitized_expiration_days = var.bulk_sanitized_expiration_days
   bulk_input_expiration_days     = var.bulk_input_expiration_days

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -46,6 +46,17 @@ variable "aws_ssm_param_root_path" {
   }
 }
 
+variable "project_aws_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt all AWS components created by this Terraform configuration that support CMEKs. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."
+  default     = null
+
+  validation {
+    condition = var.project_aws_kms_key_arn == null || can(regex("^arn:aws:kms:.*:\\d{12}:key\\/.*$", var.project_aws_kms_key_arn))
+    error_message = "The project_aws_kms_key_arn value should be null or a valid an AWS KMS key ARN."
+  }
+}
+
 variable "worklytics_host" {
   type        = string
   description = "host of worklytics instance where tenant resides. (e.g. intl.worklytics.co for prod; but may differ for dev/staging)"

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -52,7 +52,7 @@ variable "project_aws_kms_key_arn" {
   default     = null
 
   validation {
-    condition = var.project_aws_kms_key_arn == null || can(regex("^arn:aws:kms:.*:\\d{12}:key\\/.*$", var.project_aws_kms_key_arn))
+    condition     = var.project_aws_kms_key_arn == null || can(regex("^arn:aws:kms:.*:\\d{12}:key\\/.*$", var.project_aws_kms_key_arn))
     error_message = "The project_aws_kms_key_arn value should be null or a valid an AWS KMS key ARN."
   }
 }

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -69,6 +69,7 @@ module "api_connector" {
   path_to_function_zip            = module.psoxy.path_to_deployment_jar
   function_zip_hash               = module.psoxy.deployment_package_hash
   function_env_kms_key_arn        = var.function_env_kms_key_arn
+  logs_kms_key_arn                = var.logs_kms_key_arn
   api_caller_role_arn             = module.psoxy.api_caller_role_arn
   example_api_calls               = each.value.example_api_calls
   aws_account_id                  = var.aws_account_id
@@ -116,6 +117,7 @@ module "bulk_connector" {
   path_to_function_zip             = module.psoxy.path_to_deployment_jar
   function_zip_hash                = module.psoxy.deployment_package_hash
   function_env_kms_key_arn         = var.function_env_kms_key_arn
+  logs_kms_key_arn                 = var.logs_kms_key_arn
   psoxy_base_dir                   = var.psoxy_base_dir
   rules                            = try(var.custom_bulk_connector_rules[each.key], each.value.rules)
   global_parameter_arns            = module.global_secrets.secret_arns

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -68,6 +68,7 @@ module "api_connector" {
   path_to_config                  = "${var.psoxy_base_dir}/configs/${each.value.source_kind}.yaml"
   path_to_function_zip            = module.psoxy.path_to_deployment_jar
   function_zip_hash               = module.psoxy.deployment_package_hash
+  function_env_kms_key_arn        = var.function_env_kms_key_arn
   api_caller_role_arn             = module.psoxy.api_caller_role_arn
   example_api_calls               = each.value.example_api_calls
   aws_account_id                  = var.aws_account_id
@@ -114,6 +115,7 @@ module "bulk_connector" {
   aws_region                       = data.aws_region.current.id
   path_to_function_zip             = module.psoxy.path_to_deployment_jar
   function_zip_hash                = module.psoxy.deployment_package_hash
+  function_env_kms_key_arn         = var.function_env_kms_key_arn
   psoxy_base_dir                   = var.psoxy_base_dir
   rules                            = try(var.custom_bulk_connector_rules[each.key], each.value.rules)
   global_parameter_arns            = module.global_secrets.secret_arns

--- a/infra/modules/aws-host/output.tf
+++ b/infra/modules/aws-host/output.tf
@@ -4,6 +4,10 @@ output "path_to_deployment_jar" {
   value       = module.psoxy.path_to_deployment_jar
 }
 
+output "caller_role_name" {
+  value = module.psoxy.api_caller_role_name
+}
+
 output "api_connector_instances" {
   value = local.api_instances
 }

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -24,6 +24,12 @@ variable "aws_ssm_key_id" {
   default     = null
 }
 
+variable "function_env_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambdas' environments. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."
+  default     = null
+}
+
 variable "caller_gcp_service_account_ids" {
   type        = list(string)
   description = "ids of GCP service accounts allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -30,6 +30,12 @@ variable "function_env_kms_key_arn" {
   default     = null
 }
 
+variable "logs_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambdas' logs. NOTE: ensure CloudWatch is setup to use this key (cloudwatch principal has perms, log group in same region as key, etc) - see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html ."
+  default     = null
+}
+
 variable "caller_gcp_service_account_ids" {
   type        = list(string)
   description = "ids of GCP service accounts allowed to send requests to the proxy (eg, unique ID of the SA of your Worklytics instance)"

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -15,6 +15,7 @@ module "psoxy_lambda" {
   global_parameter_arns           = var.global_parameter_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   function_env_kms_key_arn        = var.function_env_kms_key_arn
+  logs_kms_key_arn                = var.logs_kms_key_arn
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
 
   environment_variables = merge(

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -14,6 +14,7 @@ module "psoxy_lambda" {
   function_zip_hash               = var.function_zip_hash
   global_parameter_arns           = var.global_parameter_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
+  function_env_kms_key_arn        = var.function_env_kms_key_arn
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
 
   environment_variables = merge(

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -45,6 +45,13 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "function_env_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."
+  default     = null
+}
+
+
 variable "ssm_kms_key_ids" {
   type        = map(string)
   description = "KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -51,6 +51,11 @@ variable "function_env_kms_key_arn" {
   default     = null
 }
 
+variable "logs_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambdas' logs. NOTE: ensure CloudWatch is setup to use this key (cloudwatch principal has perms, log group in same region as key, etc) - see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html ."
+  default     = null
+}
 
 variable "ssm_kms_key_ids" {
   type        = map(string)

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -37,6 +37,7 @@ module "psoxy_lambda" {
   path_to_function_zip            = var.path_to_function_zip
   function_zip_hash               = var.function_zip_hash
   function_env_kms_key_arn        = var.function_env_kms_key_arn
+  logs_kms_key_arn                = var.logs_kms_key_arn
   global_parameter_arns           = var.global_parameter_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   ssm_kms_key_ids                 = var.ssm_kms_key_ids

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -36,6 +36,7 @@ module "psoxy_lambda" {
   source_kind                     = var.source_kind
   path_to_function_zip            = var.path_to_function_zip
   function_zip_hash               = var.function_zip_hash
+  function_env_kms_key_arn        = var.function_env_kms_key_arn
   global_parameter_arns           = var.global_parameter_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   ssm_kms_key_ids                 = var.ssm_kms_key_ids

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -59,6 +59,12 @@ variable "function_env_kms_key_arn" {
   default     = null
 }
 
+variable "logs_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambdas' logs. NOTE: ensure CloudWatch is setup to use this key (cloudwatch principal has perms, log group in same region as key, etc) - see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html ."
+  default     = null
+}
+
 variable "ssm_kms_key_ids" {
   type        = map(string)
   description = "KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -53,6 +53,12 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "function_env_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."
+  default     = null
+}
+
 variable "ssm_kms_key_ids" {
   type        = map(string)
   description = "KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -20,7 +20,7 @@ locals {
   salt_parameter_name_suffix = "PSOXY_SALT"
   function_name              = "${module.env_id.id}-${var.instance_id}"
 
-  kms_keys_to_allow_ids = merge(
+  kms_key_ids_to_allow = merge(
     var.ssm_kms_key_ids,
     var.kms_keys_to_allow
   )
@@ -132,7 +132,7 @@ data "aws_caller_identity" "current" {}
 # bc 'key_id' may be ARN, id, or alias, we need to look up the ARN for each key - as IAM policy must
 # be specified with ARNs
 data "aws_kms_key" "keys_to_allow" {
-  for_each = local.kms_keys_to_allow_ids
+  for_each = local.kms_key_ids_to_allow
 
   key_id = each.value
 }
@@ -173,7 +173,7 @@ locals {
     Resource = var.global_parameter_arns
   }]
 
-  key_statements = length(local.kms_keys_to_allow_ids) > 0 ? [{
+  key_statements = length(local.kms_key_ids_to_allow) > 0 ? [{
     Sid = "AllowKMSUse"
     Action = [
       "kms:Decrypt",

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -76,15 +76,21 @@ resource "aws_lambda_function" "psoxy-instance" {
 }
 
 # cloudwatch group per lambda function
-resource "aws_cloudwatch_log_group" "lambda-log" {
+resource "aws_cloudwatch_log_group" "lambda_log" {
   name              = "/aws/lambda/${aws_lambda_function.psoxy-instance.function_name}"
   retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.logs_kms_key_arn
 
   lifecycle {
     ignore_changes = [
       tags
     ]
   }
+}
+
+moved {
+  from = aws_cloudwatch_log_group.lambda-log
+  to   = aws_cloudwatch_log_group.lambda_log
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -224,5 +230,5 @@ output "iam_role_for_lambda_name" {
 }
 
 output "log_group" {
-  value = aws_cloudwatch_log_group.lambda-log.name
+  value = aws_cloudwatch_log_group.lambda_log.name
 }

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -20,7 +20,7 @@ locals {
   salt_parameter_name_suffix = "PSOXY_SALT"
   function_name              = "${module.env_id.id}-${var.instance_id}"
 
-  kms_keys_to_allow_ids      = merge(
+  kms_keys_to_allow_ids = merge(
     var.ssm_kms_key_ids,
     var.kms_keys_to_allow
   )
@@ -146,7 +146,7 @@ locals {
   ))
 
   local_ssm_param_statements = [{
-    Sid    = "ReadInstanceSSMParameters"
+    Sid = "ReadInstanceSSMParameters"
     Action = [
       "ssm:GetParameter",
       "ssm:GetParameterVersion",
@@ -155,14 +155,14 @@ locals {
       "ssm:PutParameter",
       "ssm:DeleteParameter" # delete locks, bad access tokens, etc
     ]
-    Effect   = "Allow"
+    Effect = "Allow"
     Resource = [
       "${local.param_arn_prefix}*" # wildcard to match all params corresponding to this function
     ]
   }]
 
   global_ssm_param_statements = [{
-    Sid    = "ReadSharedSSMParameters"
+    Sid = "ReadSharedSSMParameters"
     Action = [
       "ssm:GetParameter",
       "ssm:GetParameters",
@@ -174,7 +174,7 @@ locals {
   }]
 
   key_statements = length(local.kms_keys_to_allow_ids) > 0 ? [{
-    Sid    = "AllowKMSUse"
+    Sid = "AllowKMSUse"
     Action = [
       "kms:Decrypt",
       "kms:Encrypt", # needed, bc lambdas need to write some SSM parameters

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -43,6 +43,12 @@ variable "function_env_kms_key_arn" {
   default     = null
 }
 
+variable "logs_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambdas' logs. NOTE: ensure CloudWatch is setup to use this key (cloudwatch principal has perms, log group in same region as key, etc) - see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html ."
+  default     = null
+}
+
 # TODO: remove after 0.4.x
 variable "ssm_kms_key_ids" {
   type        = map(string)

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -37,9 +37,16 @@ variable "aws_assume_role_arn" {
   default     = null
 }
 
+# TODO: remove after 0.4.x
 variable "ssm_kms_key_ids" {
   type        = map(string)
-  description = "KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."
+  description = "DEPRECATED; KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."
+  default     = {}
+}
+
+variable "kms_keys_to_allow" {
+  type        = map(string)
+  description = "KMS key IDs or ARNs for keys this lambda needs to use, if any."
   default     = {}
 }
 

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -37,6 +37,12 @@ variable "aws_assume_role_arn" {
   default     = null
 }
 
+variable "function_env_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."
+  default     = null
+}
+
 # TODO: remove after 0.4.x
 variable "ssm_kms_key_ids" {
   type        = map(string)

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -36,6 +36,7 @@ module "psoxy_lambda" {
   path_to_function_zip            = var.path_to_function_zip
   function_zip_hash               = var.function_zip_hash
   function_env_kms_key_arn        = var.function_env_kms_key_arn
+  logs_kms_key_arn                = var.logs_kms_key_arn
   memory_size_mb                  = var.memory_size_mb
   timeout_seconds                 = 55
   reserved_concurrent_executions  = var.reserved_concurrent_executions

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -35,6 +35,7 @@ module "psoxy_lambda" {
   handler_class                   = "co.worklytics.psoxy.Handler"
   path_to_function_zip            = var.path_to_function_zip
   function_zip_hash               = var.function_zip_hash
+  function_env_kms_key_arn        = var.function_env_kms_key_arn
   memory_size_mb                  = var.memory_size_mb
   timeout_seconds                 = 55
   reserved_concurrent_executions  = var.reserved_concurrent_executions

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -39,6 +39,12 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "function_env_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."
+  default     = null
+}
+
 variable "ssm_kms_key_ids" {
   type        = map(string)
   description = "KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -45,6 +45,12 @@ variable "function_env_kms_key_arn" {
   default     = null
 }
 
+variable "logs_kms_key_arn" {
+  type        = string
+  description = "AWS KMS key ARN to use to encrypt lambdas' logs. NOTE: ensure CloudWatch is setup to use this key (cloudwatch principal has perms, log group in same region as key, etc) - see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html ."
+  default     = null
+}
+
 variable "ssm_kms_key_ids" {
   type        = map(string)
   description = "KMS key IDs or ARNs that were used for encrypting SSM parameters needed by this lambda, if any."

--- a/infra/modules/google-workspace-dwd-connection/main.tf
+++ b/infra/modules/google-workspace-dwd-connection/main.tf
@@ -118,7 +118,7 @@ EOT
 
 # enable domain-wide-delegation via Google Workspace Admin console
 resource "local_file" "todo_auth_google_workspace" {
-  count    = var.todos_as_local_files ? 1 : 0
+  count = var.todos_as_local_files ? 1 : 0
 
   filename = "TODO ${var.todo_step} - setup ${local.instance_id}.md"
   content  = local.todo_content

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -37,7 +37,7 @@ locals {
       display_name    = "Cloud Functions Admin",
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin"
     },
-  }  # TODO: add list of permissions, which customer could use to create custom role as alternative
+  } # TODO: add list of permissions, which customer could use to create custom role as alternative
 
   required_gcp_roles_to_provision_google_workspace_source = {
     "roles/iam.serviceAccountAdmin" = {

--- a/infra/modules/source-token-external-todo/main.tf
+++ b/infra/modules/source-token-external-todo/main.tf
@@ -17,7 +17,7 @@ EOT
 }
 
 resource "local_file" "source_connection_instructions" {
-  count    = var.todos_as_local_files ? 1 : 0
+  count = var.todos_as_local_files ? 1 : 0
 
   filename = "TODO ${var.todo_step} - setup ${var.source_id}.md"
   content  = local.todo_content


### PR DESCRIPTION
### Features
  - expose variable to encrypt ssm parameters with CMEK
  - support encrypting cloud watch log groups with CMEK, expose in example
  - support encrypting lambda env vars with CMEK, expose in example
  - add an example of encrypting S3 bucket with CMEK (currently supported, but requires some advanced tf config)

### Change implications

 - dependencies added/changed? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204910069771257