### PR TITLE
bulk import missing setting

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -949,7 +949,7 @@ EOT
         ]
       }
       settings_to_provide = {
-        "Data Source Processing" = "badge"
+        "Parser" = "badge"
       }
       example_file = "docs/sources/bulk/badge-example.csv"
     }


### PR DESCRIPTION
### Fixes
- Fix missing `parserId` setting (as part of [inconsistent parser settings in `worklytics-connector-specs`](https://app.asana.com/0/1204795682779110/1204856079471602/f) review).

### Features
.

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? 
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? 
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
