### PR TITLE
S155 delete sanitized file on test completion

### DIFF
--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -34,6 +34,7 @@ const { version } = require('./package.json');
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)
     .option('-s, --save-sanitized-file', 'Save sanitized file to disk', false)
+    .option('--delete-sanitized-file', 'Delete sanitized file from output bucket', false)
     .configureOutput({
       outputError: (str, write) => write(chalk.bold.red(str)),
     });

--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -34,7 +34,7 @@ const { version } = require('./package.json');
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)
     .option('-s, --save-sanitized-file', 'Save sanitized file to disk', false)
-    .option('--delete-sanitized-file', 'Delete sanitized file from output bucket', false)
+    .option('-ds, --delete-sanitized-file [type]', 'Delete sanitized file from output bucket (default: true, "-ds false" to keep it)', true)
     .configureOutput({
       outputError: (str, write) => write(chalk.bold.red(str)),
     });
@@ -49,6 +49,10 @@ const { version } = require('./package.json');
 
   program.parse(process.argv);
   const options = program.opts();
+  if (_.isString(options.deleteSanitizedFile)) {
+    options.deleteSanitizedFile = !(options.deleteSanitizedFile === 'false');
+  }
+
   const logger = getLogger(options.verbose);
 
   // For async errors on 3rd party libraries

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -10,6 +10,7 @@ import {
 import {
   S3Client,
   GetObjectCommand,
+  DeleteObjectCommand,
   PutObjectCommand,
   ListBucketsCommand,
   ListObjectsV2Command
@@ -277,10 +278,33 @@ async function download(bucket, key, options, client, logger) {
   return downloadResponse.Body.transformToString();
 }
 
+/**
+ * Delete object from S3;
+ * ref: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/classes/deleteobjectcommand.html
+ * @param {string} bucket
+ * @param {string} key - Object's key (filename in S3)
+ * @param {object} options
+ * @param {string} options.role - role to assume
+ * @param {string} options.region - region to use
+ * @param {S3Client} client - optional
+ * @returns {Promise}
+ */
+async function deleteObject(bucket, key, options, client) {
+  if (!client) {
+    client = await createS3Client(options.role, options.region);
+  }
+  return await client.send(new DeleteObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    // BypassGovernanceRetention: true, ??
+  }));
+}
+
 export default {
   call,
   createCloudWatchClient,
   createS3Client,
+  deleteObject,
   download,
   getLogEvents,
   getLogStreams,

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -167,7 +167,7 @@ async function listFilesMetadata(bucketName) {
  * @param {string} filePath - local file path
  * @param {Storage} client
  * @param {string} filename - optional, destination file name
- * @returns {UploadResponse} - https://googleapis.dev/nodejs/storage/latest/global.html#UploadResponse
+ * @returns {Promise} - https://googleapis.dev/nodejs/storage/latest/global.html#UploadResponse
  */
 async function upload(bucketName, filePath, client, filename) {
   if (!client) {
@@ -179,13 +179,28 @@ async function upload(bucketName, filePath, client, filename) {
 }
 
 /**
+ * Delete file from GCS
+ * https://googleapis.dev/nodejs/storage/latest/File.html#delete
+ * @param {string} bucketName
+ * @param {string} filename - name of the file to delete (includes "path")
+ * @param {Storage} client
+ * @returns {Promise} - https://googleapis.dev/nodejs/storage/latest/global.html#DeleteFileResponse
+ */
+async function deleteFile(bucketName, filename, client) {
+  if (!client) {
+    client = createStorageClient();
+  }
+  return client.bucket(bucketName).file(filename).delete();
+}
+
+/**
  * Download file from GCS
  *
  * @param {string} bucketName
  * @param {string} fileName
  * @param {Storage} client
  * @param {Object} logger - winston instance
- * @returns {DownloadResponse} - https://googleapis.dev/nodejs/storage/latest/global.html#DownloadResponse
+ * @returns {Promise} - https://googleapis.dev/nodejs/storage/latest/global.html#DownloadResponse
  */
 async function download(bucketName, fileName, client, logger) {
   if (!client) {
@@ -209,6 +224,7 @@ async function download(bucketName, fileName, client, logger) {
 export default {
   call,
   createStorageClient,
+  deleteFile,
   download,
   getIdentityToken,
   getLogs,

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -64,6 +64,20 @@ async function testAWS(options, logger) {
 
   logger.success('File downloaded');
 
+  if (options.deleteSanitizedFile) {
+    logger.verbose(`Deleting sanitized file from output bucket: ${outputBucket}`);
+    try {
+      // Note:
+      // We don't use bucket versioning. The S3 client will attempt to delete
+      // the default "null" version of the object, but:
+      // > If there isn't a null version, Amazon S3 does not remove any objects
+      //   but will still respond that the command was successful.
+      await aws.deleteObject(outputBucket, outputKey, options, client);
+    } catch (error) {
+      logger.error(`Error deleting sanitized file: ${error.message}`);
+    }
+  }
+
   return downloadResult;
 }
 
@@ -120,6 +134,8 @@ async function testGCP(options, logger) {
  * @param {string} options.region - AWS: buckets region
  * @param {string} options.role - AWS: role to assume (ARN format; optional)
  * @param {boolean} options.saveSanitizedFile - Whether to save sanitized file or not
+ * @param {boolean} options.deleteSanitizedFile - Whether to delete sanitized file or not (from
+ *  output bucket, after test completion)
  * @returns {string}
  */
 export default async function (options = {}) {

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -116,6 +116,15 @@ async function testGCP(options, logger) {
   const fileContents = downloadResult.toString('utf8');
   logger.verbose('Download result:', { additional: fileContents });
 
+  if (options.deleteSanitizedFile) {
+    logger.verbose(`Deleting sanitized file from output bucket: ${outputBucket}`);
+    try {
+      await gcp.deleteFile(outputBucket, outputKey, client);
+    } catch (error) {
+      logger.error(`Error deleting sanitized file: ${error.message}`);
+    }
+  }
+
   return fileContents;
 }
 


### PR DESCRIPTION
### Fixes
.

### Features
 - [add option to DELETE bulk file from bulk -output bucket after test](https://app.asana.com/0/1201039336231823/1205043877019512/f): it's `default = true` now, so no need to update `.sh` scripts

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
