### PR TITLE
release tooling 4

### DIFF
--- a/tools/release/prep.sh
+++ b/tools/release/prep.sh
@@ -58,3 +58,8 @@ git grep -l "$CURRENT_RELEASE_PATTERN" java/
 git grep -l "$CURRENT_RELEASE_PATTERN" infra/
 git grep -l "$CURRENT_RELEASE_PATTERN" tools/
 
+git add java/
+git add infra/examples/**/main.tf
+git add infra/examples-dev/**/main.tf
+git add infra/examples-dev/**/msft-365.tf
+git add infra/examples-dev/**/google-workspace.tf

--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Arguments: repository name and tag name
+RELEASE="$1"
+
+GREEN='\e[0;32m'
+RED='\e[0;31m'
+NC='\e[0m' # No Color
+
+set -e
+
+if git rev-parse "$RELEASE" >/dev/null 2>&1; then
+  printf "Tag ${GREEN}$RELEASE${NC} already exists.\n"
+else
+  git checkout main
+
+  # verify on main branch and clean status
+  CURRENT_BRANCH=$(git branch --show-current)
+  if [ "$CURRENT_BRANCH" != "main" ]; then
+    printf "${RED}Current branch is not main. Please checkout main branch and try again.${NC}\n"
+    exit 1
+  fi
+
+  git tag $RELEASE
+fi
+
+git push origin $RELEASE
+
+if gh release view $RELEASE >/dev/null 2>&1
+then
+  printf "Release ${GREEN}$RELEASE${NC} already exists.\n"
+else
+  gh release create --draft --generate-notes $RELEASE
+fi
+
+
+# Fetch release notes
+release_notes=$(gh release view $RELEASE --json body -q '.body')
+
+# Remove GitHub username mentions
+modified_notes=$(echo -e "$release_notes" | sed -r 's/by @[a-zA-Z0-9_-]+ in//g')
+
+# Update release notes
+gh release edit $RELEASE -n "$modified_notes"


### PR DESCRIPTION
### Features
  - after version ref updates, `git add` files expected to be changed
  - `tools/release/publish.sh` script, which preps release tag, creates gh release, formats notes

### Change implications

 - dependencies added/changed? **no**
