### PR TITLE
use `pathTemplate` for asana

### DIFF
--- a/docs/sources/example-rules/asana/asana.yaml
+++ b/docs/sources/example-rules/asana/asana.yaml
@@ -1,11 +1,11 @@
 ---
 endpoints:
-  - pathRegex: "^/api/1.0/workspaces[?]?[^/]*$"
+  - pathTemplate: "/api/1.0/workspaces"
     allowedQueryParams:
       - "limit"
       - "offset"
       - "opt_fields"
-  - pathRegex: "^/api/1.0/users[?]?[^/]*"
+  - pathTemplate: "/api/1.0/users"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -26,7 +26,7 @@ endpoints:
           - "$.data[*].gid"
         includeReversible: true
         encoding: "JSON"
-  - pathRegex: "^/api/1.0/workspaces/[^/]*/teams?[^/]*"
+  - pathTemplate: "/api/1.0/workspaces/{workspaceId}/teams"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -37,7 +37,7 @@ endpoints:
           - "$.data[*]..name"
           - "$.data[*].description"
           - "$.data[*].html_description"
-  - pathRegex: "^/api/1.0/teams/[^/]*/projects?[^/]*"
+  - pathTemplate: "/api/1.0/teams/{teamId}/projects"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -56,7 +56,7 @@ endpoints:
           - "$.data[*].created_by"
           - "$.data[*].completed_by"
           - "$..name"
-  - pathRegex: "^/api/1.0/tasks[?][^/]*"
+  - pathTemplate: "/api/1.0/tasks"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -84,7 +84,7 @@ endpoints:
           - "$.data[*].followers[*].gid"
           - "$.data[*]..email"
         encoding: "JSON"
-  - pathRegex: "^/api/1.0/tasks/[^/]*(\\?)?[^/]*"
+  - pathTemplate: "/api/1.0/tasks/{taskId}"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -112,7 +112,7 @@ endpoints:
           - "$.data.followers[*].gid"
           - "$.data..email"
         encoding: "JSON"
-  - pathRegex: "^/api/1.0/tasks/[^/]*/stories?[^/]*"
+  - pathTemplate: "/api/1.0/tasks/{taskId}/stories"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -138,7 +138,7 @@ endpoints:
           - "$.data[*].story.created_by.gid"
           - "$.data[*]..email"
         encoding: "JSON"
-  - pathRegex: "^/api/1.0/tasks/[^/]*/subtasks?[^/]*"
+  - pathTemplate: "/api/1.0/tasks/{taskId}/subtasks"
     allowedQueryParams:
       - "limit"
       - "offset"
@@ -166,7 +166,7 @@ endpoints:
           - "$.data[*].followers[*].gid"
           - "$.data[*]..email"
         encoding: "JSON"
-  - pathRegex: "^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*"
+  - pathTemplate: "/api/1.0/workspaces/{workspaceId}/tasks/search"
     allowedQueryParams:
       - "limit"
       - "modified_at.after"

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/asana/PrebuiltSanitizerRules.java
@@ -44,7 +44,7 @@ public class PrebuiltSanitizerRules {
     );
 
     static final Endpoint WORKSPACES = Endpoint.builder()
-            .pathRegex("^/api/1.0/workspaces[?]?[^/]*$")
+            .pathTemplate("/api/1.0/workspaces")
             .allowedQueryParams(commonAllowedQueryParameters)
             //no redaction/pseudonymization
             // current UX for Asana connector lets users specify workspace by name, so can't redact it;
