### PR TITLE
pass-through `Link` HTTP Header

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -144,8 +144,8 @@
 
         <!-- explicit direct dep on apache HTTP Client (psoxy-core has transitive dep on it) -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
             <version>${dependency.apache-httpcore.version}</version>
         </dependency>
 

--- a/java/core/psoxy-core.iml
+++ b/java/core/psoxy-core.iml
@@ -42,6 +42,7 @@
     <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.43.3" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.14" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-api:0.31.1" level="project" />
     <orderEntry type="library" name="Maven: io.grpc:grpc-context:1.27.2" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-contrib-http-util:0.31.1" level="project" />
@@ -53,7 +54,7 @@
     <orderEntry type="library" name="Maven: com.github.bbottema:emailaddress-rfc2822:2.3.1" level="project" />
     <orderEntry type="library" name="Maven: com.sun.mail:jakarta.mail:1.6.7" level="project" />
     <orderEntry type="library" name="Maven: com.sun.activation:jakarta.activation:1.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents.core5:httpcore5:5.2.2" level="project" />
     <orderEntry type="library" name="Maven: com.bettercloud:vault-java-driver:5.1.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:4.11.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:4.11.0" level="project" />

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.java.Log;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
@@ -83,9 +83,7 @@ public class CommonRequestHandler {
             HttpHeaders.CONTENT_TYPE,
             HttpHeaders.CACHE_CONTROL,
             HttpHeaders.ETAG,
-            // Used to express a typed relationship with another resource, where the relation type is defined by RFC 5988
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
-            "Link",
+            HttpHeaders.LINK,
             HttpHeaders.EXPIRES,
             HttpHeaders.LAST_MODIFIED,
             HttpHeaders.RETRY_AFTER

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -50,35 +50,45 @@ public class CommonRequestHandler {
 
     @Inject
     EnvVarsConfigService envVarsConfigService;
-    @Inject ConfigService config;
-    @Inject RulesUtils rulesUtils;
-    @Inject SourceAuthStrategy sourceAuthStrategy;
-    @Inject ObjectMapper objectMapper;
+    @Inject
+    ConfigService config;
+    @Inject
+    RulesUtils rulesUtils;
+    @Inject
+    SourceAuthStrategy sourceAuthStrategy;
+    @Inject
+    ObjectMapper objectMapper;
     @Inject
     RESTApiSanitizerFactory sanitizerFactory;
     @Inject
     PseudonymizerImplFactory pseudonymizerImplFactory;
     @Inject
     RESTRules rules;
-    @Inject HealthCheckRequestHandler healthCheckRequestHandler;
+    @Inject
+    HealthCheckRequestHandler healthCheckRequestHandler;
     @Inject
     ReversibleTokenizationStrategy reversibleTokenizationStrategy;
-    @Inject UrlSafeTokenPseudonymEncoder pseudonymEncoder;
+    @Inject
+    UrlSafeTokenPseudonymEncoder pseudonymEncoder;
 
     /**
      * Basic headers to pass: content, caching, retries. Can be expanded by connection later.
      * Matches literally on headers.
+     *
      * @see #passThroughHeaders(HttpEventResponse.HttpEventResponseBuilder, HttpResponse)
      * @see <a href="https://flaviocopes.com/http-response-headers/"></a>
      * @see <a href="https://developer.mozilla.org/en-US/docs/Glossary/Response_header"></a>
      */
     public static Set<String> DEFAULT_HEADERS_PASS_THROUGH = normalizeHeaders(Set.of(
-        HttpHeaders.CONTENT_TYPE,
-        HttpHeaders.CACHE_CONTROL,
-        HttpHeaders.ETAG,
-        HttpHeaders.EXPIRES,
-        HttpHeaders.LAST_MODIFIED,
-        HttpHeaders.RETRY_AFTER
+            HttpHeaders.CONTENT_TYPE,
+            HttpHeaders.CACHE_CONTROL,
+            HttpHeaders.ETAG,
+            // Used to express a typed relationship with another resource, where the relation type is defined by RFC 5988
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+            "Link",
+            HttpHeaders.EXPIRES,
+            HttpHeaders.LAST_MODIFIED,
+            HttpHeaders.RETRY_AFTER
     ));
 
     /**
@@ -87,15 +97,15 @@ public class CommonRequestHandler {
      * @see #passThroughHeaders(HttpEventResponse.HttpEventResponseBuilder, HttpResponse)
      */
     public Set<Pattern> RE_MATCH_HEADERS_PASS_THROUGH = ImmutableSet.of(
-        Pattern.compile(normalizeHeader("X-RateLimit.*"))
+            Pattern.compile(normalizeHeader("X-RateLimit.*"))
     );
 
     /**
      * <a href="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2">rfc7230</a>
      * "... A recipient MAY combine multiple header fields with the same field
-     *    name into one "field-name: field-value" pair, without changing the
-     *    semantics of the message, by appending each subsequent field value to
-     *    the combined field value in order, separated by a comma."
+     * name into one "field-name: field-value" pair, without changing the
+     * semantics of the message, by appending each subsequent field value to
+     * the combined field value in order, separated by a comma."
      */
     private static final Joiner HEADER_JOINER = Joiner.on(",");
 
@@ -186,15 +196,15 @@ public class CommonRequestHandler {
 
         //TODO: what headers to forward???
         sourceApiRequest.setHeaders(sourceApiRequest.getHeaders()
-            //seems like Google API HTTP client has a default 'Accept' header with 'text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2' ??
-            .setAccept(ContentType.APPLICATION_JSON.toString())  //MSFT gives weird "{"error":{"code":"InternalServerError","message":"The MIME type 'text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2' requires a '/' character between type and subtype, such as 'text/plain'."}}
+                //seems like Google API HTTP client has a default 'Accept' header with 'text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2' ??
+                .setAccept(ContentType.APPLICATION_JSON.toString())  //MSFT gives weird "{"error":{"code":"InternalServerError","message":"The MIME type 'text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2' requires a '/' character between type and subtype, such as 'text/plain'."}}
         );
 
         //setup request
         sourceApiRequest
-            .setThrowExceptionOnExecuteError(false)
-            .setConnectTimeout(SOURCE_API_REQUEST_CONNECT_TIMEOUT_MILLISECONDS)
-            .setReadTimeout(SOURCE_API_REQUEST_READ_TIMEOUT);
+                .setThrowExceptionOnExecuteError(false)
+                .setConnectTimeout(SOURCE_API_REQUEST_CONNECT_TIMEOUT_MILLISECONDS)
+                .setReadTimeout(SOURCE_API_REQUEST_READ_TIMEOUT);
 
         //q: add exception handlers for IOExceptions / HTTP error responses, so those retries
         // happen in proxy rather than on Worklytics-side?
@@ -242,7 +252,6 @@ public class CommonRequestHandler {
     }
 
 
-
     /**
      * encapsulates dynamically configuring Sanitizer based on request (to support some aspects of
      * its behavior being controlled via HTTP headers)
@@ -256,7 +265,7 @@ public class CommonRequestHandler {
             if (!Objects.equals(pseudonymImplementation.get(),
                     sanitizer.getPseudonymizer().getOptions().getPseudonymImplementation())) {
                 return sanitizerFactory.create(rules,
-                    pseudonymizerImplFactory.create(sanitizer.getPseudonymizer().getOptions().withPseudonymImplementation(pseudonymImplementation.get())));
+                        pseudonymizerImplFactory.create(sanitizer.getPseudonymizer().getOptions().withPseudonymImplementation(pseudonymImplementation.get())));
             }
         }
 
@@ -267,20 +276,21 @@ public class CommonRequestHandler {
     @VisibleForTesting
     Optional<PseudonymImplementation> parsePseudonymImplementation(HttpEventRequest request) {
         return request.getHeader(ControlHeader.PSEUDONYM_IMPLEMENTATION.getHttpHeader())
-            .map(PseudonymImplementation::parseHttpHeaderValue);
+                .map(PseudonymImplementation::parseHttpHeaderValue);
     }
 
     /**
      * side effects: modifies the responseBuilder, adding the headers to pass through
+     *
      * @param responseBuilder - the proxy response being built
-     * @param response - the original response from the upstream API
+     * @param response        - the original response from the upstream API
      */
     @VisibleForTesting
     void passThroughHeaders(HttpEventResponse.HttpEventResponseBuilder responseBuilder, com.google.api.client.http.HttpResponse response) {
         Set<String> availableHeaders = normalizeHeaders(response.getHeaders().keySet());
 
         Sets.intersection(availableHeaders, DEFAULT_HEADERS_PASS_THROUGH).forEach(
-            h -> responseBuilder.header(h, HEADER_JOINER.join(response.getHeaders().getHeaderStringValues(h)))
+                h -> responseBuilder.header(h, HEADER_JOINER.join(response.getHeaders().getHeaderStringValues(h)))
         );
 
         for (String availableHeader : availableHeaders) {
@@ -298,6 +308,7 @@ public class CommonRequestHandler {
     static String normalizeHeader(String header) {
         return header.toLowerCase(Locale.US);
     }
+
     /**
      * @param headers header set
      * @return new set with headers normalized for comparisons
@@ -318,14 +329,14 @@ public class CommonRequestHandler {
 
         //assume that in cloud function env, this will get ours ...
         Optional<String> accountToImpersonate =
-           request.getHeader(ControlHeader.USER_TO_IMPERSONATE.getHttpHeader());
+                request.getHeader(ControlHeader.USER_TO_IMPERSONATE.getHttpHeader());
 
 
         accountToImpersonate.ifPresent(user -> log.info("Impersonating user"));
         //TODO: warn here for Google Workspace connectors, which expect user??
 
         accountToImpersonate = accountToImpersonate
-            .map(s -> pseudonymEncoder.decodeAndReverseAllContainedKeyedPseudonyms(s, reversibleTokenizationStrategy));
+                .map(s -> pseudonymEncoder.decodeAndReverseAllContainedKeyedPseudonyms(s, reversibleTokenizationStrategy));
 
         Credentials credentials = sourceAuthStrategy.getCredentials(accountToImpersonate);
         HttpCredentialsAdapter initializeWithCredentials = new HttpCredentialsAdapter(credentials);
@@ -335,14 +346,15 @@ public class CommonRequestHandler {
         // itself, if that's possible
 
         ComposedHttpRequestInitializer initializer =
-            ComposedHttpRequestInitializer.of(initializeWithCredentials,
-                new GzipedContentHttpRequestInitializer("Psoxy"));
+                ComposedHttpRequestInitializer.of(initializeWithCredentials,
+                        new GzipedContentHttpRequestInitializer("Psoxy"));
 
         return transport.createRequestFactory(initializer);
     }
 
     /**
      * Only allowed under development mode
+     *
      * @param request
      * @return
      */
@@ -350,8 +362,8 @@ public class CommonRequestHandler {
         if (config.isDevelopment()) {
             // caller requested to skip
             return request.getHeader(ControlHeader.SKIP_SANITIZER.getHttpHeader())
-                .map(Boolean::parseBoolean)
-                .orElse(false);
+                    .map(Boolean::parseBoolean)
+                    .orElse(false);
         } else {
             return false;
         }
@@ -374,8 +386,8 @@ public class CommonRequestHandler {
         uriBuilder.setHost(config.getConfigPropertyOrError(ProxyConfigProperty.TARGET_HOST));
         URL hostURL = uriBuilder.build().toURL();
         String hostPlusPath =
-            StringUtils.stripEnd(hostURL.toString(),"/") + "/" +
-                StringUtils.stripStart(request.getPath(),"/");
+                StringUtils.stripEnd(hostURL.toString(), "/") + "/" +
+                        StringUtils.stripStart(request.getPath(), "/");
         String targetURLString = hostPlusPath;
         if (StringUtils.isNotBlank(request.getQuery().orElse(null))) {
             targetURLString = hostPlusPath + "?" + request.getQuery().get();

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -180,6 +180,7 @@ class CommonRequestHandlerTest {
                         response.addHeader("X-RateLimit-Category", "ABC");
                         response.addHeader("X-RateLimit-Remaining", "25600");
                         response.addHeader("X-CustomStuff", "value123");
+                        response.addHeader("Link", "https://some-url.com/with_a?link=to_use");
                         response.setStatusCode(200);
                         response.setContentType(Json.MEDIA_TYPE);
                         response.setContent("OK");
@@ -200,8 +201,8 @@ class CommonRequestHandlerTest {
         Set<String> UNEXPECTED_HEADERS = CommonRequestHandler.normalizeHeaders(
             Set.of("Set-Cookie", org.apache.http.HttpHeaders.CONNECTION, "X-CustomStuff"));
 
-        // 7 headers + content-type
-        assertEquals(8, headersMap.size());
+        // 8 headers + content-type
+        assertEquals(9, headersMap.size());
         assertTrue(headersMap.keySet().stream().noneMatch(UNEXPECTED_HEADERS::contains));
 
         assertEquals("no-cache, no-store, max-age=0, must-revalidate", headersMap.get(CommonRequestHandler.normalizeHeader(org.apache.http.HttpHeaders.CACHE_CONTROL)));

--- a/java/impl/aws/psoxy-aws.iml
+++ b/java/impl/aws/psoxy-aws.iml
@@ -12,7 +12,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: co.worklytics.psoxy:psoxy-core:0.4.30" level="project" />
+    <orderEntry type="module" module-name="psoxy-core" />
     <orderEntry type="module" module-name="gateway-core" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.15" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2" level="project" />
@@ -35,6 +35,7 @@
     <orderEntry type="library" name="Maven: org.yaml:snakeyaml:2.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.43.3" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.14" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-api:0.31.1" level="project" />
     <orderEntry type="library" name="Maven: io.grpc:grpc-context:1.27.2" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-contrib-http-util:0.31.1" level="project" />
@@ -46,7 +47,7 @@
     <orderEntry type="library" name="Maven: com.github.bbottema:emailaddress-rfc2822:2.3.1" level="project" />
     <orderEntry type="library" name="Maven: com.sun.mail:jakarta.mail:1.6.7" level="project" />
     <orderEntry type="library" name="Maven: com.sun.activation:jakarta.activation:1.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents.core5:httpcore5:5.2.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.28" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.dagger:dagger-compiler:2.40.5" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.dagger:dagger-producers:2.40.5" level="project" />

--- a/java/impl/cmd-line/psoxy-cmd-line.iml
+++ b/java/impl/cmd-line/psoxy-cmd-line.iml
@@ -13,7 +13,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: co.worklytics.psoxy:psoxy-core:0.4.30" level="project" />
+    <orderEntry type="module" module-name="psoxy-core" />
     <orderEntry type="module" module-name="gateway-core" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.12.0" level="project" />
@@ -29,7 +29,7 @@
     <orderEntry type="library" name="Maven: com.github.bbottema:emailaddress-rfc2822:2.3.1" level="project" />
     <orderEntry type="library" name="Maven: com.sun.mail:jakarta.mail:1.6.7" level="project" />
     <orderEntry type="library" name="Maven: com.sun.activation:jakarta.activation:1.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents.core5:httpcore5:5.2.2" level="project" />
     <orderEntry type="library" name="Maven: com.bettercloud:vault-java-driver:5.1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.28" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.dagger:dagger-compiler:2.40.5" level="project" />
@@ -92,6 +92,7 @@
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.14" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.15" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-contrib-http-util:0.31.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-gson:1.43.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java-util:3.23.2" level="project" />

--- a/java/impl/gcp/psoxy-gcp.iml
+++ b/java/impl/gcp/psoxy-gcp.iml
@@ -33,7 +33,7 @@
     <orderEntry type="library" name="Maven: com.github.bbottema:emailaddress-rfc2822:2.3.1" level="project" />
     <orderEntry type="library" name="Maven: com.sun.mail:jakarta.mail:1.6.7" level="project" />
     <orderEntry type="library" name="Maven: com.sun.activation:jakarta.activation:1.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.16" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents.core5:httpcore5:5.2.2" level="project" />
     <orderEntry type="library" name="Maven: com.bettercloud:vault-java-driver:5.1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.28" level="project" />
     <orderEntry type="library" name="Maven: com.google.dagger:dagger:2.40.5" level="project" />
@@ -117,6 +117,7 @@
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.13" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.15" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.15" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:4.11.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:4.11.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.12.19" level="project" />

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -19,7 +19,7 @@
         <dependency.apache-commons-csv.version>1.10.0</dependency.apache-commons-csv.version>
         <dependency.guava.version>32.0.1-jre</dependency.guava.version>
         <dependency.commons-io.version>2.13.0</dependency.commons-io.version>
-        <dependency.apache-httpcore.version>4.4.16</dependency.apache-httpcore.version>
+        <dependency.apache-httpcore.version>5.2.2</dependency.apache-httpcore.version>
         <dependency.google-cloud-bom.version>0.198.0</dependency.google-cloud-bom.version>
         <dependency.google-http-client.version>1.43.3</dependency.google-http-client.version>
         <dependency.google-auth-library-oauth2-http.version>1.18.0</dependency.google-auth-library-oauth2-http.version>


### PR DESCRIPTION
GH uses [Link header](https://docs.github.com/en/enterprise-cloud@latest/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers) for audit log. It seems something standard, so adding it as part of default headers to include.

### Features
[Psoxy support for link header](https://app.asana.com/0/0/1205095768432261)

### Change implications

 - dependencies added/changed? **yes (explain) / **yes** `org.apache.httpcomponents.core` 4.4.16 to `org.apache.httpcomponents.core5` to 5.2.2
 - something to note in `CHANGELOG.md`? **no**
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change **no**
