### PR TITLE
transform to preserve `proxyAddresses` format

### DIFF
--- a/docs/sources/api-response-examples/g-workspace/calendar/sanitized/calendarList.json
+++ b/docs/sources/api-response-examples/g-workspace/calendar/sanitized/calendarList.json
@@ -6,7 +6,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1541799526249000\"",
-      "id":"p~UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMnKYUk8FJevl3wvFyZY0eF-@acme.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"acme.com\",\"hash\":\"rzmdfZy7jFbdlUZGLlzb7c5E7bJ9naZRvtD5L9XKXU0\",\"reversible\":\"p~UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMnKYUk8FJevl3wvFyZY0eF-@acme.com\"}",
       "summary":null,
       "timeZone":"America/Los_Angeles",
       "colorId":"8",
@@ -50,7 +50,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1541799526249000\"",
-      "id":"p~Faa3BanSBWkYR2EPtGafNXYuk0V4dwvFVMHYNozsObZ1l6GhwLnzHTroBinny4zMSHzLeKzvWDxRDEvPxET7tqdNNCpj9QWJqZHMsfJctLA@group.v.calendar.google.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"group.v.calendar.google.com\",\"hash\":\"EWB7Oj.8.xjF3fOK8ZFlHsnM1SyjU_moNk_mhQGzT9E\",\"reversible\":\"p~Faa3BanSBWkYR2EPtGafNXYuk0V4dwvFVMHYNozsObZ1l6GhwLnzHTroBinny4zMSHzLeKzvWDxRDEvPxET7tqdNNCpj9QWJqZHMsfJctLA@group.v.calendar.google.com\"}",
       "summary":null,
       "description":"Holidays and Observances in United States",
       "timeZone":"America/Los_Angeles",
@@ -69,7 +69,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1639589485357000\"",
-      "id":"p~DE__fI7lKDU-e4_ZTA7yZpj7Vu5cQ7jQbQE9h8aU5zhJj5a-qFlQQN2CcRaIPs47@gmail.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"qd9uR3XVt6EwqRqV2fe.e4r7f8NJfgupwPtE5lXSkyA\",\"reversible\":\"p~DE__fI7lKDU-e4_ZTA7yZpj7Vu5cQ7jQbQE9h8aU5zhJj5a-qFlQQN2CcRaIPs47@gmail.com\"}",
       "summary":null,
       "timeZone":"America/Los_Angeles",
       "summaryOverride":null,
@@ -88,7 +88,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1639589486168000\"",
-      "id":"p~PFD1QVQwvuvZRY2tco2DwEsqKpZlDgOOMMQem6rik-tCXf06BdpTZY4rbexbkEuiwUH2qgd6A0bFe3lXRdHtBQMypznMn-d_kZ-IZV-qpEeTpncrcF7un65Qsv6kP90O@group.calendar.google.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"group.calendar.google.com\",\"hash\":\"u_HtUugB3Z.yQg72voJs3bPDrNinW1BXIRLftQNT7co\",\"reversible\":\"p~PFD1QVQwvuvZRY2tco2DwEsqKpZlDgOOMMQem6rik-tCXf06BdpTZY4rbexbkEuiwUH2qgd6A0bFe3lXRdHtBQMypznMn-d_kZ-IZV-qpEeTpncrcF7un65Qsv6kP90O@group.calendar.google.com\"}",
       "summary":null,
       "timeZone":"America/New_York",
       "colorId":"23",
@@ -106,7 +106,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1639589488947000\"",
-      "id":"p~cs917Yg9tfqGyvXJ9TekgMRS9PiX7DoIyrbKf3BPnMXRVZanwrlMfQ5aaVqCGwuX@acme.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"acme.com\",\"hash\":\"vwfqMJYMMMVaTvq2P3omz4MOc.4EtFEOsN.H9cNSyHA\",\"reversible\":\"p~cs917Yg9tfqGyvXJ9TekgMRS9PiX7DoIyrbKf3BPnMXRVZanwrlMfQ5aaVqCGwuX@acme.com\"}",
       "summary":null,
       "timeZone":"America/Los_Angeles",
       "colorId":"20",
@@ -124,7 +124,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1658269473142000\"",
-      "id":"p~nV9LNaGvxSTwebrX20e6Q8qSjkbafIPOXprC66qwbUfPgXI8KR5o4sIOxbekPC5l0ocS-YBBJERZwO0v4ncZJA@acme.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"acme.com\",\"hash\":\"BoMTKUFmri3UX9xRkmANkcVsxkc8Dc4kXCVNugGLdJg\",\"reversible\":\"p~nV9LNaGvxSTwebrX20e6Q8qSjkbafIPOXprC66qwbUfPgXI8KR5o4sIOxbekPC5l0ocS-YBBJERZwO0v4ncZJA@acme.com\"}",
       "summary":null,
       "timeZone":"Europe/Madrid",
       "colorId":"19",