@@ -52,7 +52,7 @@ public class PrebuiltSanitizerRules {
             .build();
 
     static final Endpoint USERS = Endpoint.builder()
-            .pathRegex("^/api/1.0/users[?]?[^/]*")
+           .pathTemplate("/api/1.0/users")
             .allowedQueryParams(usersAllowedQueryParameters)
             .transform(Transform.Redact.builder()
                     .jsonPath("$.data[*].name")
@@ -68,7 +68,7 @@ public class PrebuiltSanitizerRules {
             .build();
 
     static final Endpoint TEAMS = Endpoint.builder()
-            .pathRegex("^/api/1.0/workspaces/[^/]*/teams?[^/]*")
+            .pathTemplate("/api/1.0/workspaces/{workspaceId}/teams")
             .allowedQueryParams(commonAllowedQueryParameters)
             .transform(Transform.Redact.builder()
                     .jsonPath("$.data[*]..name")
@@ -78,7 +78,7 @@ public class PrebuiltSanitizerRules {
             .build();
 
     static final Endpoint TEAM_PROJECTS = Endpoint.builder()
-            .pathRegex("^/api/1.0/teams/[^/]*/projects?[^/]*")
+            .pathTemplate("/api/1.0/teams/{teamId}/projects")
             .allowedQueryParams(teamsAllowedQueryParameters)
             .transform(Transform.Redact.builder()
                     .jsonPath("$.data[*].current_status")
@@ -95,25 +95,25 @@ public class PrebuiltSanitizerRules {
             .build();
 
     static final Endpoint LIST_TASKS = Endpoint.builder()
-            .pathRegex("^/api/1.0/tasks[?][^/]*")
+            .pathTemplate("/api/1.0/tasks")
             .allowedQueryParams(taskAllowedQueryParameters)
             .transforms(getTaskTransforms(true))
             .build();
 
     static final Endpoint WORKSPACE_TASKS_SEARCH = Endpoint.builder()
-            .pathRegex("^/api/1.0/workspaces/[^/]*/tasks/search?[^/]*")
+            .pathTemplate("/api/1.0/workspaces/{workspaceId}/tasks/search")
             .allowedQueryParams(searchTaskByWorkspaceAllowedQueryParameters)
             .transforms(getTaskTransforms(true))
             .build();
 
     static final Endpoint TASK = Endpoint.builder()
-            .pathRegex("^/api/1.0/tasks/[^/]*(\\?)?[^/]*")
+            .pathTemplate("/api/1.0/tasks/{taskId}")
             .allowedQueryParams(taskAllowedQueryParameters)
             .transforms(getTaskTransforms(false))
             .build();
 
     static final Endpoint TASK_STORIES = Endpoint.builder()
-            .pathRegex("^/api/1.0/tasks/[^/]*/stories?[^/]*")
+            .pathTemplate("/api/1.0/tasks/{taskId}/stories")
             .allowedQueryParams(commonAllowedQueryParameters)
             .transform(Transform.Redact.builder()
                     .jsonPath("$.data[*]..name") //just all names, really
@@ -138,7 +138,7 @@ public class PrebuiltSanitizerRules {
             .build();
 
     static final Endpoint TASK_SUBTASKS = Endpoint.builder()
-            .pathRegex("^/api/1.0/tasks/[^/]*/subtasks?[^/]*")
+            .pathTemplate("/api/1.0/tasks/{taskId}/subtasks")
             .allowedQueryParams(taskAllowedQueryParameters)
             .transforms(getTaskTransforms(true))
             .build();

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/asana/AsanaTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/asana/AsanaTests.java
@@ -38,9 +38,15 @@ public class AsanaTests extends JavaRulesTestBaseCase {
     void workspaces() {
         //String jsonString = asJson(exampleDirectoryPath, "users.json");
 
+
         String endpoint = "https://app.asana.com/api/1.0/workspaces";
         assertUrlAllowed(endpoint);
+        assertUrlAllowed(endpoint + "?limit=75&opt_fields=gid");
+        
+        //misleading - some query params are allowed
         assertUrlWithQueryParamsBlocked(endpoint);
+
+
         //nothing sanitized from this for now
     }
 

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/asana/AsanaTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/asana/AsanaTests.java
@@ -42,7 +42,7 @@ public class AsanaTests extends JavaRulesTestBaseCase {
         String endpoint = "https://app.asana.com/api/1.0/workspaces";
         assertUrlAllowed(endpoint);
         assertUrlAllowed(endpoint + "?limit=75&opt_fields=gid");
-        
+
         //misleading - some query params are allowed
         assertUrlWithQueryParamsBlocked(endpoint);
 


### PR DESCRIPTION
### Features
 - use `pathTemplate` approach, which makes for nicer looking rules than `pathRegex`
 - additional test cases
 
### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no-op rule changes**
