### PR TITLE
add warnings about uncompressed responses

### DIFF
--- a/docs/development/compression.md
+++ b/docs/development/compression.md
@@ -1,0 +1,48 @@
+# HTTP Compression
+
+## Overview
+
+Given nature of use-case, proxy does A LOT of network transit:
+  * client to proxy (request)
+  * proxy to data source (request)
+  * data source to proxy (response)
+  * proxy to client (response)
+
+So this drives cost in several ways:
+   - larger network payloads increases proxy running time, which is billable
+   - network volume itself is billable in some host platforms
+   - indirectly, clients are waiting for proxy to respond, so that's an indirect cost (paid on client-side)
+
+Generally, proxy is transferring JSON data, which is highly compressible. Using `gzip` likely to
+reduce network volume by 50-80%. So we want to make sure we do this everywhere.
+
+
+## Proxy-to-Client Response
+
+### AWS
+
+#### Function Urls
+
+Compression must be managed at the application layer (eg, in our proxy code).
+
+This is done in `co.worklytics.psoxy.Handler`, which uses `ResponseCompressionHandler` to detect
+request for compressed response, and then compress the response.
+
+#### API Gateway
+
+API Gateway is no longer used by our default terraform examples. But compression can be enabled
+at the gateway level (rather than relying on function url implementation, or in addition to).
+
+https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gzip-compression-decompression.html
+
+### GCP
+
+GCP Cloud Functions will handle compression themselves IF the request meets various conditions.
+
+There is no explicit, Cloud Function-specific documentation about this, but it seems that the
+behavior for App Engine applies:
+
+https://cloud.google.com/appengine/docs/legacy/standard/go111/how-requests-are-handled#:~:text=For%20responses%20that%20are%20returned,HTML%2C%20CSS%2C%20or%20JavaScript.
+
+
+

--- a/java/core/src/main/java/co/worklytics/psoxy/ResponseHeader.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ResponseHeader.java
@@ -16,7 +16,9 @@ public enum ResponseHeader {
      *
      */
     RULES_SHA("Rules-SHA"),
-    ERROR("Error")
+    ERROR("Error"),
+
+    WARNING("Warning"),
     ;
 
     @NonNull

--- a/java/core/src/main/java/co/worklytics/psoxy/Warning.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/Warning.java
@@ -1,0 +1,15 @@
+package co.worklytics.psoxy;
+
+public enum Warning {
+
+    COMPRESSION_NOT_REQUESTED,
+    ;
+
+    public String asHttpHeaderCode() {
+        return this.name().toLowerCase().replace('_', '-');
+    }
+
+    public static Warning parseHttpHeaderCode(String headerCode) {
+        return Warning.valueOf(headerCode.toUpperCase().replace('-', '_'));
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -318,7 +318,7 @@ public class CommonRequestHandler {
 
     @SneakyThrows
     HttpRequestFactory getRequestFactory(HttpEventRequest request) {
-        // per connection request factory, abstracts auth ..
+        // per connection request factory, abstracts auth ...
         HttpTransport transport = new NetHttpTransport();
 
         //TODO: changing impl of credentials/initializer should support sources authenticated by

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/Handler.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/Handler.java
@@ -61,11 +61,12 @@ public class Handler implements com.amazonaws.services.lambda.runtime.RequestHan
             APIGatewayV2HTTPEventRequestAdapter httpEventRequestAdapter = new APIGatewayV2HTTPEventRequestAdapter(httpEvent);
             response = requestHandler.handle(httpEventRequestAdapter);
 
-            context.getLogger().log(httpEventRequestAdapter.getHeader(HttpHeaders.ACCEPT_ENCODING).orElse("accept-encoding not found"));
             if (ResponseCompressionHandler.isCompressionRequested(httpEventRequestAdapter)) {
                 Pair<Boolean, HttpEventResponse> compressedResponse = responseCompressionHandler.compressIfNeeded(response);
                 base64Encoded = compressedResponse.getLeft();
                 response = compressedResponse.getRight();
+            } else {
+                response.getHeaders().put(ResponseHeader.WARNING.getHttpHeader(), Warning.COMPRESSION_NOT_REQUESTED.asHttpHeaderCode());
             }
 
         } catch (Throwable e) {

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
@@ -1,7 +1,9 @@
 package co.worklytics.psoxy;
 
+import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.HttpEventResponse;
 import co.worklytics.psoxy.gateway.impl.CommonRequestHandler;
+import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -18,12 +20,18 @@ public class Route implements HttpFunction {
 
     @Inject
     CommonRequestHandler requestHandler;
+    @Inject
+    EnvVarsConfigService envVarsConfigService;
 
     @Override
     public void service(HttpRequest request, HttpResponse response)
             throws IOException {
 
         CloudFunctionRequest cloudFunctionRequest = CloudFunctionRequest.of(request);
+
+        if (envVarsConfigService.isDevelopment()) {
+            cloudFunctionRequest.getWarnings().forEach(log::warning);
+        }
 
         if (requestHandler == null) {
             DaggerGcpContainer.create().injectRoute(this);

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
@@ -9,6 +9,7 @@ import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
 
 import lombok.extern.java.Log;
+import org.apache.commons.lang3.RandomUtils;
 
 import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
@@ -29,8 +30,12 @@ public class Route implements HttpFunction {
 
         CloudFunctionRequest cloudFunctionRequest = CloudFunctionRequest.of(request);
 
-        if (envVarsConfigService.isDevelopment()) {
-            cloudFunctionRequest.getWarnings().forEach(log::warning);
+        try {
+            if (envVarsConfigService.isDevelopment()) {
+                cloudFunctionRequest.getWarnings().forEach(log::warning);
+            }
+        } catch (Throwable e) {
+            //suppress anything that went wrong here
         }
 
         if (requestHandler == null) {
@@ -42,6 +47,12 @@ public class Route implements HttpFunction {
 
         abstractResponse.getHeaders()
                 .forEach(response::appendHeader);
+
+        //sample 1% of requests, warning if compression not requested
+        if (RandomUtils.nextInt(0, 99) == 0 && !cloudFunctionRequest.getWarnings().isEmpty()) {
+            response.appendHeader(ResponseHeader.WARNING.getHttpHeader(),
+                Warning.COMPRESSION_NOT_REQUESTED.asHttpHeaderCode());
+        }
 
         response.setStatusCode(abstractResponse.getStatusCode());
 


### PR DESCRIPTION

### Features
 - log warnings if compressed content wasn't requested, and also set a response header back to client to warn that this isn't a good idea

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205274238696807
  - https://app.asana.com/0/0/1205274265612037