### PR TITLE
interactive init script 

### DIFF
--- a/tools/init-example-full.sh
+++ b/tools/init-example-full.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+SCRIPT_VERSION="rc-v0.4.28"
+
+# colors
+RED='\e[0;31m'
+BLUE='\e[0;34m'
+NC='\e[0m' # No Color
+
+REPO_CLONE_BASE_DIR=${1:-".terraform/modules/psoxy/"}
+TF_CONFIG_ROOT=`pwd`
+
+if [[ ! -d "$REPO_CLONE_BASE_DIR" ]]; then
+  printf "Directory ${RED}${TF_CONFIG_ROOT}${NC} does not exist.\n"
+  exit 1
+fi
+
+
+TFVARS_FILE="${TF_CONFIG_ROOT}/terraform.tfvars"
+
+if [ ! -f "${TFVARS_FILE}" ]; then
+  printf "Initializing ${BLUE}terraform.tfvars${NC} file for your configuration ...\n"
+
+
+
+  # determine terraform apply location
+  read -p "Do you wish to run 'terraform apply' locally on this machine? (Y/n) " -n 1 -r
+
+  REPLY=${REPLY:-Y}
+  case "$REPLY" in
+    [yY][eE][sS]|[yY])
+      echo "Deployment environment set to 'local'."
+      DEPLOYMENT_ENV="local"
+      ;;
+    [nN]|[oO])
+      ;;
+    *)
+      printf "${RED}Invalid input${NC}\n"
+      exit 1
+      ;;
+  esac
+  echo "" # newline
+
+  if [[ -z "$DEPLOYMENT_ENV" ]]; then
+    read -p "Do you wish to run 'terraform apply' in Terraform Cloud? (Y/n) " -n 1 -r
+
+    REPLY=${REPLY:-Y}
+    case "$REPLY" in
+      [yY][eE][sS]|[yY])
+        echo "Deployment environment set to 'terraform_cloud'."
+        DEPLOYMENT_ENV="terraform_cloud"
+        ;;
+      [nN]|[oO])
+        ;;
+      *)
+        printf "${READ}Invalid input${NC}\n"
+        exit 1
+        ;;
+    esac
+    echo "" # newline
+  fi
+
+
+  if [[ -z "$DEPLOYMENT_ENV" ]]; then
+    read -p "Do you wish to run 'terraform apply' in GitHub Actions? (Y/n) " -n 1 -r
+
+    REPLY=${REPLY:-Y}
+    case "$REPLY" in
+      [yY][eE][sS]|[yY])
+        echo "Deployment environment set to 'github_action'."
+        DEPLOYMENT_ENV="github_action"
+        ;;
+      [nN]|[oO])
+        ;;
+      *)
+        printf "${RED}Invalid input${NC}\n"
+        exit 1
+        ;;
+    esac
+    echo "" # newline
+  fi
+
+  if [[ -z "$DEPLOYMENT_ENV" ]]; then
+    printf "${RED}No deployment environment selected.${NC} Exiting.\n"
+    exit 1;
+  fi
+
+
+  if [ -f "${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl" ]; then
+    cp "${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl" "${TFVARS_FILE}"
+  else
+    touch "${TFVARS_FILE}"
+  fi
+
+  ${REPO_CLONE_BASE_DIR}tools/init-tfvars.sh "${TFVARS_FILE}" "${REPO_CLONE_BASE_DIR}" "${DEPLOYMENT_ENV}"
+fi
+
+# pattern used to grep for provider at top-level of Terraform configuration
+TOP_LEVEL_PROVIDER_PATTERN="^├── provider\[registry.terraform.io/hashicorp"
+AWS_PROVIDER_COUNT=$(terraform providers | grep "${TOP_LEVEL_PROVIDER_PATTERN}/aws" | wc -l)
+AWS_HOSTED=$(test $AWS_PROVIDER_COUNT -ne 0)
+if [ $AWS_HOSTED ]; then
+  HOST_PLATFORM="aws"
+else
+  HOST_PLATFORM="gcp"
+fi
+
+# START CREATION OF BUILD SCRIPT
+# create example build script, to support building deployment bundle (JAR) outside of Terraform
+# (useful for debugging)
+
+BUILD_DEPLOYMENT_BUNDLE_SCRIPT=${TF_CONFIG_ROOT}/build
+if [ -f $BUILD_DEPLOYMENT_BUNDLE_SCRIPT ]; then
+  rm "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
+fi
+
+touch "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
+echo "#!/bin/bash" >> $BUILD_DEPLOYMENT_BUNDLE_SCRIPT
+
+echo "\"${REPO_CLONE_BASE_DIR}tools/build.sh\" $HOST_PLATFORM \"${REPO_CLONE_BASE_DIR}java\"" >> $BUILD_DEPLOYMENT_BUNDLE_SCRIPT
+chmod +x "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
+# END BUILD SCRIPT
+
+# Install test tool (if user agrees)
+read -p "Do you want to install the NodeJS-based tooling to test your psoxy instance from this machine? (requires NodeJS/npm) (Y/n) " -n 1 -r
+REPLY=${REPLY:-Y}
+echo    # Move to a new line
+case "$REPLY" in
+  [yY][eE][sS]|[yY])
+    ${REPO_CLONE_BASE_DIR}tools/install-test-tool.sh "${REPO_CLONE_BASE_DIR}tools"
+    ;;
+  *)
+    echo "Installation of test tool skipped."
+    ;;
+esac
+
+

