### PR TITLE
S154 update salesforce doc

### DIFF
--- a/docs/sources/salesforce.md
+++ b/docs/sources/salesforce.md
@@ -26,9 +26,13 @@
           - API Enabled
           - APEX REST Services
       - And the policy has the application created marked as enabled in "Connected App Access". Otherwise requests will return 401 with INVALID_SESSION_ID
-  2. Once created, open "Manage Consumer Details"
-  3. Update the content of `PSOXY_SALESFORCE_CLIENT_ID` from Consumer Key and `PSOXY_SALESFORCE_CLIENT_SECRET` from Consumer Secret
+
+    The user set up as "run as" on the connector should have between `Permission Sets` and `Profile` the permission of `View All Data`. This is due the kind of queries supported
+    for retrieving [Activity Histories](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_activityhistory.htm) based on the
+    related *account id*.
+
+   2. Once created, open "Manage Consumer Details"
+   3. Update the content of `PSOXY_SALESFORCE_CLIENT_ID` from Consumer Key	and `PSOXY_SALESFORCE_CLIENT_SECRET` from Consumer Secret
+   4. Finally, we recommend to run `test-salesforce` script with all the queries in the example to ensure the expected information covered by rules can be obtained from Salesforce API.
 
 NOTE: derived from [worklytics-connector-specs](../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.
-
-

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -34,14 +34,14 @@ module "worklytics_connectors" {
   source = "../../modules/worklytics-connectors"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=v0.4.32"
 
-  enabled_connectors        = var.enabled_connectors
-  jira_cloud_id             = var.jira_cloud_id
-  jira_server_url           = var.jira_server_url
-  jira_example_issue_id     = var.jira_example_issue_id
-  salesforce_domain         = var.salesforce_domain
-  github_installation_id    = var.github_installation_id
-  github_organization       = var.github_organization
-  github_example_repository = var.github_example_repository
+  enabled_connectors            = var.enabled_connectors
+  jira_cloud_id                 = var.jira_cloud_id
+  jira_server_url               = var.jira_server_url
+  jira_example_issue_id         = var.jira_example_issue_id
+  salesforce_domain             = var.salesforce_domain
+  github_installation_id        = var.github_installation_id
+  github_organization           = var.github_organization
+  github_example_repository     = var.github_example_repository
   salesforce_example_account_id = var.salesforce_example_account_id
 }
 

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -42,6 +42,7 @@ module "worklytics_connectors" {
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization
   github_example_repository = var.github_example_repository
+  salesforce_example_account_id = var.salesforce_example_account_id
 }
 
 # sources which require additional dependencies are split into distinct Terraform files, following

--- a/infra/examples-dev/aws-all/misc-data-source-variables.tf
+++ b/infra/examples-dev/aws-all/misc-data-source-variables.tf
@@ -43,3 +43,9 @@ variable "github_example_repository" {
   default     = null
   description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
 }
+
+variable "salesforce_example_account_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Salesforce connector) Id of the account id for usign as an example calls for Salesforce (ex: 0015Y00002c7g95QAA)"
+}

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -51,6 +51,7 @@ module "worklytics_connectors" {
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization
   github_example_repository = var.github_example_repository
+  salesforce_example_account_id = var.salesforce_example_account_id
 }
 
 # sources which require additional dependencies are split into distinct Terraform files, following

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -43,14 +43,14 @@ module "worklytics_connectors" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=v0.4.32"
 
 
-  enabled_connectors        = var.enabled_connectors
-  jira_cloud_id             = var.jira_cloud_id
-  jira_server_url           = var.jira_server_url
-  jira_example_issue_id     = var.jira_example_issue_id
-  salesforce_domain         = var.salesforce_domain
-  github_installation_id    = var.github_installation_id
-  github_organization       = var.github_organization
-  github_example_repository = var.github_example_repository
+  enabled_connectors            = var.enabled_connectors
+  jira_cloud_id                 = var.jira_cloud_id
+  jira_server_url               = var.jira_server_url
+  jira_example_issue_id         = var.jira_example_issue_id
+  salesforce_domain             = var.salesforce_domain
+  github_installation_id        = var.github_installation_id
+  github_organization           = var.github_organization
+  github_example_repository     = var.github_example_repository
   salesforce_example_account_id = var.salesforce_example_account_id
 }
 

--- a/infra/examples-dev/gcp/misc-data-source-variables.tf
+++ b/infra/examples-dev/gcp/misc-data-source-variables.tf
@@ -43,3 +43,9 @@ variable "github_example_repository" {
   default     = null
   description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
 }
