### PR TITLE
prep json serialization to hold 2nd hash

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
@@ -61,6 +61,19 @@ public class PseudonymizedIdentity {
      */
     String hash;
 
+    /**
+     * future-use. 0.4 hash for pseudonym, if `hash` is NOT 0.4.
+     *
+     * in the future, will be filled for LEGACY (0.3) cases; but for now, will be null (and always
+     * absent from JSON-serialized form)
+     *
+     * this will give both DEFAULT and LEGACY hashes for pseudonyms, allowing for eventual migration
+     * of LEGACY customers to DEFAULT (0.4)
+     *
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String h_4;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String original;
 


### PR DESCRIPTION
### Features
 - add extra field to `PseudonymizedIdentity`, so client will be prepared for it

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
