### PR TITLE
source variable naming

### DIFF
--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -35,9 +35,9 @@ module "worklytics_connectors" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=rc-v0.4.31"
 
   enabled_connectors        = var.enabled_connectors
-  example_jira_issue_id     = var.example_jira_issue_id
   jira_cloud_id             = var.jira_cloud_id
   jira_server_url           = var.jira_server_url
+  jira_example_issue_id     = var.jira_example_issue_id
   salesforce_domain         = var.salesforce_domain
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization

--- a/infra/examples-dev/aws-all/misc-data-source-variables.tf
+++ b/infra/examples-dev/aws-all/misc-data-source-variables.tf
@@ -1,0 +1,45 @@
+# Terraform variables for miscellaneous data sources
+# (not coupled to hosting environment; so split into separate file to ease keeping them in sync
+#  across AWS/GCP examples.  DRY!!)
+
+variable "salesforce_domain" {
+  type        = string
+  description = "Domain of the Salesforce to connect to (only required if using Salesforce connector). To find your My Domain URL, from Setup, in the Quick Find box, enter My Domain, and then select My Domain"
+  default     = ""
+}
+
+variable "jira_server_url" {
+  type        = string
+  default     = null
+  description = "(Only required if using Jira Server connector) URL of the Jira server (ex: myjiraserver.mycompany.com)"
+}
+
+variable "jira_cloud_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
+}
+
+variable "jira_example_issue_id" {
+  type        = string
+  default     = null
+  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+}
+
+variable "github_installation_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector) InstallationId of the application in your org for authentication with the proxy instance (ex: 123456)"
+}
+
+variable "github_organization" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
+}
+
+variable "github_example_repository" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
+}

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -89,47 +89,6 @@ variable "caller_aws_arns" {
   }
 }
 
