### PR TITLE
Added depends for avoiding issues if enabled but not applied

### DIFF
--- a/infra/examples-dev/gcp/msft-365.tf
+++ b/infra/examples-dev/gcp/msft-365.tf
@@ -1,5 +1,3 @@
-# BEGIN MSFT
-
 module "worklytics_connectors_msft_365" {
   source = "../../modules/worklytics-connectors-msft-365"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=rc-v0.4.36"
@@ -34,6 +32,10 @@ module "msft-connection-auth-federation" {
   description           = "Federation to be used for psoxy Connector - ${each.value.display_name}${local.env_qualifier}"
   issuer                = "https://accounts.google.com"
   subject               = module.psoxy.api_connector_gcp_execution_service_accounts[each.key].unique_id
+
+  depends_on = [
+    module.psoxy
+  ]
 }
 
 locals {

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -174,6 +174,10 @@ module "api_connector" {
     local.secrets_bound_as_env_vars[each.key],
     module.psoxy.secrets
   )
+
+  depends_on = [
+    google_service_account.api_connectors
+  ]
 }
 
 module "custom_api_connector_rules" {


### PR DESCRIPTION
For connectors like Google Workspace or MSFT 365, if they are marked as enabled in `tfvars` but not yet deployed, when running `terraform console` it could complain about missing keys.

Solved partially for MSFT, but still there is an error from gcp-host:

```
 Error: Invalid index
│ 
│   on ../../modules/gcp-host/main.tf line 146, in module "api_connector":
│  146:   service_account_email                 = google_service_account.api_connectors[each.key].email
│     ├────────────────
│     │ each.key is "azure-ad"
│     │ google_service_account.api_connectors is object with 6 attributes
│ 
│ The given key does not identify an element in this collection value.
``` 
It seems that for console, it doesn't like it to have them split in different files...

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something to note in `CHANGELOG.md`? 
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? 
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
