### PR TITLE
 pass gcp identity in

### DIFF
--- a/infra/examples-dev/aws-all/google-workspace-variables.tf
+++ b/infra/examples-dev/aws-all/google-workspace-variables.tf
@@ -3,6 +3,12 @@ variable "google_workspace_gcp_project_id" {
   description = "string ID of GCP project that will host oauth clients for Google Workspace API connectors; must exist"
 }
 
+variable "google_workspace_gcp_tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (GCP SA/user terraform is running as, if already known.  If omitted, will attempt to detect; detection is known to fail in GCP Cloud Shell."
+  default     = null
+}
+
 variable "google_workspace_terraform_sa_account_email" {
   type        = string
   description = "Email of GCP service account that will be used to provision GCP resources. Leave 'null' to use application default for you environment."

--- a/infra/examples-dev/aws-all/google-workspace.tf
+++ b/infra/examples-dev/aws-all/google-workspace.tf
@@ -17,6 +17,7 @@ module "worklytics_connectors_google_workspace" {
   environment_id                 = var.environment_name
   enabled_connectors             = var.enabled_connectors
   gcp_project_id                 = var.google_workspace_gcp_project_id
+  gcp_tf_runner_email            = try(coalesce(var.gcp_tf_runner_email, var.google_workspace_terraform_sa_account_email), null)
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
 }

--- a/infra/examples-dev/aws-all/google-workspace.tf
+++ b/infra/examples-dev/aws-all/google-workspace.tf
@@ -17,7 +17,7 @@ module "worklytics_connectors_google_workspace" {
   environment_id                 = var.environment_name
   enabled_connectors             = var.enabled_connectors
   gcp_project_id                 = var.google_workspace_gcp_project_id
-  gcp_tf_runner_email            = try(coalesce(var.gcp_tf_runner_email, var.google_workspace_terraform_sa_account_email), null)
+  gcp_tf_runner_email            = var.google_workspace_terraform_sa_account_email
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
 }

--- a/infra/examples-dev/gcp/google-workspace-variables.tf
+++ b/infra/examples-dev/gcp/google-workspace-variables.tf
@@ -3,6 +3,12 @@ variable "google_workspace_gcp_project_id" {
   description = "string ID of GCP project that will host oauth clients for Google Workspace API connectors; must exist"
 }
 
+variable "google_workspace_gcp_tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (GCP SA/user terraform is running as, if already known.  If omitted, will attempt to detect; detection is known to fail in GCP Cloud Shell."
+  default     = null
+}
+
 variable "google_workspace_terraform_sa_account_email" {
   type        = string
   description = "Email of GCP service account that will be used to provision GCP resources. Leave 'null' to use application default for you environment."

--- a/infra/examples-dev/gcp/google-workspace-variables.tf
+++ b/infra/examples-dev/gcp/google-workspace-variables.tf
@@ -3,12 +3,6 @@ variable "google_workspace_gcp_project_id" {
   description = "string ID of GCP project that will host oauth clients for Google Workspace API connectors; must exist"
 }
 
-variable "google_workspace_gcp_tf_runner_email" {
-  type        = string
-  description = "Email address of the Terraform Cloud runner (GCP SA/user terraform is running as, if already known.  If omitted, will attempt to detect; detection is known to fail in GCP Cloud Shell."
-  default     = null
-}
-
 variable "google_workspace_terraform_sa_account_email" {
   type        = string
   description = "Email of GCP service account that will be used to provision GCP resources. Leave 'null' to use application default for you environment."

--- a/infra/examples-dev/gcp/google-workspace.tf
+++ b/infra/examples-dev/gcp/google-workspace.tf
@@ -17,6 +17,7 @@ module "worklytics_connectors_google_workspace" {
   environment_id                 = var.environment_name
   enabled_connectors             = var.enabled_connectors
   gcp_project_id                 = var.google_workspace_gcp_project_id
+  gcp_tf_runner_email            = try(coalesce(var.google_workspace_gcp_tf_runner_email, var.google_workspace_terraform_sa_account_email), null)
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
 }

--- a/infra/examples-dev/gcp/google-workspace.tf
+++ b/infra/examples-dev/gcp/google-workspace.tf
@@ -17,7 +17,7 @@ module "worklytics_connectors_google_workspace" {
   environment_id                 = var.environment_name
   enabled_connectors             = var.enabled_connectors
   gcp_project_id                 = var.google_workspace_gcp_project_id
-  gcp_tf_runner_email            = try(coalesce(var.google_workspace_gcp_tf_runner_email, var.google_workspace_terraform_sa_account_email), null)
+  gcp_tf_runner_email            = var.google_workspace_terraform_sa_account_email
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
 }

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -102,6 +102,7 @@ module "psoxy" {
   custom_bulk_connector_arguments = var.custom_bulk_connector_arguments
   lookup_tables                   = var.lookup_tables
   custom_artifacts_bucket_name    = var.custom_artifacts_bucket_name
+  tf_runner_email                 = try(coalesce(var.gcp_tf_runner_email, var.gcp_terraform_sa_account_email), null)
   todos_as_local_files            = var.todos_as_local_files
   todo_step                       = local.max_auth_todo_step
 }

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -14,6 +14,12 @@ variable "gcp_terraform_sa_account_email" {
   }
 }
 
+variable "gcp_tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (GCP SA/user terraform is running as, if already known.  If omitted, will attempt to detect; detection is known to fail in GCP Cloud Shell."
+  default     = null
+}
+
 variable "environment_name" {
   type        = string
   description = "Qualifier to append to names/ids of resources for psoxy. If not empty, A-Za-z0-9 or - characters only. Max length 10. Useful to distinguish between deployments into same GCP project."

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -157,6 +157,7 @@ module "api_connector" {
   config_parameter_prefix               = local.config_parameter_prefix
   invoker_sa_emails                     = var.worklytics_sa_emails
   default_labels                        = var.default_labels
+  tf_runner_email                       = var.tf_runner_email
   todos_as_local_files                  = var.todos_as_local_files
 
   environment_variables = merge(
@@ -212,6 +213,7 @@ module "bulk_connector" {
   input_bucket_name             = try(each.value.input_bucket_name, null)
   sanitized_bucket_name         = try(each.value.sanitized_bucket_name, null)
   default_labels                = var.default_labels
+  tf_runner_email               = var.tf_runner_email
   todos_as_local_files          = var.todos_as_local_files
   available_memory_mb           = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 512)
 

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -1,3 +1,9 @@
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}
+
 variable "gcp_project_id" {
   type        = string
   description = "id of GCP project that will host psoxy instance"

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -146,6 +146,8 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret"
 
 module "tf_runner" {
   source = "../../modules/gcp-tf-runner"
+
+  tf_runner_email = var.tf_runner_email
 }
 
 # to provision Cloud Function, TF must be able to act as the service account that the function will

--- a/infra/modules/gcp-psoxy-bulk/variables.tf
+++ b/infra/modules/gcp-psoxy-bulk/variables.tf
@@ -123,6 +123,12 @@ variable "default_labels" {
   default     = {}
 }
 
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}
+
 variable "todos_as_local_files" {
   type        = bool
   description = "whether to render TODOs as flat files"

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -39,6 +39,8 @@ locals {
 
 module "tf_runner" {
   source = "../../modules/gcp-tf-runner"
+
+  tf_runner_email = var.tf_runner_email
 }
 
 data "google_service_account" "function" {

--- a/infra/modules/gcp-psoxy-rest/variables.tf
+++ b/infra/modules/gcp-psoxy-rest/variables.tf
@@ -140,6 +140,12 @@ variable "available_memory_mb" {
   default     = 1024
 }
 
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}
+
 variable "todos_as_local_files" {
   type        = bool
   description = "whether to render TODOs as flat files"

--- a/infra/modules/gcp-sa-auth-key-aws-secret/main.tf
+++ b/infra/modules/gcp-sa-auth-key-aws-secret/main.tf
@@ -5,6 +5,8 @@
 
 module "tf_runner" {
   source = "../../modules/gcp-tf-runner"
+
+  tf_runner_email = var.tf_runner_email
 }
 
 # grant this directly on SA, jit for when we know it is needed to create keys

--- a/infra/modules/gcp-sa-auth-key-aws-secret/variables.tf
+++ b/infra/modules/gcp-sa-auth-key-aws-secret/variables.tf
@@ -20,3 +20,9 @@ variable "kms_key_id" {
   description = "KMS key ID or ARN to use for encrypting secrets. If not provided, secrets will be encrypted by SSM with its keys (controlled by AWS)."
   default     = null
 }
+
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}

--- a/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
+++ b/infra/modules/gcp-sa-auth-key-secret-manager/main.tf
@@ -10,6 +10,8 @@
 
 module "tf_runner" {
   source = "../../modules/gcp-tf-runner"
+
+  tf_runner_email = var.tf_runner_email
 }
 
 # grant this directly on SA, jit for when we know it is needed to create keys

--- a/infra/modules/gcp-sa-auth-key-secret-manager/variables.tf
+++ b/infra/modules/gcp-sa-auth-key-secret-manager/variables.tf
@@ -34,3 +34,9 @@ variable "replica_regions" {
     "us-west1",
   ]
 }
+
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}

--- a/infra/modules/gcp-sa-auth-key/main.tf
+++ b/infra/modules/gcp-sa-auth-key/main.tf
@@ -7,6 +7,8 @@
 
 module "tf_runner" {
   source = "../../modules/gcp-tf-runner"
+
+  tf_runner_email = var.tf_runner_email
 }
 
 # grant this directly on SA, jit for when we know it is needed to create keys

--- a/infra/modules/gcp-sa-auth-key/variables.tf
+++ b/infra/modules/gcp-sa-auth-key/variables.tf
@@ -9,3 +9,9 @@ variable "rotation_days" {
   default     = 60
   description = "rotation period for the SA key, in days"
 }
+
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}

--- a/infra/modules/gcp-tf-runner/main.tf
+++ b/infra/modules/gcp-tf-runner/main.tf
@@ -5,11 +5,14 @@
 # times throughout the code base, and includes some hard-coded convention stuff that imho is better
 # to have in one place.
 
+# in GCP Cloud Console, appears to come back as { "email":"", "id":"" }
 data "google_client_openid_userinfo" "me" {
 
 }
 
 locals {
+  runner_email = coalesce(data.google_client_openid_userinfo.me.email, var.tf_runner_email, "UNABLE_TO_DETERMINE")
+
   # hacky way to determine if Terraform running as a service account or not
   tf_is_service_account = endswith(data.google_client_openid_userinfo.me.email, "iam.gserviceaccount.com")
 

--- a/infra/modules/gcp-tf-runner/variables.tf
+++ b/infra/modules/gcp-tf-runner/variables.tf
@@ -1,0 +1,5 @@
+variable "tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}

--- a/infra/modules/worklytics-connectors-google-workspace/main.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/main.tf
@@ -41,6 +41,7 @@ module "google_workspace_connection_auth" {
   source = "../../modules/gcp-sa-auth-key"
 
   service_account_id = module.google_workspace_connection[each.key].service_account_id
+  tf_runner_email    = var.gcp_tf_runner_email
 }
 
 

--- a/infra/modules/worklytics-connectors-google-workspace/variables.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/variables.tf
@@ -19,6 +19,12 @@ variable "gcp_project_id" {
   description = "id of GCP project that will host OAuth Clients for Google Workspace API connectors"
 }
 
+variable "gcp_tf_runner_email" {
+  type        = string
+  description = "Email address of the Terraform Cloud runner (GCP SA/user terraform is running as, if already known.  If omitted, will attempt to detect."
+  default     = null
+}
+
 variable "google_workspace_example_user" {
   type        = string
   description = "user to impersonate for Google Workspace API calls (null for none)"


### PR DESCRIPTION
given limitations of #545, this is the only viable solution to support service account impersonation for `google` provider case; given that impersonating service accounts is best practice, we really should get this working


### Fixes
 - data resources used by #545 don't expose email address of service account, in case that you're impersonating the service account via terraform (if application default credential is a service account, I think it will work)


### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