--- a/tools/init-example.sh
+++ b/tools/init-example.sh
@@ -1,39 +1,37 @@
 #!/bin/bash
 
-# Psoxy init script
+# Psoxy init script - lite version
+#
+# Usage:
+#   ./tools/release/init-example.sh <repo-root>
 #
 # this is meant to be run from within a Terraform configuration for Psoxy, modeled on one of our
+# examples
+#
+# this is a 'thin' version, expected to be duplicated across multiple examples and then leverage
+# that 'terraform init' will do a clone of the repo, in which a longer init script will be provided
+#
 #
 # Testing:
 #   - within example directory, such as `infra/examples/aws-msft-365`:
-#     ../../tools/release/init-example.sh
-#
-#  or
-#    ../../tools/release/init-example.sh terraform_cloud
+#     ../../../tools/init-example.sh ~/code/psoxy
 #
 #   to repeat:
-#     ../../tools/release/reset-example.sh
-
+#     ../../../tools/reset-example.sh
 
 # colors
 RED='\e[0;31m'
 BLUE='\e[0;34m'
 NC='\e[0m' # No Color
 
+
+EXPLICIT_REPO_CLONE_DIR=$1
+
+if [[ "${EXPLICIT_REPO_CLONE_DIR}" != */ ]]; then
+    EXPLICIT_REPO_CLONE_DIR="${EXPLICIT_REPO_CLONE_DIR}/"
+fi
+
 TF_CONFIG_ROOT=`pwd`
-
-case "$1" in
-  terraform_cloud)
-    DEPLOYMENT_ENV="terraform_cloud"
-    ;;
-  github_action)
-    DEPLOYMENT_ENV="github_action"
-    ;;
-  *)
-    DEPLOYMENT_ENV="local"
-esac
-
-printf "Initializing configuration for deployment from ${BLUE}${DEPLOYMENT_ENV}${NC} ...\n"
 
 if ! terraform -v &> /dev/null ; then
   printf "${RED}Terraform not available; required for this Psoxy example. See https://github.com/Worklytics/psoxy#prerequisites ${NC}\n"
@@ -45,64 +43,23 @@ printf "Initializing ${BLUE}psoxy${NC} Terraform configuration ...\n"
 terraform init
 
 TF_INIT_EXIT_CODE=$?
-if [ $TF_INIT_EXIT_CODE -ne 0 ]; then
+if [[ $TF_INIT_EXIT_CODE -ne 0 ]]; then
   printf "${RED}Terraform init failed. See above for details. Cannot continue to initialize example configuration.${NC}\n"
   exit 1
 fi
 
