### PR TITLE
ssm param placeholder check

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -425,11 +425,14 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                 if (jsonToken.isEmpty()) {
                     return Optional.empty();
                 } else {
+                    byte[] value = jsonToken.get().getBytes(StandardCharsets.UTF_8);
                     try {
-                        AccessTokenDto accessTokenDto = objectMapper.readerFor(AccessTokenDto.class).readValue(jsonToken.get().getBytes(StandardCharsets.UTF_8));
+                        AccessTokenDto accessTokenDto = objectMapper.readerFor(AccessTokenDto.class).readValue(value);
                         return Optional.ofNullable(accessTokenDto).map(AccessTokenDto::asAccessToken);
                     } catch (IOException e) {
-                        log.log(Level.SEVERE, "Could not parse contents of token into an object", e);
+                        //NOTE: not logging 'e' itself, as sometimes includes value, so if value
+                        // really is a proper token then we don't want it in the logs
+                        log.log(Level.WARNING, "Could not parse contents of token into an AccessToken object; possibly expected initially, if config has a placeholder value for token");
                         return Optional.empty();
                     }
                 }


### PR DESCRIPTION
### Features
 - SSM params can't have `null` values or something similar; so we fill them with placeholders initially. This is an implementation detail that application code shouldn't know about, so hide this behind `ParameterStoreConfigService` so look the same as if not filled.

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**