### PR TITLE
fix gcp secret access

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 @Log
 public class CommonRequestHandler {
 
-    //we have ~540 totalyes in Cloud Function connection, so can have generous values here
+    //we have ~540 total in Cloud Function connection, so can have generous values here
     private static final int SOURCE_API_REQUEST_CONNECT_TIMEOUT_MILLISECONDS = 30_000;
     private static final int SOURCE_API_REQUEST_READ_TIMEOUT = 300_000;
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 @Log
 public class CommonRequestHandler {
 
-    //we have ~540 total in Cloud Function connection, so can have generous values here
+    //we have ~540 totalyes in Cloud Function connection, so can have generous values here
     private static final int SOURCE_API_REQUEST_CONNECT_TIMEOUT_MILLISECONDS = 30_000;
     private static final int SOURCE_API_REQUEST_READ_TIMEOUT = 300_000;
 

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
@@ -25,8 +25,9 @@ public class Route implements HttpFunction {
 
         CloudFunctionRequest cloudFunctionRequest = CloudFunctionRequest.of(request);
 
-        //TODO: avoid rebuild graph everytime
-        DaggerGcpContainer.create().injectRoute(this);
+        if (requestHandler == null) {
+            DaggerGcpContainer.create().injectRoute(this);
+        }
 
         HttpEventResponse abstractResponse =
                 requestHandler.handle(cloudFunctionRequest);


### PR DESCRIPTION
### Fixes
  - not binding GCP secrets as env vars (#472), that are read-only so IAM role is `SecretAccessor` fail - bc of attempt to read `Secret` itself, which that role doesn't permit, before actual read of the version

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**