-variable "salesforce_domain" {
-  type        = string
-  description = "Domain of the Salesforce to connect to (only required if using Salesforce connector). To find your My Domain URL, from Setup, in the Quick Find box, enter My Domain, and then select My Domain"
-  default     = ""
-}
-
-variable "jira_server_url" {
-  type        = string
-  default     = null
-  description = "(Only required if using Jira Server connector) URL of the Jira server (ex: myjiraserver.mycompany.com)"
-}
-
-variable "jira_cloud_id" {
-  type        = string
-  default     = null
-  description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
-}
-
-variable "jira_example_issue_id" {
-  type        = string
-  default     = null
-  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
-}
-
-variable "github_installation_id" {
-  type        = string
-  default     = null
-  description = "(Only required if using Github connector) InstallationId of the application in your org for authentication with the proxy instance (ex: 123456)"
-}
-
-variable "github_organization" {
-  type        = string
-  default     = null
-  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
-}
-
-variable "github_example_repository" {
-  type        = string
-  default     = null
-  description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
-}
 
 variable "connector_display_name_suffix" {
   type        = string

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -107,10 +107,10 @@ variable "jira_cloud_id" {
   description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
 }
 
-variable "example_jira_issue_id" {
+variable "jira_example_issue_id" {
   type        = string
   default     = null
-  description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
 variable "github_installation_id" {

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -44,9 +44,9 @@ module "worklytics_connectors" {
 
 
   enabled_connectors        = var.enabled_connectors
-  example_jira_issue_id     = var.example_jira_issue_id
   jira_cloud_id             = var.jira_cloud_id
   jira_server_url           = var.jira_server_url
+  jira_example_issue_id     = var.jira_example_issue_id
   salesforce_domain         = var.salesforce_domain
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization

--- a/infra/examples-dev/gcp/misc-data-source-variables.tf
+++ b/infra/examples-dev/gcp/misc-data-source-variables.tf
@@ -1,0 +1,45 @@
+# Terraform variables for miscellaneous data sources
+# (not coupled to hosting environment; so split into separate file to ease keeping them in sync
+#  across AWS/GCP examples.  DRY!!)
+
+variable "salesforce_domain" {
+  type        = string
+  description = "Domain of the Salesforce to connect to (only required if using Salesforce connector). To find your My Domain URL, from Setup, in the Quick Find box, enter My Domain, and then select My Domain"
+  default     = ""
+}
+
+variable "jira_server_url" {
+  type        = string
+  default     = null
+  description = "(Only required if using Jira Server connector) URL of the Jira server (ex: myjiraserver.mycompany.com)"
+}
+
+variable "jira_cloud_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
+}
+
+variable "jira_example_issue_id" {
+  type        = string
+  default     = null
+  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+}
+
+variable "github_installation_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector) InstallationId of the application in your org for authentication with the proxy instance (ex: 123456)"
+}
+
+variable "github_organization" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
+}
+
+variable "github_example_repository" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
+}

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -251,10 +251,10 @@ variable "jira_cloud_id" {
   description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
 }
 
-variable "example_jira_issue_id" {
+variable "jira_example_issue_id" {
   type        = string
   default     = null
-  description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
 variable "github_installation_id" {

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -233,48 +233,6 @@ variable "custom_bulk_connector_rules" {
   }
 }
 
-variable "salesforce_domain" {
-  type        = string
-  description = "Domain of the Salesforce to connect to (only required if using Salesforce connector). To find your My Domain URL, from Setup, in the Quick Find box, enter My Domain, and then select My Domain"
-  default     = ""
-}
-
-variable "jira_server_url" {
-  type        = string
-  default     = null
-  description = "(Only required if using Jira Server connector) URL of the Jira server (ex: myjiraserver.mycompany.com)"
-}
-
-variable "jira_cloud_id" {
-  type        = string
-  default     = null
-  description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
-}
-
-variable "jira_example_issue_id" {
-  type        = string
-  default     = null
-  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
-}
-
-variable "github_installation_id" {
-  type        = string
-  default     = null
-  description = "(Only required if using Github connector) InstallationId of the application in your org for authentication with the proxy instance (ex: 123456)"
-}
-
-variable "github_organization" {
-  type        = string
-  default     = null
-  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
-}
-
-variable "github_example_repository" {
-  type        = string
-  default     = null
-  description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
-}
-
 # build lookup tables to JOIN data you receive back from Worklytics with your original data.
 #   - `join_key_column` should be the column you expect to JOIN on, usually 'employee_id'
 #   - `columns_to_include` is an optional a list of columns to include in the lookup table,

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -606,11 +606,11 @@ EOT
       example_api_calls_user_to_impersonate : null
       example_api_calls : [
         "/rest/api/2/search?maxResults=25",
-        "/rest/api/2/issue/${local.example_jira_issue_id}/comment?maxResults=25",
-        "/rest/api/2/issue/${local.example_jira_issue_id}/worklog?maxResults=25",
+        "/rest/api/2/issue/${local.jira_example_issue_id}/comment?maxResults=25",
+        "/rest/api/2/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
         "/rest/api/latest/search?maxResults=25",
-        "/rest/api/latest/issue/${local.example_jira_issue_id}/comment?maxResults=25",
-        "/rest/api/latest/issue/${local.example_jira_issue_id}/worklog?maxResults=25",
+        "/rest/api/latest/issue/${local.jira_example_issue_id}/comment?maxResults=25",
+        "/rest/api/latest/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
       ],
       external_token_todo : <<EOT
   1. Follow the instructions to create a [Personal Access Token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) in your instance.
@@ -656,15 +656,15 @@ EOT
         "/ex/jira/${local.jira_cloud_id}/rest/api/2/users",
         "/ex/jira/${local.jira_cloud_id}/rest/api/2/group/bulk",
         "/ex/jira/${local.jira_cloud_id}/rest/api/2/search?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.example_jira_issue_id}/changelog?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.example_jira_issue_id}/comment?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.example_jira_issue_id}/worklog?maxResults=25",
+        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/changelog?maxResults=25",
+        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/comment?maxResults=25",
+        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
         "/ex/jira/${local.jira_cloud_id}/rest/api/3/users",
         "/ex/jira/${local.jira_cloud_id}/rest/api/3/group/bulk",
         "/ex/jira/${local.jira_cloud_id}/rest/api/3/search?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.example_jira_issue_id}/changelog?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.example_jira_issue_id}/comment?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.example_jira_issue_id}/worklog?maxResults=25",
+        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/changelog?maxResults=25",
+        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/comment?maxResults=25",
+        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
         "/ex/jira/${local.jira_cloud_id}/rest/api/3/project/search?maxResults=25",
       ],
       external_token_todo : <<EOT

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -142,7 +142,7 @@ locals {
 
 
   jira_cloud_id             = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
-  example_jira_issue_id     = coalesce(var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
+  jira_example_issue_id     = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
   github_installation_id    = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
   github_organization       = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
   github_example_repository = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -45,11 +45,19 @@ variable "jira_cloud_id" {
   description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
 }
 
+#DEPRECATED
 variable "example_jira_issue_id" {
   type        = string
   default     = null
-  description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+  description = "Deprecated; use `jira_example_issued_id`. (Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
+
+variable "jira_example_issue_id" {
+  type        = string
+  default     = null
+  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+}
+
 
 variable "github_installation_id" {
   type        = string

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -7,6 +7,7 @@ module "worklytics_connector_specs" {
   jira_server_url           = var.jira_server_url
   salesforce_domain         = var.salesforce_domain
   example_jira_issue_id     = var.example_jira_issue_id
+  jira_example_issue_id     = var.jira_example_issue_id
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization
   github_example_repository = var.github_example_repository

--- a/infra/modules/worklytics-connectors/variables.tf
+++ b/infra/modules/worklytics-connectors/variables.tf
@@ -21,16 +21,17 @@ variable "jira_cloud_id" {
   description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
 }
 
+#DEPRECATED
 variable "example_jira_issue_id" {
   type        = string
   default     = null
-  description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
+  description = "Deprecated; use `jira_example_issued_id`. (Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
-variable "todo_step" {
-  type        = number
-  description = "of all todos, where does this one logically fall in sequence"
-  default     = 1
+variable "jira_example_issue_id" {
+  type        = string
+  default     = null
+  description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
 variable "github_installation_id" {
@@ -49,4 +50,10 @@ variable "github_example_repository" {
   type        = string
   default     = null
   description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
+}
+
+variable "todo_step" {
+  type        = number
+  description = "of all todos, where does this one logically fall in sequence"
+  default     = 1
 }

--- a/tools/release/sync-examples.sh
+++ b/tools/release/sync-examples.sh
@@ -26,7 +26,7 @@ fi
 
 SOURCE_OF_TRUTH="aws-all"
 REPLICAS=("gcp")
-FILES_TO_COPY=("google-workspace.tf" "google-workspace-variables.tf")
+FILES_TO_COPY=("google-workspace.tf" "google-workspace-variables.tf" "misc-data-source-variables.tf")
 
 for replica in "${REPLICAS[@]}"
 do


### PR DESCRIPTION
### Features
 - source variable naming, use source as prefix to more clearly group
 - split source variables into own file, re-use across aws-all / gcp examples


### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205054651201385