### PR TITLE
sha256 encoder

### DIFF
--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoder.java
@@ -1,0 +1,43 @@
+package com.avaulta.gateway.pseudonyms.impl;
+
+import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * implementation of defacto encoding used by BulkDataSanitizerImpl as of v0.4.30
+ */
+public class Sha256PseudonymEncoder implements PseudonymEncoder {
+
+
+    @Override
+    public String encode(Pseudonym pseudonym) {
+        return base64Encode(pseudonym.getHash());
+    }
+
+    @Override
+    public Pseudonym decode(String input) {
+        return Pseudonym.builder()
+            .hash(input.getBytes(StandardCharsets.UTF_8))
+            .build();
+    }
+
+    @Override
+    public boolean canBeDecoded(String possiblePseudonym) {
+        return possiblePseudonym != null &&
+            possiblePseudonym.getBytes(StandardCharsets.UTF_8).length == 43; //43 rather than 32, bc of base64 encoding
+    }
+
+    //base64 encoding, to match implementation in HashUtils.java from psoxy-core v0.4.30
+    String base64Encode(byte[] bytes) {
+        String encoded = new String(
+            Base64.getEncoder()
+                .withoutPadding()
+                .encode(bytes),
+            StandardCharsets.UTF_8);
+        return StringUtils.replaceChars(encoded, "/+", "_.");
+    }
+}

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoder.java
@@ -28,7 +28,7 @@ public class Sha256PseudonymEncoder implements PseudonymEncoder {
     @Override
     public boolean canBeDecoded(String possiblePseudonym) {
         return possiblePseudonym != null &&
-            possiblePseudonym.getBytes(StandardCharsets.UTF_8).length == 43; //43 rather than 32, bc of base64 encoding
+            possiblePseudonym.getBytes(StandardCharsets.UTF_8).length == 43; //43 rather than 32, bc of base64 encoding without padding
     }
 
     //base64 encoding, to match implementation in HashUtils.java from psoxy-core v0.4.30

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoder.java
@@ -20,9 +20,11 @@ public class Sha256PseudonymEncoder implements PseudonymEncoder {
 
     @Override
     public Pseudonym decode(String input) {
-        return Pseudonym.builder()
-            .hash(input.getBytes(StandardCharsets.UTF_8))
-            .build();
+        if (!canBeDecoded(input)) {
+            throw new IllegalArgumentException("input cannot be decoded");
+        }
+
+        return Pseudonym.builder().hash(base64decode(input)).build();
     }
 
     @Override
@@ -39,5 +41,10 @@ public class Sha256PseudonymEncoder implements PseudonymEncoder {
                 .encode(bytes),
             StandardCharsets.UTF_8);
         return StringUtils.replaceChars(encoded, "/+", "_.");
+    }
+
+    byte[] base64decode(String input) {
+        return Base64.getDecoder()
+                .decode(StringUtils.replaceChars(input, "_.", "/+"));
     }
 }

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoderTest.java
@@ -1,0 +1,65 @@
+package com.avaulta.gateway.pseudonyms.impl;
+
+import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
+import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Random;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Sha256PseudonymEncoderTest {
+
+    Sha256PseudonymEncoder encoder = new Sha256PseudonymEncoder();
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        // examples taken from https://github.com/Worklytics/psoxy/blob/b483e3788d5457398d55cad7934de959b74c7900/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java#L228-L239
+        "SappwO4KZKGprqqUNruNreBD2BVR98nEM6NRCu3R2dM",
+        "mfsaNYuCX__xvnRz4gJp_t0zrDTC5DkuCJvMkubugsI",
+        ".ZdDGUuOMK.Oy7_PJ3pf9SYX12.3tKPdLHfYbjVGcGk",
+        ".fs1T64Micz8SkbILrABgEv4kSg.tFhvhP35HGSLdOo"
+    })
+    void canBeDecoded(String encoded) {
+        assertTrue(encoder.canBeDecoded(encoded));
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "asdfasdf",
+        "1343287afdaskdljf4324sasdfa",
+    })
+    void cannotBeDecoded(String encoded) {
+        assertFalse(encoder.canBeDecoded(encoded));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "asdfasdf",
+        "1343287afdaskdljf4324sasdfa",
+        "asdf1234234",
+        "alice@acme.com"
+    })
+    void roundtrip(String identifier) {
+        Sha256DeterministicTokenizationStrategy sha256DeterministicTokenizationStrategy =
+            new Sha256DeterministicTokenizationStrategy("salt");
+
+        Pseudonym pseudonym = Pseudonym.builder()
+            .hash(sha256DeterministicTokenizationStrategy.getToken(identifier, Function.identity()))
+            .build();
+
+        String encoded = encoder.encode(pseudonym);
+
+        assertTrue(encoder.canBeDecoded(encoded));
+        assertEquals(encoder.base64Encode(pseudonym.getHash()), // arguably too much of a tautology
+            new String(encoder.decode(encoded).getHash()));
+
+    }
+}

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/Sha256PseudonymEncoderTest.java
@@ -58,7 +58,7 @@ class Sha256PseudonymEncoderTest {
         String encoded = encoder.encode(pseudonym);
 
         assertTrue(encoder.canBeDecoded(encoded));
-        assertEquals(encoder.base64Encode(pseudonym.getHash()), // arguably too much of a tautology
+        assertEquals(new String(pseudonym.getHash()),
             new String(encoder.decode(encoded).getHash()));
 
     }


### PR DESCRIPTION
### Features
 - a Sha256 encoder, implementing defacto encoding done by proxy in bulk mode when format set to `URL_SAFE_TOKEN`

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