@@ -141,7 +141,7 @@
     {
       "kind":"calendar#calendarListEntry",
       "etag":"\"1660779857672000\"",
-      "id":"p~-U7WKf4bQgfCSqtg28kpp672BXIc8kZN6Gmtg2iKn15G7DFX6AwvFyZ9VqU3_dCJ@acme.com",
+      "id":"{\"scope\":\"email\",\"domain\":\"acme.com\",\"hash\":\"sH64NW4Q7.F4pd56Ts2QD_LRirrngazuWe_3f7rjq1Y\",\"reversible\":\"p~-U7WKf4bQgfCSqtg28kpp672BXIc8kZN6Gmtg2iKn15G7DFX6AwvFyZ9VqU3_dCJ@acme.com\"}",
       "summary":"Transferred",
       "timeZone":"America/Los_Angeles",
       "colorId":"12",

--- a/docs/sources/api-response-examples/g-workspace/directory/no-app-ids/user.json
+++ b/docs/sources/api-response-examples/g-workspace/directory/no-app-ids/user.json
@@ -1,6 +1,6 @@
 {
   "kind":"admin#directory#user",
-  "id":"p~oNKsbK3Y8E5osRUjOgzKP-PbnPggtzc-ID2nzRt8kRNxCQZgDXdDdqs1EQ-uUbCr-JaWI7t2Ow8ZUFnFjhCu_Q",
+  "id":"{\"scope\":\"gapps\",\"hash\":\"wjUHe6OJkIDPrYUL6RuTbep4GVgCh88oZAr8jR0sZcY\",\"reversible\":\"p~oNKsbK3Y8E5osRUjOgzKP-PbnPggtzc-ID2nzRt8kRNxCQZgDXdDdqs1EQ-uUbCr-JaWI7t2Ow8ZUFnFjhCu_Q\"}",
   "etag":"\"g2-KWSBhdhEV1DJNuuX35hICepPpOEDe4lPvnwuxvf4/3nm0BxOJJfOv5nDTHneimEDnNRg\"",
   "primaryEmail":"{\"scope\":\"email\",\"domain\":\"worklytics.co\",\"hash\":\"1nOUZ6C0aR7HtY1l3rbtEQwknX6sdfaWxYMsdwYDlS0\"}",
   "isAdmin":true,

--- a/docs/sources/api-response-examples/g-workspace/directory/no-app-ids/users.json
+++ b/docs/sources/api-response-examples/g-workspace/directory/no-app-ids/users.json
@@ -4,7 +4,7 @@
   "users":[
     {
       "kind":"admin#directory#user",
-      "id":"p~oNKsbK3Y8E5osRUjOgzKP-PbnPggtzc-ID2nzRt8kRNxCQZgDXdDdqs1EQ-uUbCr-JaWI7t2Ow8ZUFnFjhCu_Q",
+      "id":"{\"scope\":\"gapps\",\"hash\":\"wjUHe6OJkIDPrYUL6RuTbep4GVgCh88oZAr8jR0sZcY\",\"reversible\":\"p~oNKsbK3Y8E5osRUjOgzKP-PbnPggtzc-ID2nzRt8kRNxCQZgDXdDdqs1EQ-uUbCr-JaWI7t2Ow8ZUFnFjhCu_Q\"}",
       "etag":"\"g2-KWSBhdhEV1DJNuuX35hICepPpOEDe4lPvnwuxvf4/3nm0BxOJJfOv5nDTHneimEDnNRg\"",
       "primaryEmail":"{\"scope\":\"email\",\"domain\":\"worklytics.co\",\"hash\":\"1nOUZ6C0aR7HtY1l3rbtEQwknX6sdfaWxYMsdwYDlS0\"}",
       "isAdmin":true,
@@ -119,7 +119,7 @@
     },
     {
       "kind":"admin#directory#user",
-      "id":"p~g3ohXT2tEUUlzUii8CezGBYONzDWWBeEWFMzzGxPqqs9kMnhjr7IXSUalkUwyJPq",
+      "id":"{\"scope\":\"gapps\",\"hash\":\"GHuF6tcIRogazhhRZeHTECrYhO1nQq7BFggh20FOz3U\",\"reversible\":\"p~g3ohXT2tEUUlzUii8CezGBYONzDWWBeEWFMzzGxPqqs9kMnhjr7IXSUalkUwyJPq\"}",
       "etag":"\"g2-KWSBhdhEV1DJNuuX35hICepPpOEDe4lPvnwuxvf4/MW5lZemqM7i3B82DXmbR3pne-KM\"",
       "primaryEmail":"{\"scope\":\"email\",\"domain\":\"worklytics.co\",\"hash\":\"4ejOMXOmbQO_V7hY0Puos924riETBcAxmwLewzgpX48\"}",
       "isAdmin":true,

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/user.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/user.json
@@ -11,7 +11,7 @@
     "{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"XRcSIwOXlgrxLZOIHxdtE3GCke5TsftXzOm5zmnm36g\"}"
   ],
   "proxyAddresses":[
-    "{\"scope\":\"email\",\"domain\":\"M365x214355.onmicrosoft.com\",\"hash\":\".tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI\"}",
-    "{\"scope\":\"email\",\"domain\":\"M365x214355.onmicrosoft.com\",\"hash\":\"L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp.7x1r3Yk0\"}"
+    "SMTP:t~-tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI@M365x214355.onmicrosoft.com",
+    "smtp:t~L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp-7x1r3Yk0@M365x214355.onmicrosoft.com"
   ]
 }

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/user.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/user.json
@@ -6,12 +6,12 @@
   "officeLocation":"12/1110",
   "preferredLanguage":"en-US",
   "userPrincipalName":"{\"scope\":\"email\",\"domain\":\"M365x214355.onmicrosoft.com\",\"hash\":\".tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI\"}",
-  "id":"p~SIoJOpeSgYF7YUPQ28IWZexVuHyN9A80SJXrbfawKpDRcddGnKI4QDKyjQI9KtjJZDb8FZ27UE_toS68FyWz7Y22fnQYLP91SHJGVwQiN3E",
+  "id":"{\"scope\":\"azure-ad\",\"hash\":\"J0_C7jfy9KhwcfmhAjVNQOnzUnYaE3Kovzt2FAkc2W0\",\"reversible\":\"p~SIoJOpeSgYF7YUPQ28IWZexVuHyN9A80SJXrbfawKpDRcddGnKI4QDKyjQI9KtjJZDb8FZ27UE_toS68FyWz7Y22fnQYLP91SHJGVwQiN3E\"}",
   "otherMails":[
     "{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"XRcSIwOXlgrxLZOIHxdtE3GCke5TsftXzOm5zmnm36g\"}"
   ],
   "proxyAddresses":[
-    "SMTP:t~-tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI@M365x214355.onmicrosoft.com",
-    "smtp:t~L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp-7x1r3Yk0@M365x214355.onmicrosoft.com"
+    "SMTP:t~.tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI@M365x214355.onmicrosoft.com",
+    "smtp:t~L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp.7x1r3Yk0@M365x214355.onmicrosoft.com"
   ]
 }

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/users.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/users.json
@@ -13,8 +13,8 @@
         "{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"qd9uR3XVt6EwqRqV2fe.e4r7f8NJfgupwPtE5lXSkyA\"}"
       ],
       "proxyAddresses":[
-        "{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk\"}",
-        "{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"lvy8VyWgzHtEbGoV33ah8PG0kB.iObC5o61biWbEQQQ\"}"
+        "SMTP:t~q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk@worklytics.onmicrosoft.com",
+        "smtp:t~lvy8VyWgzHtEbGoV33ah8PG0kB-iObC5o61biWbEQQQ@worklytics.onmicrosoft.com"
       ]
     },
     {

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/users.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized-no-app-ids/users.json
@@ -2,7 +2,7 @@
   "@odata.context":"https://graph.microsoft.com/v1.0/$metadata#users",
   "value":[
     {
-      "id":"p~bFDzUA6DcTb6Jc4bDJ4UDkZwq_lK0Ob5TJA0h6E_6UmQ_EQgmQCK_TdrApUV5q-PZaA9i28Oitm-X6bYa8iwQSNV1qzposKfzSfm7JN860o",
+      "id":"{\"scope\":\"azure-ad\",\"hash\":\"wi1gC8mRNWrRNZwUimQwwbNP.K4LsFXbM.MVW8sxU6E\",\"reversible\":\"p~bFDzUA6DcTb6Jc4bDJ4UDkZwq_lK0Ob5TJA0h6E_6UmQ_EQgmQCK_TdrApUV5q-PZaA9i28Oitm-X6bYa8iwQSNV1qzposKfzSfm7JN860o\"}",
       "businessPhones":[ ],
       "jobTitle":null,
       "mail":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk\"}",
@@ -14,11 +14,11 @@
       ],
       "proxyAddresses":[
         "SMTP:t~q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk@worklytics.onmicrosoft.com",
-        "smtp:t~lvy8VyWgzHtEbGoV33ah8PG0kB-iObC5o61biWbEQQQ@worklytics.onmicrosoft.com"
+        "smtp:t~lvy8VyWgzHtEbGoV33ah8PG0kB.iObC5o61biWbEQQQ@worklytics.onmicrosoft.com"
       ]
     },
     {
-      "id":"p~olwC_FZa24BttFSG87T2U-fJybmzdHj6SMc7LxV4zOm0oLvgEDHxSVdAUvflsZfNPyGZt4MDy8hyxOZP9VHyJpfDnlVva0m1ElQ-WrRUjxM",
+      "id":"{\"scope\":\"azure-ad\",\"hash\":\"LiJb.ARnRq28mWRHlForzfDucaSRql_MCi1ofRfJzWg\",\"reversible\":\"p~olwC_FZa24BttFSG87T2U-fJybmzdHj6SMc7LxV4zOm0oLvgEDHxSVdAUvflsZfNPyGZt4MDy8hyxOZP9VHyJpfDnlVva0m1ElQ-WrRUjxM\"}",
       "businessPhones":[ ],
       "jobTitle":null,
       "mail":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"YbwNv0Jw8i7kKLWaqhEIMC5Se6pPeE4kIBf2st3rm9c\"}",
@@ -27,7 +27,7 @@
       "userPrincipalName":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"YbwNv0Jw8i7kKLWaqhEIMC5Se6pPeE4kIBf2st3rm9c\"}"
     },
     {
-      "id":"p~CBRYQdohf24wt2ERzO_2CUZ1D7HWgla01CtX9RnFgko9_YX4INCm3pJZDkOYr_wJHHXNWuFYA5yKMQ0GOunQ_yECslrs_0kt_P_0uAUlKes",
+      "id":"{\"scope\":\"azure-ad\",\"hash\":\"Qnf9KfhBS2X9800Fccc0XV43UssVGg1FyI0qMnbxlRI\",\"reversible\":\"p~CBRYQdohf24wt2ERzO_2CUZ1D7HWgla01CtX9RnFgko9_YX4INCm3pJZDkOYr_wJHHXNWuFYA5yKMQ0GOunQ_yECslrs_0kt_P_0uAUlKes\"}",
       "businessPhones":[ ],
       "jobTitle":null,
       "mail":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"yRNnmnw83TqOPzYGRAEQavMUIWzFFtw350OZkB1kQrk\"}",
@@ -36,7 +36,7 @@
       "userPrincipalName":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"yRNnmnw83TqOPzYGRAEQavMUIWzFFtw350OZkB1kQrk\"}"
     },
     {
-      "id":"p~11O1eqpq2vEzigY-HlCb5svil7cXxmuDhaMTaj86mLDZA43zB4KsiYB6d56uPZYidcBB96tOU2AfhbhLQbbhqAvLsaPaOgMj64f71eMQHc0",
+      "id":"{\"scope\":\"azure-ad\",\"hash\":\"cT7EZPg_yGzlrofKJGizatyyWgytRjBtqgKfWRFObLI\",\"reversible\":\"p~11O1eqpq2vEzigY-HlCb5svil7cXxmuDhaMTaj86mLDZA43zB4KsiYB6d56uPZYidcBB96tOU2AfhbhLQbbhqAvLsaPaOgMj64f71eMQHc0\"}",
       "businessPhones":[ ],
       "jobTitle":null,
       "mail":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"8wfO0E2lPfP4s.Kdl80rQxSLgKoyCH5VsTHCln70YgI\"}",
@@ -45,7 +45,7 @@
       "userPrincipalName":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"8wfO0E2lPfP4s.Kdl80rQxSLgKoyCH5VsTHCln70YgI\"}"
     },
     {
-      "id":"p~kOTAg44Qv8HSvYWG7niJEq_fPTSFm1vHKYfVhmrS221C1HOmCt8kkL376bc8842blh7-oAvtkYr2dK5dFhDDaMs_TWiVje9MvvyyZE6JI7E",
+      "id":"{\"scope\":\"azure-ad\",\"hash\":\".3jWTWfzM_LnR_xcBNHj7FiAKOTHfED_ZRfEQV0xaog\",\"reversible\":\"p~kOTAg44Qv8HSvYWG7niJEq_fPTSFm1vHKYfVhmrS221C1HOmCt8kkL376bc8842blh7-oAvtkYr2dK5dFhDDaMs_TWiVje9MvvyyZE6JI7E\"}",
       "businessPhones":[ ],
       "jobTitle":null,
       "mail":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"ZFmgYXeeM9Vr385OqSDur7FU59uw8MpRF74uYg7kMxQ\"}",
@@ -60,7 +60,7 @@
       "officeLocation":null,
       "preferredLanguage":null,
       "userPrincipalName":"{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"mbQYAaLx.FMtyO1ax80fwVazndo4PZoqtcAqSvqXTV0\"}",
-      "id":"p~xU2vGhAEBHegciOlP1Oz2bRY1_OkAY-GO2VY7FGQU5tc-5pDPeQYr4dh1Xrkbl1dmx1pyWCN8R3C-tWSXv_7DNDELLFYYHtX6FiIDjdLDaw"
+      "id":"{\"scope\":\"azure-ad\",\"hash\":\"hZe4R6PeCSDn7OlmErcY3ogoH9DPV8p.tVVnhyg9_Aw\",\"reversible\":\"p~xU2vGhAEBHegciOlP1Oz2bRY1_OkAY-GO2VY7FGQU5tc-5pDPeQYr4dh1Xrkbl1dmx1pyWCN8R3C-tWSXv_7DNDELLFYYHtX6FiIDjdLDaw\"}"
     }
   ]
 }

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized/user.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized/user.json
@@ -11,7 +11,7 @@
     "{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"XRcSIwOXlgrxLZOIHxdtE3GCke5TsftXzOm5zmnm36g\"}"
   ],
   "proxyAddresses":[
-    "SMTP:t~-tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI@M365x214355.onmicrosoft.com",
-    "smtp:t~L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp-7x1r3Yk0@M365x214355.onmicrosoft.com"
+    "SMTP:t~.tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI@M365x214355.onmicrosoft.com",
+    "smtp:t~L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp.7x1r3Yk0@M365x214355.onmicrosoft.com"
   ]
 }

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized/user.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized/user.json
@@ -11,7 +11,7 @@
     "{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"XRcSIwOXlgrxLZOIHxdtE3GCke5TsftXzOm5zmnm36g\"}"
   ],
   "proxyAddresses":[
-    "{\"scope\":\"email\",\"domain\":\"M365x214355.onmicrosoft.com\",\"hash\":\".tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI\"}",
-    "{\"scope\":\"email\",\"domain\":\"M365x214355.onmicrosoft.com\",\"hash\":\"L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp.7x1r3Yk0\"}"
+    "SMTP:t~-tbhph3DloGSd5l9e9TeFqmEboAqU8o6BdigmHZOmxI@M365x214355.onmicrosoft.com",
+    "smtp:t~L282PmjOP7xZpTtW7M1sKbWHzVvzLV4Yfp-7x1r3Yk0@M365x214355.onmicrosoft.com"
   ]
 }

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized/users.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized/users.json
@@ -13,8 +13,8 @@
         "{\"scope\":\"email\",\"domain\":\"gmail.com\",\"hash\":\"qd9uR3XVt6EwqRqV2fe.e4r7f8NJfgupwPtE5lXSkyA\"}"
       ],
       "proxyAddresses":[
-        "{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk\"}",
-        "{\"scope\":\"email\",\"domain\":\"worklytics.onmicrosoft.com\",\"hash\":\"lvy8VyWgzHtEbGoV33ah8PG0kB.iObC5o61biWbEQQQ\"}"
+        "SMTP:t~q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk@worklytics.onmicrosoft.com",
+        "smtp:t~lvy8VyWgzHtEbGoV33ah8PG0kB-iObC5o61biWbEQQQ@worklytics.onmicrosoft.com"
       ]
     },
     {

--- a/docs/sources/api-response-examples/microsoft-365/directory/sanitized/users.json
+++ b/docs/sources/api-response-examples/microsoft-365/directory/sanitized/users.json
@@ -14,7 +14,7 @@
       ],
       "proxyAddresses":[
         "SMTP:t~q13PonzfNpUWmyGUYmClKKmAFrkH_BjdABY74ccirMk@worklytics.onmicrosoft.com",
-        "smtp:t~lvy8VyWgzHtEbGoV33ah8PG0kB-iObC5o61biWbEQQQ@worklytics.onmicrosoft.com"
+        "smtp:t~lvy8VyWgzHtEbGoV33ah8PG0kB.iObC5o61biWbEQQQ@worklytics.onmicrosoft.com"
       ]
     },
     {

--- a/docs/sources/api-response-examples/zoom/sanitized/list-users.json
+++ b/docs/sources/api-response-examples/zoom/sanitized/list-users.json
@@ -5,10 +5,10 @@
   "total_records":1,
   "users":[
     {
-      "id":"p~JzXCV2FA272NOeqHYQbR4PewwSZI9hznATn7Wse3j8GpsoD91NC0nDg1vNKrhPEc",
+      "id":"{\"scope\":\"zoom\",\"hash\":\"ZOPLM4doMzcRkn5mKz63MrQApQc.e4CHTv5z8dPxYVk\",\"reversible\":\"p~JzXCV2FA272NOeqHYQbR4PewwSZI9hznATn7Wse3j8GpsoD91NC0nDg1vNKrhPEc\"}",
       "email":"{\"scope\":\"email\",\"domain\":\"example.com\",\"hash\":\"Oyl8_kWC39yrNSWNGUSM7xylJREQ62Dj6OynAkyY2Ro\"}",
       "type":2,
-      "pmi":"p~LKW3WIP3bZzEQFelvQBi0lpLDZtk-1qJbWe3rHfhYhdfeki-8voee3S0wopon6Y3",
+      "pmi":"{\"scope\":\"zoom\",\"hash\":\"b4spdxpK7EOqmO86s79CDfEPeOvKSCq7aUndB5pE26Y\",\"reversible\":\"p~LKW3WIP3bZzEQFelvQBi0lpLDZtk-1qJbWe3rHfhYhdfeki-8voee3S0wopon6Y3\"}",
       "phone_number":"{\"scope\":\"zoom\",\"hash\":\"iNlsdCT16rKNdAUT1D9VAG4oJ9FaXs6ndFk0sc8KGc0\"}",
       "timezone":"America/Los_Angeles",
       "verified":1,

--- a/docs/sources/example-rules/microsoft-365/directory.yaml
+++ b/docs/sources/example-rules/microsoft-365/directory.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -61,15 +59,9 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: true
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -80,11 +72,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -109,7 +100,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/directory_no-app-ids.yaml
+++ b/docs/sources/example-rules/microsoft-365/directory_no-app-ids.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -66,15 +64,9 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: true
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -85,11 +77,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -114,7 +105,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/directory_no-app-ids_no-orig.yaml
+++ b/docs/sources/example-rules/microsoft-365/directory_no-app-ids_no-orig.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -66,15 +64,9 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: false
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -85,11 +77,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -114,7 +105,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/outlook-cal.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-cal.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -61,15 +59,9 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: true
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -80,11 +72,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -109,7 +100,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/outlook-cal_no-app-ids.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-cal_no-app-ids.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -66,15 +64,9 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: true
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -85,11 +77,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -114,7 +105,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/outlook-cal_no-app-ids_no-groups.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-cal_no-app-ids_no-groups.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/outlook-mail.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-mail.yaml
@@ -59,10 +59,6 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<pseudonymizeRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        regex: "(?i)^smtp:(.*)$"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"

--- a/docs/sources/example-rules/microsoft-365/outlook-mail.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-mail.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -61,15 +59,13 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: true
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -80,11 +76,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -109,7 +104,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/outlook-mail_no-app-ids.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-mail_no-app-ids.yaml
@@ -64,10 +64,6 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<pseudonymizeRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        regex: "(?i)^smtp:(.*)$"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"

--- a/docs/sources/example-rules/microsoft-365/outlook-mail_no-app-ids.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-mail_no-app-ids.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"
@@ -66,15 +64,13 @@ endpoints:
           - "$..onPremisesSecurityIdentifier"
           - "$..onPremisesProvisioningErrors"
           - "$..securityIdentifier"
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<pseudonymize>
         jsonPaths:
           - "$..mail"
-          - "$..proxyAddresses[*]"
         includeOriginal: true
         encoding: "JSON"
   - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
@@ -85,11 +81,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -114,7 +109,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/docs/sources/example-rules/microsoft-365/outlook-mail_no-app-ids_no-groups.yaml
+++ b/docs/sources/example-rules/microsoft-365/outlook-mail_no-app-ids_no-groups.yaml
@@ -8,11 +8,10 @@ endpoints:
       - "$orderBy"
       - "$count"
     transforms:
-      - !<redactRegexMatches>
+      - !<pseudonymizeRegexMatches>
         jsonPaths:
           - "$..proxyAddresses[*]"
-        redactions:
-          - "(?i)^smtp:"
+        regex: "(?i)^smtp:(.*)$"
       - !<redact>
         jsonPaths:
           - "$..displayName"
@@ -37,7 +36,6 @@ endpoints:
           - "$..imAddresses[*]"
           - "$..mail"
           - "$..otherMails[*]"
-          - "$..proxyAddresses[*]"
           - "$..onPremisesSamAccountName"
           - "$..onPremisesUserPrincipalName"
           - "$..onPremisesDistinguishedName"

--- a/java/core/src/main/java/co/worklytics/psoxy/HashUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/HashUtils.java
@@ -39,4 +39,8 @@ public class HashUtils {
         // https://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters
         return StringUtils.replaceChars(encoded, "/+", "_.");
     }
+
+    public byte[] decode(String encoded) {
+        return Base64.getDecoder().decode(StringUtils.replaceChars(encoded, "_.", "/+"));
+    }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import org.apache.commons.lang3.StringUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
@@ -72,29 +73,26 @@ public class PseudonymizedIdentity {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String reversible;
 
+    /**
+     * convert this to Pseudonym; works ONLY if built with DEFAULT format
+     *
+     * @return
+     */
     public Pseudonym asPseudonym() {
 
         //q: what to do w original, if anything?
 
-        Base64.Decoder decoder = Base64.getUrlDecoder();
+        UrlSafeTokenPseudonymEncoder encoder = new UrlSafeTokenPseudonymEncoder();
 
         byte[] decodedHash, decodedReversible;
         if (hash != null) {
-            decoder = Base64.getUrlDecoder();
-            try {
-                decodedHash = decoder.decode(hash.getBytes());
-            } catch (IllegalArgumentException e) {
-                decoder = Base64.getDecoder();
-                //q: should we log this?
-                decodedHash = decoder.decode(StringUtils.replaceChars(hash, "_.", "/+").getBytes());
-            }
+            decodedHash = encoder.decode(hash).getHash();
         } else {
             decodedHash = null;
         }
 
         if (reversible != null) {
-            UrlSafeTokenPseudonymEncoder encoder = new UrlSafeTokenPseudonymEncoder();
-            return encoder.decode(reversible);
+            decodedReversible = encoder.decode(reversible).getReversible();
         } else {
             decodedReversible = null;
         }
@@ -104,5 +102,25 @@ public class PseudonymizedIdentity {
             .domain(domain)
             .reversible(decodedReversible)
             .build();
+    }
+
+    /**
+     * convert this to Pseudonym; works ONLY if built with LEGACY format
+     *
+     * @return
+     */
+    public Pseudonym fromLegacy() {
+        HashUtils hashUtils = new HashUtils();
+
+        Pseudonym.PseudonymBuilder<?, ?> builder = Pseudonym.builder()
+                .hash(hashUtils.decode(hash))
+                .domain(domain);
+
+        if (reversible != null) {
+            UrlSafeTokenPseudonymEncoder encoder = new UrlSafeTokenPseudonymEncoder();
+            builder.reversible(encoder.decode(reversible).getReversible());
+        }
+
+        return builder.build();
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
@@ -1,6 +1,7 @@
 package co.worklytics.psoxy;
 
 import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import org.apache.commons.lang3.StringUtils;
@@ -92,18 +93,11 @@ public class PseudonymizedIdentity {
         }
 
         if (reversible != null) {
-            try {
-                decodedReversible = decoder.decode(reversible.getBytes());
-            } catch (IllegalArgumentException e) {
-                decoder = Base64.getDecoder();
-                //q: should we log this?
-                decodedReversible = decoder.decode(StringUtils.replaceChars(reversible, "_.", "/+").getBytes());
-            }
+            UrlSafeTokenPseudonymEncoder encoder = new UrlSafeTokenPseudonymEncoder();
+            return encoder.decode(reversible);
         } else {
             decodedReversible = null;
         }
-
-
 
         return Pseudonym.builder()
             .hash(decodedHash)

--- a/java/core/src/main/java/co/worklytics/psoxy/Pseudonymizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/Pseudonymizer.java
@@ -42,7 +42,7 @@ public interface Pseudonymizer {
      */
     PseudonymizedIdentity pseudonymize(Object identifier);
 
-    PseudonymizedIdentity pseudonymize(Object identifier, Transform.Pseudonymize transform);
+    PseudonymizedIdentity pseudonymize(Object identifier, Transform.PseudonymizationTransform transform);
 
     ConfigurationOptions getOptions();
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
@@ -63,7 +63,7 @@ public class PseudonymizerImpl implements Pseudonymizer {
     }
 
     @Override
-    public PseudonymizedIdentity pseudonymize(Object value, Transform.Pseudonymize transformOptions) {
+    public PseudonymizedIdentity pseudonymize(Object value, Transform.PseudonymizationTransform transformOptions) {
         if (value == null) {
             return null;
         }

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -410,7 +410,8 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
                     return pseudonymizedString;
                 }
             } else {
-                return s;
+                //if no match, redact it
+                return null;
             }
         };
     }

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -381,7 +381,17 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
                 }
                 PseudonymizedIdentity pseudonymizedIdentity = pseudonymizer.pseudonymize(toPseudonymize, transform);
 
-                String pseudonymizedString = urlSafePseudonymEncoder.encode(pseudonymizedIdentity.asPseudonym());
+                String pseudonymizedString;
+                if (pseudonymizedIdentity.getReversible() != null) {
+                    //exploits that already reversibly encoded, including prefix
+                    pseudonymizedString = pseudonymizedIdentity.getReversible();
+                } else {
+                    pseudonymizedString = UrlSafeTokenPseudonymEncoder.TOKEN_PREFIX + pseudonymizedIdentity.getHash();
+                }
+                if (pseudonymizedIdentity.getDomain() != null) {
+                    pseudonymizedString += UrlSafeTokenPseudonymEncoder.DOMAIN_SEPARATOR + pseudonymizedIdentity.getDomain();
+                }
+
                 if (matcher.groupCount() > 0) {
                     // return original, replacing match with encoded pseudonym
                     return fullString.replace(matcher.group(1), pseudonymizedString);

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -24,16 +24,17 @@ public class PrebuiltSanitizerRules {
         .jsonPath("$.['@odata.context']")
         .build();
 
+    static final Transform.PseudonymizeRegexMatches PSEUDONYMIZE_PROXY_ADDRESSES = Transform.PseudonymizeRegexMatches.builder()
+        .jsonPath("$..proxyAddresses[*]")
+        .regex("(?i)^smtp:(.*)$")
+        .build();
+
     static final String DIRECTORY_REGEX_USERS = "^/(v1.0|beta)/users/?[^/]*";
     static final String DIRECTORY_REGEX_USERS_BY_PSEUDO = "^/(v1.0|beta)/users(/p~[a-zA-Z0-9_-]+?)?[^/]*";
     static final String DIRECTORY_REGEX_GROUP_MEMBERS = "^/(v1.0|beta)/groups/[^/]*/members.*";
 
     static final List<Transform> USER_TRANSFORMS = Arrays.asList(
-        // VERY hacky; there is nothing that guarantees order of evaluation of the transforms ...
-        Transform.RedactRegexMatches.builder()
-            .jsonPath("$..proxyAddresses[*]")
-            .redaction("(?i)^smtp:")
-            .build(),
+        PSEUDONYMIZE_PROXY_ADDRESSES,
         Transform.Redact.builder()
             .jsonPath("$..displayName")
             .jsonPath("$..aboutMe")
@@ -57,7 +58,6 @@ public class PrebuiltSanitizerRules {
             .jsonPath("$..imAddresses[*]")
             .jsonPath("$..mail")
             .jsonPath("$..otherMails[*]")
-            .jsonPath("$..proxyAddresses[*]")
             .jsonPath("$..onPremisesSamAccountName")
             .jsonPath("$..onPremisesUserPrincipalName")
             .jsonPath("$..onPremisesDistinguishedName")
@@ -94,15 +94,9 @@ public class PrebuiltSanitizerRules {
                 .jsonPath("$..onPremisesProvisioningErrors")
                 .jsonPath("$..securityIdentifier")
                 .build())
-            // VERY hacky; there is nothing that guarantees order of evaluation of the transforms ...
-            .transform(Transform.RedactRegexMatches.builder()
-                .jsonPath("$..proxyAddresses[*]")
-                .redaction("(?i)^smtp:")
-                .build())
             .transform(Transform.Pseudonymize.builder()
                     .includeOriginal(true)
                     .jsonPath("$..mail")
-                    .jsonPath("$..proxyAddresses[*]")
                     .build())
         .build();
 

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -3,7 +3,9 @@ package co.worklytics.psoxy.storage.impl;
 import co.worklytics.psoxy.PseudonymizedIdentity;
 import co.worklytics.psoxy.Pseudonymizer;
 import co.worklytics.psoxy.rules.CsvRules;
+import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
+import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.BulkDataRules;
 import com.avaulta.gateway.rules.ColumnarRules;
@@ -152,7 +154,14 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
                                 //this shouldn't happen, bc ColumnarRules don't support preserving original
                                 log.warning("Encoding pseudonym for column '" + outputColumnName + "' using format that will not include the 'original' value, althought transformation preserved it");
                             }
-                            return urlSafeTokenPseudonymEncoder.encode(identity.asPseudonym());
+                            if (pseudonymizer.getOptions().getPseudonymImplementation() == PseudonymImplementation.LEGACY) {
+                                if (identity.getReversible() != null) {
+                                    throw new Error("Cannot encode legacy PseudonymizedIdentity with reversibles as URL_SAFE_TOKEN");
+                                }
+                                return urlSafeTokenPseudonymEncoder.encode(identity.fromLegacy());
+                            } else {
+                                return urlSafeTokenPseudonymEncoder.encode(identity.asPseudonym());
+                            }
                         } else {
                             //JSON
                             return objectMapper.writeValueAsString(identity);

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizedIdentityTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizedIdentityTest.java
@@ -1,0 +1,131 @@
+package co.worklytics.psoxy;
+
+import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.test.MockModules;
+import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
+import com.avaulta.gateway.rules.transforms.Transform;
+import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
+import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
+import dagger.Component;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.util.Base64;
+
+import static co.worklytics.test.TestModules.withMockEncryptionKey;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PseudonymizedIdentityTest {
+
+    @Singleton
+    @Component(modules = {
+            PsoxyModule.class,
+            MockModules.ForConfigService.class,
+            MockModules.ForRules.class,
+    })
+    public interface Container {
+        void inject(PseudonymizedIdentityTest test);
+    }
+    @BeforeEach
+    public void setup() {
+        PseudonymizedIdentityTest.Container container = DaggerPseudonymizedIdentityTest_Container.create();
+        container.inject(this);
+
+        withMockEncryptionKey(config);
+    }
+
+    @Inject ConfigService config;
+    @Inject Pseudonymizer pseudonymizer;
+    @Inject PseudonymizerImplFactory pseudonymizerImplFactory;
+
+    @Test
+    void asPseudonym() {
+        pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+                .pseudonymizationSalt("an irrelevant per org secret")
+                .defaultScopeId("scope")
+                .pseudonymImplementation(PseudonymImplementation.DEFAULT)
+                .build());
+
+        PseudonymizedIdentity pseudonymizedIdentity = pseudonymizer.pseudonymize("alice@acme.com");
+
+        Pseudonym pseudonym = pseudonymizedIdentity.asPseudonym();
+
+        assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(pseudonym.getHash()),
+                pseudonymizedIdentity.getHash());
+    }
+
+    @Test
+    void asPseudonym_reversible() {
+        pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+                .pseudonymizationSalt("an irrelevant per org secret")
+                .defaultScopeId("scope")
+                .pseudonymImplementation(PseudonymImplementation.DEFAULT)
+                .build());
+
+        PseudonymizedIdentity pseudonymizedIdentity
+                = pseudonymizer.pseudonymize("alice@acme.com", Transform.Pseudonymize.builder()
+                .includeReversible(true)
+                .build());
+
+        PseudonymizedIdentity notReversible = pseudonymizer.pseudonymize("alice@acme.com", Transform.Pseudonymize.builder()
+                .includeReversible(false)
+                .build());
+
+        Pseudonym pseudonym = pseudonymizedIdentity.asPseudonym();
+
+        assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(pseudonym.getHash()),
+                pseudonymizedIdentity.getHash());
+
+        assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(pseudonym.getHash()),
+                notReversible.getHash());
+    }
+
+    @Test
+    void asPseudonym_legacy() {
+        pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+                .pseudonymizationSalt("an irrelevant per org secret")
+                .defaultScopeId("scope")
+                .pseudonymImplementation(PseudonymImplementation.LEGACY)
+                .build());
+
+        PseudonymizedIdentity pseudonymizedIdentity = pseudonymizer.pseudonymize("alice@acme.com");
+
+        Pseudonym pseudonym = pseudonymizedIdentity.fromLegacy();
+
+        assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(pseudonym.getHash()),
+                pseudonymizedIdentity.getHash());
+    }
+
+    @Test
+    void asPseudonym_reversible_legacy() {
+        pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+                .pseudonymizationSalt("an irrelevant per org secret")
+                .defaultScopeId("scope")
+                .pseudonymImplementation(PseudonymImplementation.LEGACY)
+                .build());
+
+        PseudonymizedIdentity pseudonymizedIdentity
+                = pseudonymizer.pseudonymize("alice@acme.com", Transform.Pseudonymize.builder()
+                .includeReversible(true)
+                .build());
+
+        PseudonymizedIdentity notReversible = pseudonymizer.pseudonymize("alice@acme.com", Transform.Pseudonymize.builder()
+                .includeReversible(false)
+                .build());
+
+        Pseudonym pseudonym = pseudonymizedIdentity.fromLegacy();
+
+        //pseudonym's hash is NOT equivalent to legacy pseudonymizedIdentity's hash
+        assertNotEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(pseudonym.getHash()),
+                pseudonymizedIdentity.getHash());
+
+        assertNotEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(pseudonym.getHash()),
+                notReversible.getHash());
+    }
+}

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
@@ -2,7 +2,10 @@ package co.worklytics.psoxy;
 
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.test.MockModules;
+import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
+import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
+import com.avaulta.gateway.rules.transforms.Transform;
 import dagger.Component;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,6 +14,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import java.util.Base64;
 
 import static co.worklytics.test.TestModules.withMockEncryptionKey;
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,7 +52,7 @@ class PseudonymizerImplTest {
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
             .pseudonymizationSalt("an irrelevant per org secret")
             .defaultScopeId("scope")
-            .pseudonymImplementation(PseudonymImplementation.LEGACY)
+            .pseudonymImplementation(PseudonymImplementation.DEFAULT)
             .build());
 
         withMockEncryptionKey(config);
