### PR TITLE
split backend block out of main.tf in examples

### DIFF
--- a/infra/examples-dev/aws-all/backend.tf
+++ b/infra/examples-dev/aws-all/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+
+  # we recommend you use a secure location for your Terraform state (such as S3 bucket), as it
+  # may contain sensitive values (such as API keys) depending on which data sources you configure.
+  #
+  # local may be safe for production-use IFF you are executing Terraform from a secure location
+  #
+  # Please review and seek guidance from your Security team if in doubt.
+  backend "local" {
+  }
+
+  # example remove backend (this S3 bucket must already be provisioned, and AWS role executing
+  # terraform must be able to read/write to it - and use encryption key, if any)
+  #  backend "s3" {
+  #    bucket = "terraform_state_bucket" # fill with S3 bucket where you want the statefile to be
+  #    key    = "prod_state" # fill with path where you want state file to be stored
+  #    region = "us-east-1" # cannot be a variable
+  #  }
+}

--- a/infra/examples-dev/aws-all/backend.tf
+++ b/infra/examples-dev/aws-all/backend.tf
@@ -9,8 +9,9 @@ terraform {
   backend "local" {
   }
 
-  # example remove backend (this S3 bucket must already be provisioned, and AWS role executing
-  # terraform must be able to read/write to it - and use encryption key, if any)
+  # example backend (this S3 bucket must already be provisioned, and, when you run 'terraform apply'
+  # Terraform must be authenticated as an AWS principal allowed to read/write to it - and use its
+  # encryption key, if any)
   #  backend "s3" {
   #    bucket = "terraform_state_bucket" # fill with S3 bucket where you want the statefile to be
   #    key    = "prod_state" # fill with path where you want state file to be stored

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -7,22 +7,9 @@ terraform {
     }
   }
 
-  # we recommend you use a secure location for your Terraform state (such as S3 bucket), as it
-  # may contain sensitive values (such as API keys) depending on which data sources you configure.
-  #
-  # local may be safe for production-use IFF you are executing Terraform from a secure location
-  #
-  # Please review and seek guidance from your Security team if in doubt.
-  backend "local" {
-  }
-
-  # example remove backend (this S3 bucket must already be provisioned, and AWS role executing
-  # terraform must be able to read/write to it - and use encryption key, if any)
-  #  backend "s3" {
-  #    bucket = "terraform_state_bucket" # fill with S3 bucket where you want the statefile to be
-  #    key    = "prod_state" # fill with path where you want state file to be stored
-  #    region = "us-east-1" # cannot be a variable
-  #  }
+  # NOTE: Terraform backend block is configured in a separate 'backend.tf' file, as expect everyone
+  # to customize it for their own use; whereas `main.tf` should be largely consistent across
+  # deployments
 }
 
 

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -93,6 +93,10 @@ provider "aws" {
     role_arn = var.aws_assume_role_arn
   }
 
