### PR TITLE
document that worklytics requires historical -sanitized content

### DIFF
--- a/docs/deployment-migration.md
+++ b/docs/deployment-migration.md
@@ -45,6 +45,8 @@ What you MUST **copy**:
     these identifiers aren't inherently PII - but the association could be considered discoverable.
   - any **custom sanitization rules** that you've set, either in your Terraform configuration
     or directly as the value of a `RULES` environment variable, SSM Parameter, or GCP Secret.
+  - historical **sanitized files** for any bulk connectors, if you wish to continue to have this
+    data analyzed by Worklytics. (eg, everything from all your `-sanitized` buckets)
 
 NOTE: you do NOT need to copy the `ENCRYPTION_KEY` value; rotation of this value should be
 expected by clients.

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -167,7 +167,7 @@ variable "bulk_input_expiration_days" {
 
 variable "bulk_sanitized_expiration_days" {
   type        = number
-  description = "Number of days after which objects in the bucket will expire. In practice, Worklytics syncs data ~weekly, so 30 day minimum for this value."
+  description = "Number of days after which objects in the bucket will expire. This should match the amount of historical data you wish for Worklytics to analyze (eg, typically multiple years)."
   default     = 1805 # 5 years; intent is 'forever', but some upperbound in case bucket is forgotten
 }
 

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -163,7 +163,7 @@ variable "bulk_input_expiration_days" {
 
 variable "bulk_sanitized_expiration_days" {
   type        = number
-  description = "Number of days after which objects in the bucket will expire"
+  description = "Number of days after which objects in the bucket will expire. This should match the amount of historical data you wish for Worklytics to analyze (eg, typically multiple years)."
   default     = 1805 # 5 years; intent is 'forever', but some upperbound in case bucket is forgotten
 }
 


### PR DESCRIPTION
### Fixes
  - `variables.tf` in examples suggests short expiration OK, although defaults to 5 yrs
  - migration guide doesn't note need to copy this data 

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