@@ -106,6 +111,38 @@ class PseudonymizerImplTest {
 
         assertEquals(identityHash,
             pseudonymizer.pseudonymize(CANONICAL).getHash());
+    }
+
+
+    @Test
+    void hashesMatchRegardlessOfReversible() {
+        final String CANONICAL = "original";
+
+        assertEquals(
+            pseudonymizer.pseudonymize(CANONICAL, Transform.Pseudonymize.builder().includeReversible(false).build()).getHash(),
+            pseudonymizer.pseudonymize(CANONICAL, Transform.Pseudonymize.builder().includeReversible(true).build()).getHash());
+    }
+
+    @Test
+    void encoderRoundtripForReversibles() {
+        final String CANONICAL = "original";
+
+        UrlSafeTokenPseudonymEncoder urlSafeTokenPseudonymEncoder = new UrlSafeTokenPseudonymEncoder();
+        PseudonymizedIdentity pseudonym = pseudonymizer.pseudonymize(CANONICAL, Transform.Pseudonymize.builder().includeReversible(false).build());
+        PseudonymizedIdentity reversiblePseudonym = pseudonymizer.pseudonymize(CANONICAL, Transform.Pseudonymize.builder().includeReversible(true).build());
+
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+
+
+        assertEquals(
+                pseudonym.getHash(),
+            encoder.encodeToString(reversiblePseudonym.asPseudonym().getHash()));
+
+        Pseudonym decoded = urlSafeTokenPseudonymEncoder.decode(reversiblePseudonym.getReversible());
+
+        assertEquals(
+                encoder.encodeToString(pseudonym.asPseudonym().getHash()),
+                encoder.encodeToString(decoded.getHash()));
     }
 
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
@@ -102,8 +102,15 @@ class PseudonymizerImplTest {
 
     @Test
     void hashMatchesLegacy() {
-        //value taken from legacy app
+        // all this is really testing is that we aren't breaking the LEGACY hash implementation
 
+        pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+            .pseudonymizationSalt("an irrelevant per org secret")
+            .defaultScopeId("scope")
+            .pseudonymImplementation(PseudonymImplementation.LEGACY)
+            .build());
+
+        //value taken from legacy app
         final String CANONICAL = "original";
 
         //value taken from legacy app

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -500,6 +500,16 @@ class RESTApiSanitizerImplTest {
     })
     @ParameterizedTest
     void pseudonymizeWithRegexMatches(String input) {
+
+        Pseudonymizer pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+            .pseudonymizationSalt("an irrelevant per org secret")
+            .defaultScopeId("scope")
+            .pseudonymImplementation(PseudonymImplementation.LEGACY)
+            .build());
+
+
+        sanitizer = sanitizerFactory.create(PrebuiltSanitizerRules.DEFAULTS.get("gmail"), pseudonymizer);
+
         List<MapFunction> transforms = Arrays.asList(
             sanitizer.getPseudonymizeRegexMatches(Transform.PseudonymizeRegexMatches.builder()
                 .regex(".*")

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -573,4 +573,21 @@ class RESTApiSanitizerImplTest {
     }
 
 
+
+    @CsvSource(value = {
+        "something,.*,t~wUW4bkpTjD6c.BIQaE_oLQxN4nD5vbnf5HBVz7gxck8",
+        "something,blah:.*thing,", // no match, should redact
+        "blah:something,blah:.*thing,t~iWybsRb4SscO_Z6v2gpnMTjPujG2E4FtxgYkjWc5HXQ",
+        "blah:something,blah:(.*),blah:t~wUW4bkpTjD6c.BIQaE_oLQxN4nD5vbnf5HBVz7gxck8",
+    })
+    @ParameterizedTest
+    public void pseudonymizeWithRegexMatches_nonMatchingRedacted(String input, String regex, String expected) {
+        MapFunction transform = sanitizer.getPseudonymizeRegexMatches(Transform.PseudonymizeRegexMatches.builder()
+            .regex(regex)
+            .includeReversible(false)
+            .build());
+
+        assertEquals(StringUtils.trimToNull(expected),
+            transform.map(input, sanitizer.getJsonConfiguration()));
+    }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/JavaRulesTestBaseCase.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/JavaRulesTestBaseCase.java
@@ -23,7 +23,6 @@ public abstract class JavaRulesTestBaseCase extends RulesBaseTestCase {
         String path = "/rules/" + getTestSpec().getYamlSerializationFilePath()
             .orElse(getYamlSerializationFilepath()) + ".yaml";
 
-
         RuleSet rulesFromFilesystem = yamlMapper.readerFor(getRulesUnderTest().getClass())
             .readValue(PrebuiltSanitizerRules.class.getResource(path));
 

--- a/java/gateway-core/gateway-core.iml
+++ b/java/gateway-core/gateway-core.iml
@@ -3,53 +3,24 @@
   <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$" dumb="true">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
-    </content>
-  </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11" inherit-compiler-output="true">
-    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-test-sources/test-annotations" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.28" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.12.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-csv:1.10.0" level="project" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.15" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.15.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.15.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.15.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2" level="project" />
-    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:2.0" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:4.11.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:4.11.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.12.19" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.12.19" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:3.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.9.1" level="project" />
   </component>
 </module>

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
@@ -28,7 +28,7 @@ public class UrlSafeTokenPseudonymEncoder implements PseudonymEncoder {
 
     //length of base64-url-encoded IV + ciphertext
     static final int REVERSIBLE_PSEUDONYM_LENGTH_WITHOUT_PREFIX = 43;
-    private static final String DOMAIN_SEPARATOR = "@";
+    public static final String DOMAIN_SEPARATOR = "@";
 
 
     //base64url-encoding without padding

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
@@ -22,9 +22,9 @@ public class UrlSafeTokenPseudonymEncoder implements PseudonymEncoder {
      *   - prefix + suffix to make stronger
      *
      */
-    static final String REVERSIBLE_PREFIX = "p~";
+    public static final String REVERSIBLE_PREFIX = "p~";
 
-    static final String TOKEN_PREFIX = "t~";
+    public static final String TOKEN_PREFIX = "t~";
 
     //length of base64-url-encoded IV + ciphertext
     static final int REVERSIBLE_PSEUDONYM_LENGTH_WITHOUT_PREFIX = 43;

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/transforms/Transform.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/transforms/Transform.java
@@ -286,9 +286,7 @@ public abstract class Transform {
          * if regex has a capture group, only portion of value captured by first group will be
          * pseudonymized and replaced in the content
          *
-         * if regex does NOT match content, content is left as-is (NOT pseudonymized)
-         *
-         * q: safer to redact in such cases??
+         * if regex does NOT match content, content matching to JSON path is REDACTED.
          *
          * Use case: format preserving pseudonymization, namely Microsoft Graph API encodes email
          * aliases as smtp:mailbox@domain.com or SMTP:mailbox@domain.com, depending on secondary

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
@@ -109,4 +109,12 @@ public class UrlSafeTokenPseudonymEncoderTest {
         String encoded = pseudonymEncoder.encode(pseudonym);
         assertEquals("t~UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk@acme.com", encoded);
     }
+
+    @ParameterizedTest
+    void hashesMatch(String original) {
+        deterministicTokenizationStrategy.getToken(original, Function.identity());
+        pseudonymizationStrategy.getReversibleToken(original, Function.identity());
+
+
+    }
 }

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/tokens/impl/AESCBCReversibleTokenizationStrategyTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/tokens/impl/AESCBCReversibleTokenizationStrategyTest.java
@@ -4,6 +4,7 @@ import com.avaulta.gateway.pseudonyms.impl.TestUtils;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
+import com.avaulta.gateway.tokens.Token;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,19 @@ class AESCBCReversibleTokenizationStrategyTest {
                     Pseudonym.HASH_SIZE_BYTES + 32, //hash + ciphertext
                 pseudonym.length());
         });
+    }
+
+    @Test
+    void deterministicIsPrefixOfReversible() {
+        Token reversible = Token.builder()
+            .reversible(pseudonymizationStrategy.getReversibleToken("blah", Function.identity()))
+            .build();
+        Token deterministic = Token.builder()
+            .hash(deterministicTokenizationStrategy.getToken("blah", Function.identity()))
+            .build();
+
+        assertEquals(new String(encoder.encode(reversible.getHash())),
+            new String(encoder.encode(deterministic.getHash())));
     }
 
 }

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/tokens/impl/AESGCMReversibleTokenizationStrategyTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/tokens/impl/AESGCMReversibleTokenizationStrategyTest.java
@@ -4,6 +4,7 @@ import com.avaulta.gateway.pseudonyms.impl.TestUtils;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
+import com.avaulta.gateway.tokens.Token;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,19 @@ class AESGCMReversibleTokenizationStrategyTest {
                 pseudonym.length() < Pseudonym.HASH_SIZE_BYTES + 52 //hash + cipher
             );
         });
