### PR TITLE
GCP / Google auth fixes

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -170,7 +170,7 @@ public class CommonRequestHandler {
             HttpContent content = null;
 
             if (request.getBody() != null) {
-                String contentType = request.getHeader("content-type")
+                String contentType = request.getHeader(HttpHeaders.CONTENT_TYPE)
                         .orElse("application/json");
                 content = new ByteArrayContent(contentType, request.getBody());
             }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/GoogleCloudPlatformServiceAccountKeyAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/GoogleCloudPlatformServiceAccountKeyAuthStrategy.java
@@ -124,8 +124,10 @@ public class GoogleCloudPlatformServiceAccountKeyAuthStrategy implements SourceA
         //even though GoogleCredentials implements `createDelegated`, it's a no-op if the
         // credential type doesn't support it.
         // similarly, createScoped() is no-op if not supported by GoogleCredentials implementation
+        // but if they are ops that would mutate underlying credential, they do invoke toBuilder()
+        // again and return a clone of the credential with the change - so safe; we're not mutating
+        // the same base credentials instance via multiple pointers or anything
         return baseCredentials
-            .toBuilder().build() // force a copy of base, which we'll then mutate to be delegated, scoped
             .createDelegated(accountToImpersonate)
             .createScoped(getScopes());
     }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/GoogleCloudPlatformServiceAccountKeyAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/GoogleCloudPlatformServiceAccountKeyAuthStrategy.java
@@ -98,6 +98,7 @@ public class GoogleCloudPlatformServiceAccountKeyAuthStrategy implements SourceA
             if (key.isPresent()) {
                 try (ByteArrayInputStream boas = key.map(this::toStream).orElseThrow()) {
                     provisional = ServiceAccountCredentials.fromStream(boas, httpTransportFactory);
+                    log.info("Base credentials pulled from stream of SERVICE_ACCOUNT_KEY");
                 }
             } else {
                 provisional = GoogleCredentials.getApplicationDefault();
@@ -122,7 +123,9 @@ public class GoogleCloudPlatformServiceAccountKeyAuthStrategy implements SourceA
 
         //even though GoogleCredentials implements `createDelegated`, it's a no-op if the
         // credential type doesn't support it.
+        // similarly, createScoped() is no-op if not supported by GoogleCredentials implementation
         return baseCredentials
+            .toBuilder().build() // force a copy of base, which we'll then mutate to be delegated, scoped
             .createDelegated(accountToImpersonate)
             .createScoped(getScopes());
     }

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
@@ -31,6 +31,10 @@ public class Route implements HttpFunction {
 
         CloudFunctionRequest cloudFunctionRequest = CloudFunctionRequest.of(request);
 
+        if (requestHandler == null) {
+            DaggerGcpContainer.create().injectRoute(this);
+        }
+
         try {
             if (envVarsConfigService.isDevelopment()) {
                 cloudFunctionRequest.getWarnings().forEach(log::warning);
@@ -38,10 +42,6 @@ public class Route implements HttpFunction {
         } catch (Throwable e) {
             //suppress anything that went wrong here
             log.log(Level.WARNING, "Throwable while computing warnings that is suppressed", e);
-        }
-
-        if (requestHandler == null) {
-            DaggerGcpContainer.create().injectRoute(this);
         }
 
         HttpEventResponse abstractResponse =


### PR DESCRIPTION
### Fixes
  - avoid exception that isn't breaking things, but filling logs
  - ~~copy Credential, in case we're getting the same one repeatedly from the credential cache (which is likely to work 80% of the time, so could be broken in 0.4.35??)~~


### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
