### PR TITLE
S155 support another audit log url

### DIFF
--- a/docs/sources/example-rules/github/github.yaml
+++ b/docs/sources/example-rules/github/github.yaml
@@ -166,6 +166,31 @@ endpoints:
           - "$..user"
           - "$..userId"
         encoding: "JSON"
+  - pathTemplate: "/organizations/{installationId}/audit-log"
+    allowedQueryParams:
+      - "per_page"
+      - "page"
+      - "phrase"
+      - "include"
+      - "after"
+      - "before"
+      - "order"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..hashed_token"
+          - "$..business"
+          - "$..business_id"
+          - "$..transport_protocol"
+          - "$..transport_protocol_name"
+          - "$..pull_request_title"
+          - "$..user_agent"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..actor"
+          - "$..user"
+          - "$..userId"
+        encoding: "JSON"
   - pathTemplate: "/orgs/{org}/repos"
     allowedQueryParams:
       - "per_page"

--- a/docs/sources/github.md
+++ b/docs/sources/github.md
@@ -51,7 +51,7 @@ Copy the value of `installationId` and assign it to the `github_installation_id`
 
 **NOTE**:
 - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
-- If your organization has enabled IP access restrictions you will need *404: Not found* when trying to get an access token as you will need to include IPs from AWS/GCP.
+- If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
 
 6. Update the variables with values obtained in previous step:
    - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.

--- a/docs/sources/github.md
+++ b/docs/sources/github.md
@@ -51,6 +51,7 @@ Copy the value of `installationId` and assign it to the `github_installation_id`
 
 **NOTE**:
 - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
+- If your organization has enabled IP access restrictions you will need *404: Not found* when trying to get an access token as you will need to include IPs from AWS/GCP.
 
 6. Update the variables with values obtained in previous step:
    - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -369,7 +369,7 @@ https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION
 
 **NOTE**:
  - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
- - If your organization has enabled IP access restrictions you will need *404: Not found* when trying to get an access token as you will need to include IPs from AWS/GCP.
+ - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
 
   6. Update the variables with values obtained in previous step:
      - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -369,6 +369,7 @@ https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION
 
 **NOTE**:
  - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
+ - If your organization has enabled IP access restrictions you will need *404: Not found* when trying to get an access token as you will need to include IPs from AWS/GCP.
 
   6. Update the variables with values obtained in previous step:
      - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -132,6 +132,26 @@ public class PrebuiltSanitizerRules {
                     .build())
             .build();
 
+    static final Endpoint ORG_AUDIT_LOG_WITH_INSTALLATION_ID = Endpoint.builder()
+            .pathTemplate("/organizations/{installationId}/audit-log")
+            .allowedQueryParams(orgAuditLogAllowedQueryParameters)
+            .transform(Transform.Redact.builder()
+                    .jsonPath("$..hashed_token")
+                    .jsonPath("$..business")
+                    .jsonPath("$..business_id")
+                    .jsonPath("$..transport_protocol")
+                    .jsonPath("$..transport_protocol_name")
+                    .jsonPath("$..pull_request_title")
+                    .jsonPath("$..user_agent")
+                    .build())
+            .transform(Transform.Pseudonymize.builder()
+                    .jsonPath("$..actor")
+                    .jsonPath("$..user")
+                    .jsonPath("$..userId")
+                    .build())
+            .build();
+
+
     static final Endpoint ORG_TEAM_MEMBERS = Endpoint.builder()
             .pathTemplate("/orgs/{org}/teams/{team_slug}/members")
             .allowedQueryParams(commonAllowedQueryParameters)
@@ -445,6 +465,7 @@ public class PrebuiltSanitizerRules {
             .endpoint(ORG_TEAMS)
             .endpoint(ORG_TEAM_MEMBERS)
             .endpoint(ORG_AUDIT_LOG)
+            .endpoint(ORG_AUDIT_LOG_WITH_INSTALLATION_ID)
             .endpoint(REPOSITORIES)
             .endpoint(REPO_BRANCHES)
             .endpoint(REPO_COMMITS)

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
@@ -629,6 +629,7 @@ public class GitHubTests extends JavaRulesTestBaseCase {
                 InvocationExample.of("https://api.github.com/orgs/FAKE/teams/TEAM/members", "team_members.json"),
                 InvocationExample.of("https://api.github.com/orgs/FAKE/repos", "repos.json"),
                 InvocationExample.of("https://api.github.com/orgs/FAKE/audit-log", "org_audit_log.json"),
+                InvocationExample.of("https://api.github.com/organizations/123456789/audit-log?include=all&per_page=100&phrase=created:2023-02-16T12:00:00%2B0000..2023-04-17T00:00:00%2B0000&page=0&order=asc&after=MS42OEQyOTE2MjX1MqNlJzIyfANVOHoYbUVsZ1ZjUWN6TwlZLXl6EVE%3D&before", "org_audit_log.json"),
                 InvocationExample.of("https://api.github.com/repos/FAKE/REPO/commits/COMMIT_REF", "commit.json"),
                 InvocationExample.of("https://api.github.com/repos/FAKE/REPO/branches", "repo_branches.json"),
                 InvocationExample.of("https://api.github.com/repos/FAKE/REPO/commits", "repo_commits.json"),


### PR DESCRIPTION
As commented on https://github.com/Worklytics/evalengin/pull/5988, adding the other URL for paginating audit logs.

### Fixes
- [bug: gh audit log paging problems??](https://app.asana.com/0/1205219589977464/1205289592504070)
- [bug: gh audit log parse errors](https://app.asana.com/0/1205219589977464/1205289589480657)

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? 
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? 
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
