### PR TITLE
set aws param type based on sensitive/not

### DIFF
--- a/infra/modules/aws-ssm-secrets/main.tf
+++ b/infra/modules/aws-ssm-secrets/main.tf
@@ -20,7 +20,7 @@ resource "aws_ssm_parameter" "secret" {
   for_each = local.terraform_managed_secrets
 
   name           = "${local.path_prefix}${each.key}"
-  type           = "SecureString"
+  type           = each.value.sensitive ? "SecureString"  : "String"
   description    = each.value.description
   value          = each.value.sensitive ? sensitive(coalesce(each.value.value, local.PLACEHOLDER_VALUE)) : null
   insecure_value = each.value.sensitive ? null : coalesce(each.value.value, local.PLACEHOLDER_VALUE)


### PR DESCRIPTION
### Fixes
 - AWS blocks SSMs of type 'SecureString' with `insecure_value` attribute

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **yes**
