### PR TITLE
edge cases in disabled connectors breaks terraform 

### DIFF
--- a/infra/modules/worklytics-connectors-google-workspace/outputs.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/outputs.tf
@@ -9,5 +9,5 @@ output "todos" {
 }
 
 output "next_todo_step" {
-  value = max(values(module.google_workspace_connection)[*].next_todo_step...)
+  value = try(max(values(module.google_workspace_connection)[*].next_todo_step...), var.todo_step)
 }

--- a/infra/modules/worklytics-connectors/outputs.tf
+++ b/infra/modules/worklytics-connectors/outputs.tf
@@ -20,5 +20,5 @@ output "todos" {
 }
 
 output "next_todo_step" {
-  value = max(values(module.source_token_external_todo)[*].next_todo_step...)
+  value = try(max(values(module.source_token_external_todo)[*].next_todo_step...), var.todo_step)
 }


### PR DESCRIPTION
### Fixes
 - terraform breaks if `google-workspace.tf` included in example, but all disabled
 - terraform breaks if all non-Google, non-MSFT sources disabled
 

### Change implications

 - dependencies added/changed? **no**
