### PR TITLE
gcp secret binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Working tracking of changes, updated as work done prior to release.  Please revi
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.33](https://github.com/Worklytics/psoxy/release/tag/v0.4.33)
+Changes:
+ * GCP only: secrets that are managed outside of Terraform will no longer be bound as part of the
+   cloud function's environment variables. You will see env changes in some cases, as well as 'moves'
+   of the associated IAM grants to make those secrets accessible to the cloud function, as this moves
+   up one level in module hierarchy
+
 ## [0.4.31](https://github.com/Worklytics/psoxy/release/tag/v0.4.31)
 
 Changes:

--- a/infra/modules/gcp-host/migration_0_4_33.tf
+++ b/infra/modules/gcp-host/migration_0_4_33.tf
@@ -1,0 +1,75 @@
+# Asana
+moved {
+  from = module.api_connector["asana"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["ACCESS_TOKEN"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["ASANA_ACCESS_TOKEN"]
+}
+
+
+# Dropbox - no known deployments
+
+# Github
+
+moved {
+  from = module.api_connector["github"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_ID"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["GITHUB_CLIENT_ID"]
+}
+
+moved {
+  from = module.api_connector["github"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["PRIVATE_KEY"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["GITHUB_PRIVATE_KEY"]
+}
+
+# Jira Cloud
+moved {
+  from = module.api_connector["jira-cloud"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_ID"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["JIRA_CLOUD_CLIENT_ID"]
+}
+
+moved {
+  from = module.api_connector["jira-cloud"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_SECRET"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["JIRA_CLOUD_CLIENT_SECRET"]
+}
+
+# Jira Server
+moved {
+  from = module.api_connector["jira-server"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["ACCESS_TOKEN"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["JIRA_SERVER_ACCESS_TOKEN"]
+}
+
+# Salesforce
+moved {
+  from = module.api_connector["salesforce"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_ID"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["SALESFORCE_CLIENT_ID"]
+}
+
+moved {
+  from = module.api_connector["salesforce"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_SECRET"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["SALESFORCE_CLIENT_SECRET"]
+}
+
+
+
+# Slack
+
+moved {
+  from = module.api_connector["slack-discovery-api"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["ACCESS_TOKEN"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["SLACK_DISCOVERY_API_ACCESS_TOKEN"]
+}
+
+# Zoom
+moved {
+  from = module.api_connector["zoom"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_ID"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["ZOOM_CLIENT_ID"]
+}
+
+moved {
+  from = module.api_connector["zoom"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["CLIENT_SECRET"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["ZOOM_CLIENT_SECRET"]
+}
+
+moved {
+  from = module.api_connector["zoom"].google_secret_manager_secret_iam_member.grant_sa_accessor_on_secret["ACCOUNT_ID"]
+  to   = google_secret_manager_secret_iam_member.grant_sa_secretAccessor_on_non_tf_secret["ZOOM_ACCOUNT_ID"]
+}
+
+


### PR DESCRIPTION
### Fixes
  - GCP functions don't start if Secrets bound as env vars aren't filled; rather than filling with fake values, better to just not bind as env vars

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **yes; plans will show changes**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205236328844248