### PR TITLE
improve google workspace docs

### DIFF
--- a/docs/sources/google-workspace/google-workspace.md
+++ b/docs/sources/google-workspace/google-workspace.md
@@ -51,7 +51,7 @@ If you have already created a sufficiently privileged service account user for a
 Workspace connection, you can re-use that one.
 
 Assign the account a sufficiently privileged role. At minimum, the role must have the following
-privileges:
+privileges, *read-only*:
   * Admin API
   * Domain Settings
   * Groups
@@ -60,7 +60,7 @@ privileges:
   * Users
 
 See [Google's documentation](https://support.google.com/a/answer/1219251?fl=1&sjid=8026519161455224599-NA)
-detailed explanations of each of those privileges.
+for detailed explanations of each of those privileges.
 
 NOTE:
   - you may use a predefined role, or define a [Custom Role](https://support.google.com/a/answer/2406043?fl=1).
@@ -97,7 +97,9 @@ console:
 2. Activate relevant API(s) in the project.
 3. Create a Service Account and a JSON key for the service account.
 4. Base64-encode the key and store it as a Systems Manager Parameter in AWS (same region as your
-   lambda function deployed).  The parameter name should be something like `PSOXY_GDIRECTORY_SERVICE_ACCOUNT_KEY`.
+   lambda function deployed). The parameter name should be something like `PSOXY_GDIRECTORY_SERVICE_ACCOUNT_KEY`.
+   Ensure you do inadvertently add extra characters, including whitespace, when copying-pasting
+   the key value.
 5. Get the numeric ID of the service account. Use this plus the oauth scopes to make domain-wide
    delegation grants via the Google Workspace admin console.
 

--- a/infra/examples-dev/aws-all/google-workspace.tf
+++ b/infra/examples-dev/aws-all/google-workspace.tf
@@ -20,3 +20,8 @@ module "worklytics_connectors_google_workspace" {
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
 }
+
+output "google_workspace_api_clients" {
+  description = "Map of API client identifiers for Google Workspace connectors. Useful for migrations."
+  value       = module.worklytics_connectors_google_workspace.api_clients
+}

--- a/infra/examples-dev/aws-all/msft-365.tf
+++ b/infra/examples-dev/aws-all/msft-365.tf
@@ -97,3 +97,8 @@ locals {
     })
   }
 }
+
+output "msft_365_api_clients" {
+  description = "Map of API client identifiers. Useful for configuration of clients, terraform migration."
+  value       = module.worklytics_connectors_msft_365.api_clients
+}

--- a/infra/examples-dev/gcp/google-workspace.tf
+++ b/infra/examples-dev/gcp/google-workspace.tf
@@ -20,3 +20,8 @@ module "worklytics_connectors_google_workspace" {
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
 }
