### PR TITLE
AWS fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Working tracking of changes, updated as work done prior to release.  Please revi
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.34](https://github.com/Worklytics/psoxy/release/tag/v0.4.34)
+  * AWS Only: you may see System Manager Parameter description changes; these have no functional
+    purpose, just helping provide guidance on function of different secrets.
+
 ## [0.4.33](https://github.com/Worklytics/psoxy/release/tag/v0.4.33)
 Changes that may appear in Terraform plans:
  * GCP only: secrets that are managed outside of Terraform will no longer be bound as part of the

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -217,9 +217,10 @@ variable "custom_bulk_connector_arguments" {
   type = map(object({
     memory_size_mb = optional(number)
   }))
+
+  description = "map of connector id --> arguments object"
+  default     = {}
 }
-
-
 
 variable "lookup_table_builders" {
   type = map(object({

--- a/infra/modules/gcp-secrets/main.tf
+++ b/infra/modules/gcp-secrets/main.tf
@@ -15,7 +15,15 @@ resource "google_secret_manager_secret" "secret" {
 
   project   = var.secret_project
   secret_id = "${var.path_prefix}${each.key}"
-  labels    = var.default_labels
+  labels    = merge(
+    var.default_labels,
+    {
+      terraform_managed_value = each.value.value_managed_by_tf
+    }
+  )
+
+  # TODO: put each.value.description somewhere; shouldn't be a 'label'; annotations not yet supprted
+  # by google terraform provider
 
   replication {
     user_managed {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -545,24 +545,28 @@ EOT
           writable : false
           sensitive : true
           value_managed_by_tf : false
+          description: "Client Secret of the Zoom 'Server-to-Server' OAuth App used by the Connector to retrieve Zoom data.  Value should be obtained from your Zoom admin."
         },
         {
           name : "CLIENT_ID"
           writable : false
           sensitive : false
           value_managed_by_tf : false
+          description: "Client ID of the Zoom 'Server-to-Server' OAuth App used by the Connector to retrieve Zoom data. Value should be obtained from your Zoom admin."
         },
         {
           name : "ACCOUNT_ID"
           writable : false
           sensitive : true
           value_managed_by_tf : false
+          description: "Account ID of the Zoom tenant from which the Connector will retrieve Zoom data. Value should be obtained from your Zoom admin."
         },
         {
           name : "ACCESS_TOKEN"
           writable : true
           sensitive : true
           value_managed_by_tf : false
+          description: "Short-lived Oauth access_token used by connector to retrieve Zoom data. Filled by Proxy instance."
         },
         {
           name : "OAUTH_REFRESH_TOKEN"

--- a/infra/modules/worklytics-connectors-google-workspace/main.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/main.tf
@@ -54,9 +54,11 @@ locals {
         try([v.secured_variables], []),
         [
           {
-            name     = "SERVICE_ACCOUNT_KEY"
-            value    = module.google_workspace_connection_auth[k].key_value
-            writable = false
+            name                = "SERVICE_ACCOUNT_KEY"
+            value               = module.google_workspace_connection_auth[k].key_value
+            writable            = false
+            sensitive           = true
+            value_managed_by_tf = true
           }
         ]
       )

--- a/infra/modules/worklytics-connectors-google-workspace/main.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/main.tf
@@ -59,6 +59,7 @@ locals {
             writable            = false
             sensitive           = true
             value_managed_by_tf = true
+            description         = "The API key for the GCP Service Account that is the OAuth Client for accessing the Google Workspace APIs used by the ${k} connector."
           }
         ]
       )


### PR DESCRIPTION
### Fixes
  - missing default value for `aws-host` module, which breaks upgrading old examples to `v0.4.33`

### Features
  - improve parameter descriptions for AWS
  - label GCP secrets if managed by Terrafrom or not
  - add descriptions of more parameters

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **yes; will see changes in plans**