+  default_tags {
+    tags = var.default_tags
+  }
+
   allowed_account_ids = [
     var.aws_account_id
   ]

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -36,6 +36,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "default_tags" {
+  type        = map(string)
+  description = "Tags to apply to all resources created by this configuration. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags for more info."
+  default     = {}
+}
+
 variable "aws_ssm_param_root_path" {
   type        = string
   description = "root to path under which SSM parameters created by this module will be created; NOTE: shouldn't be necessary to use this is you're following recommended approach of using dedicated AWS account for deployment"

--- a/infra/examples-dev/gcp/backend.tf
+++ b/infra/examples-dev/gcp/backend.tf
@@ -1,0 +1,18 @@
+terraform {
+  # we recommend you use a secure location for your Terraform state (such as S3 bucket), as it
+  # may contain sensitive values (such as API keys) depending on which data sources you configure.
+  #
+  # local may be safe for production-use IFF you are executing Terraform from a secure location
+  #
+  # Please review and seek guidance from your Security team if in doubt.
+  backend "local" {
+  }
+
+  # example remote backend (this GCS bucket must already be provisioned, and GCP user executing
+  # terraform must be able to read/write to it)
+  #  backend "gcs" {
+  #    bucket  = "tf-state-prod"
+  #    prefix  = "proxy/terraform-state"
+  #  }
+
+}

--- a/infra/examples-dev/gcp/backend.tf
+++ b/infra/examples-dev/gcp/backend.tf
@@ -1,15 +1,18 @@
 terraform {
-  # we recommend you use a secure location for your Terraform state (such as S3 bucket), as it
-  # may contain sensitive values (such as API keys) depending on which data sources you configure.
+  # we recommend you use a secure location for your Terraform state (such as cloud storage bucket),
+  # as it may contain sensitive values (such as API keys) depending on which data sources you
+  # configure.
   #
-  # local may be safe for production-use IFF you are executing Terraform from a secure location
+  # local may be safe for production-use if and ONLY if you are executing Terraform from a secure
+  # location.
   #
   # Please review and seek guidance from your Security team if in doubt.
   backend "local" {
   }
 
-  # example remote backend (this GCS bucket must already be provisioned, and GCP user executing
-  # terraform must be able to read/write to it)
+  # example backend (this GCS bucket must already be provisioned, and gcloud CLI where terraform is
+  # applied from must be to read/write to it)
+  # see https://www.terraform.io/docs/backends/types/gcs.html for more details
   #  backend "gcs" {
   #    bucket  = "tf-state-prod"
   #    prefix  = "proxy/terraform-state"

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -6,21 +6,9 @@ terraform {
     }
   }
 
-  # we recommend you use a secure location for your Terraform state (such as S3 bucket), as it
-  # may contain sensitive values (such as API keys) depending on which data sources you configure.
-  #
-  # local may be safe for production-use IFF you are executing Terraform from a secure location
-  #
-  # Please review and seek guidance from your Security team if in doubt.
-  backend "local" {
-  }
-
-  # example remote backend (this GCS bucket must already be provisioned, and GCP user executing
-  # terraform must be able to read/write to it)
-  #  backend "gcs" {
-  #    bucket  = "tf-state-prod"
-  #    prefix  = "proxy/terraform-state"
-  #  }
+  # NOTE: Terraform backend block is configured in a separate 'backend.tf' file, as expect everyone
+  # to customize it for their own use; whereas `main.tf` should be largely consistent across
+  # deployments
 }
 
 provider "google" {

--- a/tools/init-example-full.sh
+++ b/tools/init-example-full.sh
@@ -122,5 +122,21 @@ case "$REPLY" in
 esac
 echo "" # newline
 
+# warn customer to configure their backend
+if [ -f "${TF_CONFIG_ROOT}/backend.tf" ]; then
+  printf "Your Terraform backend is configured in ${BLUE}backend.tf${NC}. We recommend you review that file and customize it to your needs. "
+  printf "By default, your configuration will use a 'local' backend, which is not recommended for production-use.\n"
+
+  if [ "$HOST_PLATFORM" == "aws" ]; then
+    printf "As you're hosting proxy in AWS, consider the ${BLUE}s3${NC} backend: https://developer.hashicorp.com/terraform/language/settings/backends/s3\n"
+  elif [ "$HOST_PLATFORM" == "gcp" ]; then
+    printf "As you're hosting proxy in GCP, consider the ${BLUE}gcs${NC} backend: https://developer.hashicorp.com/terraform/language/settings/backends/gcs\n"
+  fi
+
+  printf "Alternatively, you could replace the 'backend' block with a 'cloud' block, and use Terraform Cloud / Enterprise. See https://developer.hashicorp.com/terraform/language/settings/terraform-cloud\n"
+fi
+
 printf "Initialization complete. If you wish to remove files created by this initalization, run ${BLUE}${REPO_CLONE_BASE_DIR}tools/reset-example.sh${NC}.\n"
+
+
 

--- a/tools/release/example.sh
+++ b/tools/release/example.sh
@@ -65,7 +65,7 @@ if [[ "${EXAMPLE_TEMPLATE_REPO: -1}" != "/" ]]; then
     EXAMPLE_TEMPLATE_REPO="$EXAMPLE_TEMPLATE_REPO/"
 fi
 
-FILES_TO_COPY=("main.tf" "variables.tf" "google-workspace.tf" "google-workspace-variables.tf" "msft-365.tf" "msft-365-variables.tf" "misc-data-source-variables.tf")
+FILES_TO_COPY=("main.tf" "variables.tf" "backend.tf" "google-workspace.tf" "google-workspace-variables.tf" "msft-365.tf" "msft-365-variables.tf" "misc-data-source-variables.tf")
 
 cd "$EXAMPLE_TEMPLATE_REPO"
 CURRENT_BRANCH=$(git branch --show-current)


### PR DESCRIPTION
### Features
 - split backend block out of main.tf, to minimize the extent that which `main.tf` will vary for our examples (simplifies sending customers patches, referring to things by line number)


### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no** only affects new examples


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205437346335310