### PR TITLE
fix aws-cognito references in examples

### DIFF
--- a/infra/examples-dev/aws-all/msft-365.tf
+++ b/infra/examples-dev/aws-all/msft-365.tf
@@ -51,6 +51,7 @@ module "cognito_identity" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-identity-cli"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-identity-cli?ref=rc-v0.4.29"
 
   aws_region       = data.aws_region.current.id
   aws_role         = var.aws_assume_role_arn

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -71,6 +71,8 @@ moved {
 
 module "cognito-identity-pool" {
   source = "../../modules/aws-cognito-pool"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=rc-v0.4.29"
+
 
   developer_provider_name = "azure-access"
   name                    = "azure-ad-federation"

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -232,6 +232,7 @@ module "cognito_identity_pool" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-pool"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=rc-v0.4.29"
 
   developer_provider_name = "azure-access"
   name                    = "azure-ad-federation"
@@ -241,6 +242,7 @@ module "cognito_identity" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-identity-cli"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-identity-cli?ref=rc-v0.4.29"
 
   identity_pool_id = module.cognito_identity_pool[0].pool_id
   aws_region       = data.aws_region.current.id


### PR DESCRIPTION
### Fixes
 - missing references to github modules for aws-cognito in several examples; although these are commented out, these are uncommented when building the example templates

### Change implications

 - dependencies added/changed? **no**