+
+variable "salesforce_example_account_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Salesforce connector) Id of the account id for usign as an example calls for Salesforce (ex: 0015Y00002c7g95QAA)"
+}

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -57,8 +57,8 @@ locals {
   }
 
   writable_secrets = flatten([
-  for instance_id, secrets in local.secrets_to_provision :
-  [for secret_id, secret in values(secrets) : secret if secret.lockable || secret.writable]
+    for instance_id, secrets in local.secrets_to_provision :
+    [for secret_id, secret in values(secrets) : secret if secret.lockable || secret.writable]
   ])
 }
 
@@ -143,7 +143,7 @@ module "api_connector" {
 
   secret_bindings = merge(
     # bc some of these are later filled directly, bind to 'latest'
-   {for k, secrets in local.secrets_to_provision[each.key] : k => merge({ secret_id : module.secrets[each.key].secret_ids_within_project[k], version_number : "latest" }) if (try(!secrets.lockable, true) && try(!secrets.writable, true))},
+    { for k, secrets in local.secrets_to_provision[each.key] : k => merge({ secret_id : module.secrets[each.key].secret_ids_within_project[k], version_number : "latest" }) if(try(!secrets.lockable, true) && try(!secrets.writable, true)) },
     module.psoxy.secrets
   )
 }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -445,8 +445,14 @@ EOT
         - API Enabled
         - APEX REST Services
       - And the policy has the application created marked as enabled in "Connected App Access". Otherwise requests will return 401 with INVALID_SESSION_ID
+
+  The user set up as "run as" on the connector should have between `Permission Sets` and `Profile` the permission of `View All Data`. This is due the kind of queries supported
+  for retrieving [Activity Histories](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_activityhistory.htm) based on the
+  related *account id*.
+
   2. Once created, open "Manage Consumer Details"
   3. Update the content of `PSOXY_SALESFORCE_CLIENT_ID` from Consumer Key	and `PSOXY_SALESFORCE_CLIENT_SECRET` from Consumer Secret
+  4. Finally, we recommend to run `test-salesforce` script with all the queries in the example to ensure the expected information covered by rules can be obtained from Salesforce API.
 EOT
     }
     slack-discovery-api = {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -146,6 +146,7 @@ locals {
   github_installation_id    = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
   github_organization       = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
   github_example_repository = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
+  salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 
   # Microsoft 365 sources; add/remove as you wish
   # See https://docs.microsoft.com/en-us/graph/permissions-reference for all the permissions available in AAD Graph API
@@ -421,7 +422,7 @@ EOT
         "/services/data/v57.0/sobjects/Account/updated?start=2016-03-09T18%3A44%3A00%2B00%3A00&end=2023-03-09T18%3A44%3A00%2B00%3A00",
         "/services/data/v57.0/composite/sobjects/User?ids={ANY_USER_ID}&fields=Alias,AccountId,ContactId,CreatedDate,CreatedById,Email,EmailEncodingKey,Id,IsActive,LastLoginDate,LastModifiedDate,ManagerId,Name,TimeZoneSidKey,Username,UserRoleId,UserType",
         "/services/data/v57.0/composite/sobjects/Account?ids={ANY_ACCOUNT_ID}&fields=Id,AnnualRevenue,CreatedDate,CreatedById,IsDeleted,LastActivityDate,LastModifiedDate,LastModifiedById,NumberOfEmployees,OwnerId,Ownership,ParentId,Rating,Sic,Type",
-        "/services/data/v57.0/query?q=SELECT%20%28SELECT%20AccountId%2CActivityDate%2CActivityDateTime%2CActivitySubtype%2CActivityType%2CCallDurationInSeconds%2CCallType%2CCreatedDate%2CCreatedById%2CDurationInMinutes%2CEndDateTime%2CId%2CIsAllDayEvent%2CIsDeleted%2CIsHighPriority%2CIsTask%2CLastModifiedDate%2CLastModifiedById%2COwnerId%2CPriority%2CStartDateTime%2CStatus%2CWhatId%2CWhoId%20FROM%20ActivityHistories%20ORDER%20BY%20LastModifiedDate%20DESC%20NULLS%20LAST%29%20FROM%20Account%20where%20id%3D%27{ANY_ACCOUNT_ID}%27",
+        "/services/data/v57.0/query?q=SELECT%20%28SELECT%20AccountId%2CActivityDate%2CActivityDateTime%2CActivitySubtype%2CActivityType%2CCallDurationInSeconds%2CCallType%2CCreatedDate%2CCreatedById%2CDurationInMinutes%2CEndDateTime%2CId%2CIsAllDayEvent%2CIsDeleted%2CIsHighPriority%2CIsTask%2CLastModifiedDate%2CLastModifiedById%2COwnerId%2CPriority%2CStartDateTime%2CStatus%2CWhatId%2CWhoId%20FROM%20ActivityHistories%20ORDER%20BY%20LastModifiedDate%20DESC%20NULLS%20LAST%29%20FROM%20Account%20where%20id%3D%27${local.salesforce_example_account_id}%27",
         "/services/data/v57.0/query?q=SELECT+Alias,AccountId,ContactId,CreatedDate,CreatedById,Email,EmailEncodingKey,Id,IsActive,LastLoginDate,LastModifiedDate,ManagerId,Name,TimeZoneSidKey,Username,UserRoleId,UserType+FROM+User+WHERE+LastModifiedDate+%3E%3D+2016-01-01T00%3A00%3A00Z+AND+LastModifiedDate+%3C+2023-03-01T00%3A00%3A00Z+ORDER+BY+LastModifiedDate+DESC+NULLS+LAST",
         "/services/data/v57.0/query?q=SELECT+Id,AnnualRevenue,CreatedDate,CreatedById,IsDeleted,LastActivityDate,LastModifiedDate,LastModifiedById,NumberOfEmployees,OwnerId,Ownership,ParentId,Rating,Sic,Type+FROM+Account+WHERE+LastModifiedDate+%3E%3D+2016-01-01T00%3A00%3A00Z+AND+LastModifiedDate+%3C+2023-03-01T00%3A00%3A00Z+ORDER+BY+LastModifiedDate+DESC+NULLS+LAST"
       ]

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -141,11 +141,11 @@ locals {
   }
 
 
-  jira_cloud_id             = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
-  jira_example_issue_id     = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
-  github_installation_id    = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
-  github_organization       = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
-  github_example_repository = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
+  jira_cloud_id                 = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
+  jira_example_issue_id         = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
+  github_installation_id        = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
+  github_organization           = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
+  github_example_repository     = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
   salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 
   # Microsoft 365 sources; add/remove as you wish

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -76,3 +76,9 @@ variable "github_example_repository" {
   default     = null
   description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
 }
+
+variable "salesforce_example_account_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Salesforce connector) Id of the account id for usign as an example calls for Salesforce (ex: 0015Y00002c7g95QAA)"
+}

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -2,15 +2,15 @@
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
 
