### PR TITLE
fix URL_SAFE_TOKEN format for bulk case

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
@@ -1,5 +1,6 @@
 package co.worklytics.psoxy;
 
+import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
@@ -66,4 +67,15 @@ public class PseudonymizedIdentity {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String reversible;
+
+    public Pseudonym asPseudonym() {
+
+        //q: what to do w original, if anything?
+
+        return Pseudonym.builder()
+            .hash(hash == null ? null : hash.getBytes())
+            .domain(domain)
+            .reversible(reversible == null ? null : reversible.getBytes())
+            .build();
+    }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
@@ -18,6 +18,7 @@ import org.hazlewood.connor.bottema.emailaddress.EmailAddressParser;
 import org.hazlewood.connor.bottema.emailaddress.EmailAddressValidator;
 
 import javax.inject.Inject;
+import java.util.Base64;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -34,6 +35,8 @@ public class PseudonymizerImpl implements Pseudonymizer {
     DeterministicTokenizationStrategy deterministicTokenizationStrategy;
     @Inject
     UrlSafeTokenPseudonymEncoder urlSafePseudonymEncoder;
+
+    Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
 
     @Getter
     ConfigurationOptions options;
@@ -98,12 +101,7 @@ public class PseudonymizerImpl implements Pseudonymizer {
             builder.hash(hashUtils.hash(canonicalization.apply(value.toString()),
                 getOptions().getPseudonymizationSalt(), asLegacyScope(scope)));
         } else if (getOptions().getPseudonymImplementation() == PseudonymImplementation.DEFAULT) {
-
-            builder.hash(urlSafePseudonymEncoder.encode(
-                Pseudonym.builder()
-                    .hash(deterministicTokenizationStrategy.getToken(value.toString(), canonicalization))
-                    .build()));
-
+            builder.hash(encoder.encodeToString(deterministicTokenizationStrategy.getToken(value.toString(), canonicalization)));
         } else {
             throw new RuntimeException("Unsupported pseudonym implementation: " + getOptions().getPseudonymImplementation());
         }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -4,6 +4,7 @@ import co.worklytics.psoxy.PseudonymizedIdentity;
 import co.worklytics.psoxy.Pseudonymizer;
 import co.worklytics.psoxy.rules.CsvRules;
 import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
+import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.BulkDataRules;
 import com.avaulta.gateway.rules.ColumnarRules;
 import co.worklytics.psoxy.storage.BulkDataSanitizer;
@@ -28,9 +29,7 @@ import javax.inject.Singleton;
 import java.io.*;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collector;
 import java.io.ByteArrayOutputStream;
 
 import java.util.stream.Collectors;
@@ -48,6 +47,9 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
 
     @Inject
     ObjectMapper objectMapper;
+
+    @Inject
+    UrlSafeTokenPseudonymEncoder urlSafeTokenPseudonymEncoder;
 
     @Getter(AccessLevel.PRIVATE)
     @Setter(onMethod_ = @VisibleForTesting)
@@ -146,7 +148,7 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
                         if (identity == null) {
                             return null;
                         } else if (rules.getPseudonymFormat() == PseudonymEncoder.Implementations.URL_SAFE_TOKEN) {
-                            return identity.getHash();
+                            return urlSafeTokenPseudonymEncoder.encode(identity.asPseudonym());
                         } else {
                             //JSON
                             return objectMapper.writeValueAsString(identity);

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -148,6 +148,10 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
                         if (identity == null) {
                             return null;
                         } else if (rules.getPseudonymFormat() == PseudonymEncoder.Implementations.URL_SAFE_TOKEN) {
+                            if (identity.getOriginal() != null) {
+                                //this shouldn't happen, bc ColumnarRules don't support preserving original
+                                log.warning("Encoding pseudonym for column '" + outputColumnName + "' using format that will not include the 'original' value, althought transformation preserved it");
+                            }
                             return urlSafeTokenPseudonymEncoder.encode(identity.asPseudonym());
                         } else {
                             //JSON

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -228,10 +228,10 @@ public class BulkDataSanitizerImplTest {
     void handle_duplicates() {
         //this is a lookup-table use case (for customers to use in own data warehouse)
         final String EXPECTED = "EMPLOYEE_ID,DEPARTMENT,EMPLOYEE_ID_ORIG\r\n" +
-            "SappwO4KZKGprqqUNruNreBD2BVR98nEM6NRCu3R2dM,Engineering,1\r\n" +
-            "mfsaNYuCX__xvnRz4gJp_t0zrDTC5DkuCJvMkubugsI,Sales,2\r\n" +
-            ".ZdDGUuOMK.Oy7_PJ3pf9SYX12.3tKPdLHfYbjVGcGk,Engineering,3\r\n" +
-            ".fs1T64Micz8SkbILrABgEv4kSg.tFhvhP35HGSLdOo,Engineering,4\r\n";
+            "t~U2FwcHdPNEtaS0dwcnFxVU5ydU5yZUJEMkJWUjk4bkVNNk5SQ3UzUjJkTQ,Engineering,1\r\n" +
+            "t~bWZzYU5ZdUNYX194dm5SejRnSnBfdDB6ckRUQzVEa3VDSnZNa3VidWdzSQ,Sales,2\r\n" +
+            "t~LlpkREdVdU9NSy5PeTdfUEozcGY5U1lYMTIuM3RLUGRMSGZZYmpWR2NHaw,Engineering,3\r\n" +
+            "t~LmZzMVQ2NE1pY3o4U2tiSUxyQUJnRXY0a1NnLnRGaHZoUDM1SEdTTGRPbw,Engineering,4\r\n";
 
         CsvRules rules = CsvRules.builder()
             .pseudonymFormat(PseudonymEncoder.Implementations.URL_SAFE_TOKEN)

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
@@ -81,7 +81,7 @@ public class UrlSafeTokenPseudonymEncoderTest {
 
     @Test
     void noReverse() {
-        String expected = "nVPSMYD7ZO_ptGIMJ65TAFo5_vVVQQ2af5Bfg7bW0Jo";
+        String expected = "t~nVPSMYD7ZO_ptGIMJ65TAFo5_vVVQQ2af5Bfg7bW0Jo";
         String original = "blah";
         Pseudonym pseudonym = Pseudonym.builder()
             .hash(deterministicTokenizationStrategy.getToken(original, Function.identity()))
@@ -107,6 +107,6 @@ public class UrlSafeTokenPseudonymEncoderTest {
             .build();
 
         String encoded = pseudonymEncoder.encode(pseudonym);
-        assertEquals("UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk@acme.com", encoded);
+        assertEquals("t~UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk@acme.com", encoded);
     }
 }


### PR DESCRIPTION
### Fixes
 - `URL_SAFE_TOKEN` format for bulk case doesn't behave as expected



### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something to note in `CHANGELOG.md`? 
    - use of `URL_SAFE_TOKEN` format for `pseudonymize` transforms in REST rules w/o `includeReversible`, will result in backwards-incompatible format. (this is not a case we believe anyone using in practice; the default rules don't do it, so even those people who have customized it would have had to explicitly change format for some reason)