+    }
+
+    @Test
+    void deterministicIsPrefixOfReversible() {
+        Token reversible = Token.builder()
+            .reversible(pseudonymizationStrategy.getReversibleToken("blah", Function.identity()))
+            .build();
+        Token deterministic = Token.builder()
+            .hash(deterministicTokenizationStrategy.getToken("blah", Function.identity()))
+            .build();
+
+        assertEquals(new String(encoder.encode(reversible.getHash())),
+            new String(encoder.encode(deterministic.getHash())));
     }
 
 }

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/tokens/impl/AESReversibleTokenizationStrategyTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/tokens/impl/AESReversibleTokenizationStrategyTest.java
@@ -3,13 +3,16 @@ package com.avaulta.gateway.tokens.impl;
 import com.avaulta.gateway.pseudonyms.impl.TestUtils;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
+import com.avaulta.gateway.tokens.Token;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -68,5 +71,21 @@ class AESReversibleTokenizationStrategyTest {
 
         assertTrue(Arrays.equals(Arrays.copyOfRange(keyed, 0, pseudonym.length), pseudonym),
             "pseudonym is prefix of keyed");
+    }
+
+    @MethodSource("getStrategies")
+    @ParameterizedTest
+    void tokenHashesMatch(ReversibleTokenizationStrategy reversibleTokenizationStrategy) {
+        Token reversible = Token.builder()
+            .reversible(reversibleTokenizationStrategy.getReversibleToken("blahasdfasdf", Function.identity()))
+            .build();
+        Token deterministic = Token.builder()
+            .hash(deterministicTokenizationStrategy.getToken("blahasdfasdf", Function.identity()))
+            .build();
+
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+
+        assertEquals(new String(encoder.encode(reversible.getHash())),
+            new String(encoder.encode(deterministic.getHash())));
     }
 }

--- a/java/impl/impl.iml
+++ b/java/impl/impl.iml
@@ -3,26 +3,12 @@
   <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$" dumb="true">
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
-    </content>
-  </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11" inherit-compiler-output="true">
-    <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.9.1" level="project" />
   </component>
 </module>

--- a/java/java.iml
+++ b/java/java.iml
@@ -3,26 +3,12 @@
   <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$" dumb="true">
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
-    </content>
-  </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11" inherit-compiler-output="true">
-    <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.9.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.9.1" level="project" />
   </component>
 </module>


### PR DESCRIPTION
### Fixes
 - serializing 'reversible' pseudonyms in URL_SAFE_TOKEN format not compatible with LEGACY pseudonym implementation; so will failover to JSON format in those cases


### Features
  - new transform to enable preserving `proxyAddresses` format

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **yes** - some logic changes to be mindful of for users of LEGACY format


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205345791601459