-  enabled_connectors        = var.enabled_connectors
-  jira_cloud_id             = var.jira_cloud_id
-  jira_server_url           = var.jira_server_url
-  salesforce_domain         = var.salesforce_domain
-  example_jira_issue_id     = var.example_jira_issue_id
-  jira_example_issue_id     = var.jira_example_issue_id
-  github_installation_id    = var.github_installation_id
-  github_organization       = var.github_organization
-  github_example_repository = var.github_example_repository
+  enabled_connectors            = var.enabled_connectors
+  jira_cloud_id                 = var.jira_cloud_id
+  jira_server_url               = var.jira_server_url
+  salesforce_domain             = var.salesforce_domain
+  example_jira_issue_id         = var.example_jira_issue_id
+  jira_example_issue_id         = var.jira_example_issue_id
+  github_installation_id        = var.github_installation_id
+  github_organization           = var.github_organization
+  github_example_repository     = var.github_example_repository
   salesforce_example_account_id = var.salesforce_example_account_id
 }
 

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -11,6 +11,7 @@ module "worklytics_connector_specs" {
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization
   github_example_repository = var.github_example_repository
+  salesforce_example_account_id = var.salesforce_example_account_id
 }
 
 

--- a/infra/modules/worklytics-connectors/variables.tf
+++ b/infra/modules/worklytics-connectors/variables.tf
@@ -52,6 +52,12 @@ variable "github_example_repository" {
   description = "(Only required if using Github connector) Name for the repository to be used as part of example calls for Github (ex: psoxy)"
 }
 
+variable "salesforce_example_account_id" {
+  type        = string
+  default     = null
+  description = "(Only required if using Salesforce connector) Id of the account id for usign as an example calls for Salesforce (ex: 0015Y00002c7g95QAA)"
+}
+
 variable "todo_step" {
   type        = number
   description = "of all todos, where does this one logically fall in sequence"


### PR DESCRIPTION
- Salesforce doc update, to reflect the kind of permission the user associated to the connector should have.
- Parameterized the example account id to use on example calls.

### Features
[Update Salesforce documentation](https://app.asana.com/0/0/1205171386098581)

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? 
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
