### PR TITLE
more constants in `psoxy-constants` module

### DIFF
--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -9,6 +9,12 @@ locals {
     "arn:aws:iam::aws:policy/AmazonSSMFullAccess"  = "AmazonSSMFullAccess"
     "arn:aws:iam::aws:policy/AWSLambda_FullAccess" = "AWSLambda_FullAccess"
   }
+  # AWS managed policy required to consume Microsoft 365 data
+  # (in addition to above)
+  required_aws_managed_policies_to_consume_msft_365_source = {
+    "arn:aws:iam::aws:policy/AmazonCognitoPowerUser" = "AmazonCognitoPowerUser"
+  }
+
   # TODO: create IAM policy document, which installer could use to create their own policy as
   # alternative to using AWS Managed policies
 

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -18,6 +18,15 @@ locals {
   # TODO: create IAM policy document, which installer could use to create their own policy as
   # alternative to using AWS Managed policies
 
+  # initial GCP APIs that must be enabled in projects that will host the proxy.
+  # (Terraform apply will enabled additional ones)
+  required_gcp_apis_to_host = {
+    # https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com
+    "iamcredentials.googleapis.com" = "IAM Service Account Credentials API",
+    # https://console.cloud.google.com/apis/library/serviceusage.googleapis.com
+    "serviceusage.googleapis.com"   = "Service Usage API",
+  }
+
   required_gcp_roles_to_provision_host = {
     "roles/storage.admin" = {
       display_name    = "Storage Admin",
@@ -43,7 +52,12 @@ locals {
       display_name    = "Cloud Functions Admin",
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin"
     },
-  } # TODO: add list of permissions, which customer could use to create custom role as alternative
+  }
+  # TODO: add list of permissions, which customer could use to create custom role as alternative
+
+
+  # TODO: confirm that this is indeed the same list (believe it is)
+  required_gcp_apis_to_provision_google_workspace_source = local.required_gcp_apis_to_host
 
   required_gcp_roles_to_provision_google_workspace_source = {
     "roles/iam.serviceAccountAdmin" = {

--- a/infra/modules/psoxy-constants/outputs.tf
+++ b/infra/modules/psoxy-constants/outputs.tf
@@ -4,6 +4,11 @@ output "required_aws_roles_to_provision_host" {
   description = "The AWS roles required to provision infrastructure needed to host Psoxy in AWS"
 }
 
+output "required_aws_managed_policies_to_consume_msft_365_source" {
+  value = local.required_aws_managed_policies_to_consume_msft_365_source
+  description = "The AWS managed policies required to provision infra needed to consume Microsoft 365 as a data source via Psoxy hosted in AWS"
+}
+
 output "required_gcp_roles_to_provision_host" {
   value       = local.required_gcp_roles_to_provision_host
   description = "The GCP roles required to provision infrastructure needed to host Psoxy in GCP"

--- a/infra/modules/psoxy-constants/outputs.tf
+++ b/infra/modules/psoxy-constants/outputs.tf
@@ -1,7 +1,13 @@
 
+# DEPRECATED
 output "required_aws_roles_to_provision_host" {
   value       = local.required_aws_roles_to_provision_host
-  description = "The AWS roles required to provision infrastructure needed to host Psoxy in AWS"
+  description = "DEPRECATED;The AWS roles required to provision infrastructure needed to host Psoxy in AWS"
+}
+
+output "required_aws_managed_policies_to_provision_host" {
+  value       = local.required_aws_roles_to_provision_host
+  description = "The AWS managed policies required to provision infrastructure needed to host Psoxy in AWS"
 }
 
 output "required_aws_managed_policies_to_consume_msft_365_source" {


### PR DESCRIPTION
### Features
 - add constant for required role for Azure AD federation from AWS
 - GCP API services as constants
 
### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204883565677974