### PR TITLE
fix gcp lookup

### DIFF
--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -296,6 +296,18 @@ resource "google_secret_manager_secret_version" "additional_transforms" {
   ])
 }
 
+
+
+# Needs to list versions, to find most recent
+resource "google_secret_manager_secret_iam_member" "additional_transforms_viewer" {
+  for_each = local.inputs_to_build_lookups_for
+
+  secret_id = google_secret_manager_secret.additional_transforms[each.key].id
+  member    = "serviceAccount:${module.bulk_connector[each.key].instance_sa_email}"
+  role      = "roles/secretmanager.secretViewer"
+}
+
+# needs to access payload of the versions
 resource "google_secret_manager_secret_iam_member" "additional_transforms" {
   for_each = local.inputs_to_build_lookups_for
 
@@ -303,6 +315,7 @@ resource "google_secret_manager_secret_iam_member" "additional_transforms" {
   member    = "serviceAccount:${module.bulk_connector[each.key].instance_sa_email}"
   role      = "roles/secretmanager.secretAccessor"
 }
+
 
 # END LOOKUP TABLES
 


### PR DESCRIPTION
### Fixes
 - cloud function SA can read versions of the secret, but lacks `secret.get` perm - so fails


### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **users of GCP lookup tables will see extra iam grant at next apply (but their current build not working anyways)**
