### PR TITLE
parse SA for tf runner, in gcp case

### DIFF
--- a/infra/modules/gcp-tf-runner/main.tf
+++ b/infra/modules/gcp-tf-runner/main.tf
@@ -30,9 +30,8 @@ data "google_service_account_id_token" "identity" {
   target_audience = "worklytics.co/gcp-tf-runner"
 }
 
-# as this runs `terraform console` underneath, it is hacky and SLOW!!!
 data "external" "identity" {
-  program = ["./${path.module}/read-tfvars.sh", "gcp_terraform_sa_account_email"]
+  program = [ "./${path.module}/read-tfvars.sh", "gcp_terraform_sa_account_email" ]
 }
 
 # alternative ideas

--- a/infra/modules/gcp-tf-runner/read-tfvars.sh
+++ b/infra/modules/gcp-tf-runner/read-tfvars.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+variable=$1
+filename="${2:-terraform.tfvars}"
+
+# TODO: extend to look at all *.tfvars files in the directory, not just terraform.tfvars
+
+json="{"
+
+
+# Parse the file, find variable, convert it to JSON
+# this approach of parsing it from a `terr
+# alternative to parsing it ourselves would be `echo var.$variable | terraform console`, but that is
+# slow and brittle to errors/warnings from terraform console.
+if [ -f $filename ]; then
+  while IFS='=' read -r key value; do
+      # Skip commented lines
+      [[ $key =~ ^#.*$ ||  -z $key ]] && continue
+
+
+      # Remove leading and trailing whitespaces
+      key=$(echo $key | xargs)
+      value=$(echo $value | xargs)
+
+      [[ $key != "$variable" ]] && continue
+
+      # Append to json string
+      json="$json\"$key\": \"$value\","
+  done <"$filename"
+fi
+
+# Remove the trailing comma and close the JSON object
+json="${json%,}}"
+echo $json


### PR DESCRIPTION
### Features
 - parse 'gcp_terraform_sa_account_email' from `terraform.tfvars`, to support GCP terraform applies via SA impersonation

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