+
+output "google_workspace_api_clients" {
+  description = "Map of API client identifiers for Google Workspace connectors. Useful for migrations."
+  value       = module.worklytics_connectors_google_workspace.api_clients
+}

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -180,8 +180,3 @@ output "todos_3" {
 #  value       = module.psoxy.pseudonym_salt
 #  sensitive   = true
 #}
-
-output "api_clients" {
-  description = "Map of API client identifiers for Google Workspace connectors. Useful for migrations."
-  value       = module.worklytics_connectors_google_workspace.api_clients
-}

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -181,3 +181,7 @@ output "todos_3" {
 #  sensitive   = true
 #}
 
+output "api_clients" {
+  description = "Map of API client identifiers for Google Workspace connectors. Useful for migrations."
+  value       = module.worklytics_connectors_google_workspace.api_clients
+}

--- a/infra/modules/google-workspace-dwd-connection/main.tf
+++ b/infra/modules/google-workspace-dwd-connection/main.tf
@@ -99,9 +99,9 @@ Complete the following steps via the Google Workspace Admin console:
    1. Visit https://admin.google.com/ and navigate to "Security" --> "Access and Data Control" -->
       "API Controls", then find "Manage Domain Wide Delegation". Click "Add new".
 
-   2. Copy and paste client ID `${google_service_account.connector-sa.unique_id}` into the
+   2. Copy and paste client ID `${google_service_account.connector_sa.unique_id}` into the
       "Client ID" input in the popup. (this is the unique ID of the GCP service account with
-       email `${google_service_account.connector-sa.email}`; you can verify it via the GCP console,
+       email `${google_service_account.connector_sa.email}`; you can verify it via the GCP console,
        under "IAM & Admin" --> "Service Accounts")
 
    3. Copy and paste the following OAuth 2.0 scope string into the "Scopes" input:
@@ -110,7 +110,7 @@ ${join(",", var.oauth_scopes_needed)}
 ```
 
    4. Authorize it. With this, your psoxy instance should be able to authenticate with Google as
-      the GCP Service Account `${google_service_account.connector-sa.email}` and request data from
+      the GCP Service Account `${google_service_account.connector_sa.email}` and request data from
       Google as authorized by the OAuth scopes you granted.
 ${local.google_workspace_admin_account_required ? local.google_workspace_service_account_setup : ""}
 EOT

--- a/infra/modules/google-workspace-dwd-connection/main.tf
+++ b/infra/modules/google-workspace-dwd-connection/main.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 # service account to personify connector
-resource "google_service_account" "connector-sa" {
+resource "google_service_account" "connector_sa" {
   project      = var.project_id
   account_id   = local.sa_account_id
   display_name = var.display_name
@@ -122,11 +122,6 @@ resource "local_file" "todo_auth_google_workspace" {
 
   filename = "TODO ${var.todo_step} - setup ${local.instance_id}.md"
   content  = local.todo_content
-}
-
-moved {
-  from = local_file.todo-google-workspace-admin-console
-  to   = local_file.todo_auth_google_workspace[0]
 }
 
 

--- a/infra/modules/google-workspace-dwd-connection/migration_0_4_36.tf
+++ b/infra/modules/google-workspace-dwd-connection/migration_0_4_36.tf
@@ -1,0 +1,13 @@
+
+# legacy migration
+moved {
+  from = local_file.todo-google-workspace-admin-console
+  to   = local_file.todo_auth_google_workspace[0]
+}
+
+# 0_4_36 migration
+moved {
+  from = google_service_account.connector-sa
+  to   = google_service_account.connector_sa
+}
+

--- a/infra/modules/google-workspace-dwd-connection/output.tf
+++ b/infra/modules/google-workspace-dwd-connection/output.tf
@@ -1,13 +1,13 @@
 output "service_account_id" {
-  value = google_service_account.connector-sa.id
+  value = google_service_account.connector_sa.id
 }
 
 output "service_account_email" {
-  value = google_service_account.connector-sa.email
+  value = google_service_account.connector_sa.email
 }
 
 output "service_account_numeric_id" {
-  value = google_service_account.connector-sa.unique_id
+  value = google_service_account.connector_sa.unique_id
 }
 
 output "next_todo_step" {

--- a/infra/modules/google-workspace-dwd-connection/output.tf
+++ b/infra/modules/google-workspace-dwd-connection/output.tf
@@ -6,6 +6,10 @@ output "service_account_email" {
   value = google_service_account.connector-sa.email
 }
 
+output "service_account_numeric_id" {
+  value = google_service_account.connector-sa.unique_id
+}
+
 output "next_todo_step" {
   value = var.todo_step + 1
 }

--- a/infra/modules/worklytics-connectors-google-workspace/outputs.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/outputs.tf
@@ -12,3 +12,12 @@ output "next_todo_step" {
   value = try(max(values(module.google_workspace_connection)[*].next_todo_step...), var.todo_step)
 }
 
+output "api_clients" {
+  description = "Map of API clients identifiers for Google Workspace connectors. Useful for migrations."
+  value = { for k, v in module.google_workspace_connection :
+    k => {
+      service_account_id         = v.service_account_id
+      oauth_client_id            = v.service_account_numeric_id
+    }
+  }
+}

--- a/infra/modules/worklytics-connectors-msft-365/outputs.tf
+++ b/infra/modules/worklytics-connectors-msft-365/outputs.tf
@@ -23,8 +23,21 @@ output "next_todo_step" {
   value = try(max(concat([var.todo_step], local.next_todo_steps)), var.todo_step + 1)
 }
 
+#deprecated; don't think it's used directly anywhere
 output "application_ids" {
   value = {
     for id, connection in module.msft_connection : id => connection.connector.application_id
+  }
+}
+
+output "api_clients" {
+  description = "Map of API client identifiers. Useful for configuration of clients, terraform migration."
+  value = {
+    for id, connection in module.msft_connection :
+    id => {
+      azuread_application_id = connection.connector.application_id
+      oauth_client_id        = connection.connector.application_id # yes, it's same as application id; but duplicated for clarity
+      azuread_object_id      = connection.connector.object_id  # used for terraform imports
+    }
   }
 }


### PR DESCRIPTION
### Features
 - clarify that google workspace perms are read only, fix typo
 - expose API clients provisioned by terraform as outputs; this will ease migrations somewhat compared to using `terraform show` to try to find the service account id / application object_id / etc

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