-if [ -d ".terraform/modules/psoxy/" ]; then
-  PSOXY_BASE_DIR=".terraform/modules/psoxy/"
-elif [ -d "${TF_CONFIG_ROOT}/.terraform/modules/psoxy/" ]; then
-  # use checkout of repo done by Terraform
-  PSOXY_BASE_DIR="${TF_CONFIG_ROOT}/.terraform/modules/psoxy/"
-else
-  # use checkout of repo on your local machine
-  cd ../../..
-  PSOXY_BASE_DIR="`pwd`/"
-  cd "${TF_CONFIG_ROOT}"
-fi
-
-TFVARS_FILE="${TF_CONFIG_ROOT}/terraform.tfvars"
-
-if [ ! -f "${TFVARS_FILE}" ]; then
-  printf "Initializing ${BLUE}terraform.tfvars${NC} file for your configuration ...\n"
-
-  if [ -f "${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl" ]; then
-    cp "${TF_CONFIG_ROOT}/terraform.tfvars.example.hcl" "${TFVARS_FILE}"
+if [[ -z $EXPLICIT_REPO_CLONE_DIR ]]; then
+  if [[ -d ".terraform/modules/psoxy/" ]]; then
+    REPO_CLONE_BASE_DIR=".terraform/modules/psoxy/"
   else
-    touch "${TFVARS_FILE}"
+    # use checkout of repo on your local machine
+    cd ../../..
+    REPO_CLONE_BASE_DIR="$(pwd)/"
+    cd "${TF_CONFIG_ROOT}" # q: could be just `cd -`, right?
   fi
-
-  ${PSOXY_BASE_DIR}tools/init-tfvars.sh $TFVARS_FILE $PSOXY_BASE_DIR $DEPLOYMENT_ENV
 else
-  printf "${RED}Nothing to initialize. File terraform.tfvars already exists.${NC}\n\n"
+  REPO_CLONE_BASE_DIR="$EXPLICIT_REPO_CLONE_DIR"
 fi
 
-# pattern used to grep for provider at top-level of Terraform configuration
-TOP_LEVEL_PROVIDER_PATTERN="^├── provider\[registry.terraform.io/hashicorp"
-AWS_PROVIDER_COUNT=$(terraform providers | grep "${TOP_LEVEL_PROVIDER_PATTERN}/aws" | wc -l)
-AWS_HOSTED=$(test $AWS_PROVIDER_COUNT -ne 0)
-if [ $AWS_HOSTED ]; then
-  HOST_PLATFORM="aws"
-else
-  HOST_PLATFORM="gcp"
-fi
-
-# START BUILD SCRIPT
-# create example build script, to support building deployment bundle (JAR) outside of Terraform
-# (useful for debugging)
-
-BUILD_DEPLOYMENT_BUNDLE_SCRIPT=${TF_CONFIG_ROOT}/build
-if [ -f $BUILD_DEPLOYMENT_BUNDLE_SCRIPT ]; then
-  rm "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
-fi
-
-touch "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
-echo "#!/bin/bash" >> $BUILD_DEPLOYMENT_BUNDLE_SCRIPT
-
-echo "\"${PSOXY_BASE_DIR}tools/build.sh\" $HOST_PLATFORM \"${PSOXY_BASE_DIR}java\"" >> $BUILD_DEPLOYMENT_BUNDLE_SCRIPT
-chmod +x "$BUILD_DEPLOYMENT_BUNDLE_SCRIPT"
-# END BUILD SCRIPT
-
-# Install test tool
-${PSOXY_BASE_DIR}tools/install-test-tool.sh "${PSOXY_BASE_DIR}tools"
+# pass control to the full init script.
+${REPO_CLONE_BASE_DIR}/tools/init-example-full.sh $REPO_CLONE_BASE_DIR

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -8,7 +8,6 @@ DEPLOYMENT_ENV=${3:-"local"}
 
 SCRIPT_VERSION="rc-v0.4.28"
 
-
 if [ -z "$PSOXY_BASE_DIR" ]; then
   printf "Usage: init-tfvars.sh <path-to-terraform.tfvars> <path-to-psoxy-base-directory> [DEPLOYMENT_ENV]\n"
   exit 1


### PR DESCRIPTION

### Features
 - split up `init-example.sh` script a bit, so part deployed in example can be minimal - so less critical if people are using old forked examples
 - make the script more interactive, to simplify usage

### Change implications

 - dependencies added/changed? **no**
