### PR TITLE
S152 jira connector todo

### DIFF
--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -282,6 +282,7 @@ module "worklytics-psoxy-connection-long-auth" {
   psoxy_endpoint_url     = module.connector-long-auth-function[each.key].cloud_function_url
   display_name           = "${each.value.display_name} via Psoxy${var.connector_display_name_suffix}"
   todo_step              = module.connector-long-auth-function[each.key].next_todo_step
+  settings_to_provide    = try(each.value.settings_to_provide, {})
 }
 # END LONG ACCESS AUTH CONNECTORS
 
@@ -371,7 +372,7 @@ output "todos_3" {
   description = "List of todo steps to complete 3rd, in markdown format."
   value = concat(
     values(module.worklytics-psoxy-connection)[*].todo,
-    values(module.worklytics-psoxy-connection)[*].todo,
+    values(module.worklytics-psoxy-connection-long-auth)[*].todo,
     values(module.psoxy-bulk-to-worklytics)[*].todo,
   )
 }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -567,6 +567,9 @@ EOT
         REFRESH_ENDPOINT : "https://auth.atlassian.com/oauth/token"
         USE_SHARED_TOKEN : "TRUE"
       }
+      settings_to_provide = {
+        "Jira Cloud Id" = local.jira_cloud_id
+      }
       reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       example_api_calls : [

--- a/infra/modules/worklytics-psoxy-connection-generic/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-generic/main.tf
@@ -14,6 +14,7 @@ locals {
     PROXY_ENDPOINT     = "Psoxy Base URL"
     PROXY_BUCKET_NAME  = "Bucket Name"
     parserId           = "Parser"
+    CLOUD_ID           = "Jira Cloud Id"
   }
 
   query_params = [for param_name, ux_name in local.autofilled_settings : "${param_name}=${urlencode(var.settings_to_provide[ux_name])}"


### PR DESCRIPTION
- Adding a parameter for including *cloud_id* as part of deep linking when creating the Jira Cloud connector.
- For *old" gcp-google-workspace module, fixing TODOs generation and including support for settings in long oauth connectors.

### Change implications

 - dependencies added/changed? **yes (explain) / no**
