### PR TITLE
more java dependency updates

### DIFF
--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -11,6 +11,7 @@ on:
     branches:
       - 'main'
       - 'rc-*'
+      - 's152-java-20-test'
 
 jobs:
   # Java 11 - supported until 30 Sept 2023
@@ -27,11 +28,9 @@ jobs:
 
   # NOTE: java 19 support ended 21 Mar 2023; it's known to be incompatible with our code
 
-  # Java 20 - released 21 Mar 2023, supported until 19 Sept 2023;
-  #  as of 5 Apr 2023, current version of java 20 provided by GitHub action is ALSO incompatible
-  # with our code; have tested temurin, liberica, microsoft, corretto, oracle and zulu - all fail
-#  ci_java20:
-#    uses: ./.github/workflows/build-java.yaml
-#    with:
-#      java-version: '20'
-#
+  # Java 20 - released 21 Mar 2023, supported until 19 Sept 2023
+  ci_java20:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '20'
+

--- a/README.md
+++ b/README.md
@@ -159,13 +159,10 @@ You will need all of the following in your deployment environment (eg, your lapt
 | Tool                                         | Version       | Test Command              |
 |----------------------------------------------|---------------|---------------------------|
 | [git](https://git-scm.com/)                  | 2.17+         | `git --version`           |
-| [Maven](https://maven.apache.org/)           | 3.6+          | `mvn -v`                  |
-| [Java 11+ JDK](https://openjdk.org/install/) | 11+, but < 19 | `mvn -v &#124; grep Java` |
-| [Terraform](https://www.terraform.io/)       | 1.3+          | `terraform version`       |
+| [Maven](https://maven.apache.org/)           | 3.6+          | `mvn -v`                 |
+| [Java 11+ JDK](https://openjdk.org/install/) | 11+, <=20     | `mvn -v &#124; grep Java` |
+| [Terraform](https://www.terraform.io/)       | 1.3.x, <= 1.5 | `terraform version`       |
 
-
-NOTE: Java 19/20 are currently broken, see [docs/troubleshooting.md](docs/troubleshooting.md); we
-suggest Java 17, which is a LTS edition supported until Sept 2026.
 
 NOTE: Using `terraform` is not strictly necessary, but it is the only supported method. You may
 provision your infrastructure via your host's CLI, web console, or another infrastructure provisioning

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,45 +11,6 @@
 
 ## General Tips
 
-### Build problems with Java 19 / 20 (specifically, openjdk 19 / 20)
-
-If you are using openjdk 19.x or 20.x, you may run into problems with the build. We suggest you
-downgrade to some java 17, which is Long-Term Support (LTS) edition, and use that.
-
-On Mac, steps would be:
-
-1. check version
-```bash
-mvn -v
-```
-- java version says "17", you're good to go. if it is <=8, or >=19, you should upgrade/downgrade
-  respectively.
-
-2. install java 17
-```bash
-brew install openjdk@17
-```
-
-3. set `JAVA_HOME` env variable to point to java 17; for example:
-
-```bash
-export JAVA_HOME='/opt/homebrew/Cellar/openjdk@17/17.0.6/libexec/openjdk.jdk/Contents/Home'
-```
-
-or, possibly your Homebrew default installation is at `/usr/local/Cellar/`, in which case:
-
-```bash
-/usr/local/Cellar/openjdk@17/17.0.6/libexec/openjdk.jdk/Contents/Home
-```
-
-NOTE:
-  - you may need to edit some similar `export` command in your `.bashrc`/`.zshrc` file, or similar;
-    or add that `export` command to such a file. Otherwise, you'll need to repeat the command every
-    time you open a new terminal window.
-  - if you install/upgrade something via Homebrew that depends on Java, you may need to repeat step
-    3 again to reset your `JAVA_HOME`
-
-
 ### General Build / Packaging Failures
 Our example Terraform configurations should compile and package the Java code into a JAR file, which
 is then deployed by Terraform to your host environment.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <revision>0.4.26</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dependency.lombok.version>1.18.22</dependency.lombok.version>
+        <dependency.lombok.version>1.18.28</dependency.lombok.version>
         <dependency.dagger.version>2.40.5</dependency.dagger.version>
         <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <dependency.apache-commons-lang3.version>3.12.0</dependency.apache-commons-lang3.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <revision>0.4.26</revision>
-        <dependency.jackson.version>2.12.5</dependency.jackson.version>
+        <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.lombok.version>1.18.22</dependency.lombok.version>
         <dependency.dagger.version>2.40.5</dependency.dagger.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,21 +11,21 @@
 
     <properties>
         <revision>0.4.26</revision>
-        <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.lombok.version>1.18.22</dependency.lombok.version>
         <dependency.dagger.version>2.40.5</dependency.dagger.version>
+        <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <dependency.apache-commons-lang3.version>3.12.0</dependency.apache-commons-lang3.version>
         <dependency.apache-commons-csv.version>1.4</dependency.apache-commons-csv.version>
-        <dependency.guava.version>31.1-jre</dependency.guava.version>
-        <dependency.commons-io.version>2.11.0</dependency.commons-io.version>
-        <dependency.apache-httpcore.version>4.4.15</dependency.apache-httpcore.version>
-        <dependency.google-cloud-bom.version>0.163.0</dependency.google-cloud-bom.version>
-        <dependency.google-http-client.version>1.41.0</dependency.google-http-client.version>
-        <dependency.google-auth-library-oauth2-http.version>1.2.2</dependency.google-auth-library-oauth2-http.version>
+        <dependency.guava.version>32.0.1-jre</dependency.guava.version>
+        <dependency.commons-io.version>2.13.0</dependency.commons-io.version>
+        <dependency.apache-httpcore.version>4.4.16</dependency.apache-httpcore.version>
+        <dependency.google-cloud-bom.version>0.198.0</dependency.google-cloud-bom.version>
+        <dependency.google-http-client.version>1.43.3</dependency.google-http-client.version>
+        <dependency.google-auth-library-oauth2-http.version>1.18.0</dependency.google-auth-library-oauth2-http.version>
         <dependency.junit-jupiter.version>5.9.1</dependency.junit-jupiter.version>
         <dependency.mockito-junit-jupiter.version>4.11.0</dependency.mockito-junit-jupiter.version>
-        <dependency.json-path.version>2.7.0</dependency.json-path.version>
+        <dependency.json-path.version>2.8.0</dependency.json-path.version>
         <dependency.bettercloud-vault-java-driver>5.1.0</dependency.bettercloud-vault-java-driver>
     </properties>
 

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -39,8 +39,7 @@ printf "\n"
 JAVA_VERSION=`mvn -v | grep Java`
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
-printf "\t- if that is a Java version < 11, you must upgrade to 11 or higher. We recommend 17, as it is LTS and we have seen problems with 19.x and 20.x.\n"
-printf "\t- if that is some version of Java 19.x / 20.x, we recommend you *downgrade* to 17. See https://github.com/Worklytics/psoxy/blob/main/docs/troubleshooting.md#build-problems-with-java-19-specifically-openjdk-19\n"
+printf "\t- if that is a Java version < 11, you must upgrade to 11. Java >= 11, <= 20 are supported.\n"
 printf "\t- if you have a Java JDK of the right version installed on your machine *other* than the one referenced there, set your ${BLUE}JAVA_HOME${NC} to its location.\n"
 
 printf "\n"


### PR DESCRIPTION
branches from #389; that was split out, as specifically requested by customer

### Features
 - guava to 31.1 --> 32.0.1
 - apache commons io to 2.11 --> 2.13
 - apache httpcore 4.4.15 --> 4.4.16
 - gcloud bom 0.163.0 -->? 0.198.0
 - google-http-client 1.41.0 --> 1.43.0
 - google-auth-library-oauth2-http 1.2.2 --> 1.18.0
 - json-path 2.7 --> 2.8

### Change implications

 - dependencies added/changed? **yes - see above**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204912240755718