### PR TITLE
url-safe hash-only pseudonym encoding format

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PsoxyModule.java
@@ -7,6 +7,7 @@ import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
 import co.worklytics.psoxy.storage.BulkDataSanitizerFactory;
 import co.worklytics.psoxy.storage.impl.BulkDataSanitizerFactoryImpl;
+import com.avaulta.gateway.pseudonyms.impl.Base64UrlSha256HashPseudonymEncoder;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
 import com.avaulta.gateway.rules.ParameterSchemaUtils;
@@ -220,6 +221,12 @@ public class PsoxyModule {
     @Singleton
     UrlSafeTokenPseudonymEncoder urlSafeTokenPseudonymEncoder() {
         return new UrlSafeTokenPseudonymEncoder();
+    }
+
+    @Provides
+    @Singleton
+    Base64UrlSha256HashPseudonymEncoder base64UrlSha256HashPseudonymEncoder() {
+        return new Base64UrlSha256HashPseudonymEncoder();
     }
 
 

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -452,12 +452,14 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
                 return configuration.jsonProvider().toJson(pseudonymizedIdentity);
             } else if (transformOptions.getEncoding() == PseudonymEncoder.Implementations.URL_SAFE_TOKEN) {
                 if (pseudonymizedIdentity.getReversible() != null
-                        && getPseudonymizer().getOptions().getPseudonymImplementation() == PseudonymImplementation.LEGACY) {
+                    && getPseudonymizer().getOptions().getPseudonymImplementation() == PseudonymImplementation.LEGACY) {
                     // can't do reversible encoding with legacy pseudonym implementation, in URL_SAFE_TOKEN
                     return configuration.jsonProvider().toJson(pseudonymizedIdentity);
                 }
                 //exploit that already reversibly encoded, including prefix
                 return ObjectUtils.firstNonNull(pseudonymizedIdentity.getReversible(), pseudonymizedIdentity.getHash());
+            } else if (transformOptions.getEncoding() == PseudonymEncoder.Implementations.URL_SAFE_HASH_ONLY) {
+                return pseudonymizedIdentity.getHash();
             } else {
                 throw new RuntimeException("Unsupported pseudonym implementation: " + transformOptions.getEncoding());
             }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -6,6 +6,7 @@ import co.worklytics.psoxy.PseudonymizerImplFactory;
 import co.worklytics.psoxy.rules.CsvRules;
 import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
 import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
+import com.avaulta.gateway.pseudonyms.impl.Base64UrlSha256HashPseudonymEncoder;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.BulkDataRules;
 import com.avaulta.gateway.rules.ColumnarRules;
@@ -57,6 +58,8 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
 
     @Inject
     UrlSafeTokenPseudonymEncoder urlSafeTokenPseudonymEncoder;
+    @Inject
+    Base64UrlSha256HashPseudonymEncoder base64UrlSha256HashPseudonymEncoder;
 
     @Inject
     PseudonymizerImplFactory pseudonymizerImplFactory;
@@ -311,6 +314,8 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
                         } else {
                             return urlSafeTokenPseudonymEncoder.encode(identity.asPseudonym());
                         }
+                    } else if (rules.getPseudonymFormat() == PseudonymEncoder.Implementations.URL_SAFE_HASH_ONLY) {
+                        return base64UrlSha256HashPseudonymEncoder.encode(identity.asPseudonym());
                     } else {
                         //JSON
                         return objectMapper.writeValueAsString(identity);

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -420,6 +420,10 @@ class RESTApiSanitizerImplTest {
             "DEFAULT,test,true,URL_SAFE_TOKEN,p~Tt8H7clbL9y8ryN4_RLYrCEsKqbjJsWcPmKb4wOdZDKAHyevsJLhRTypmrf-DpBZ",
             "DEFAULT,alice@acme.com,true,URL_SAFE_TOKEN,p~UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMnKYUk8FJevl3wvFyZY0eF-@acme.com",
             "DEFAULT,alice@acme.com,false,URL_SAFE_TOKEN,UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk",
+            "DEFAULT,alice@acme.com,true,URL_SAFE_HASH_ONLY,UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk",
+            "DEFAULT,alice@acme.com,false,URL_SAFE_HASH_ONLY,UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk",
+            //TODO: add an interesting case where base64 and base64-url encodings differ
+            //"DEFAULT,blahBlahBlah,false,URL_SAFE_HASH_ONLY,UFdK0TvVTvZ23c6QslyCy0o2MSq2DRtDjEXfTPJyyMk",
         }
     )
     @ParameterizedTest

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/PseudonymEncoder.java
@@ -1,6 +1,7 @@
 package com.avaulta.gateway.pseudonyms;
 
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
+import com.avaulta.gateway.pseudonyms.impl.Base64UrlSha256HashPseudonymEncoder;
 
 public interface PseudonymEncoder {
 
@@ -9,7 +10,6 @@ public interface PseudonymEncoder {
         /**
          * encode Pseudonym as a JSON-object
          *
-         * @see UrlSafeTokenPseudonymEncoder
          */
         JSON,
 
@@ -19,6 +19,16 @@ public interface PseudonymEncoder {
          * @see UrlSafeTokenPseudonymEncoder
          */
         URL_SAFE_TOKEN,
+
+        /**
+         * encode Pseudonym's hash as base64-URL, without padding.
+         *
+         * (this is equivalent to the URL_SAFE_TOKEN format, but without prefix (`t~`/`p~`); and
+         * without any additional data, such as encrypted form of pseudonym OR any form of domain)
+         *
+         * @see Base64UrlSha256HashPseudonymEncoder
+         */
+        URL_SAFE_HASH_ONLY,
     }
 
     String encode(Pseudonym pseudonym);


### PR DESCRIPTION
### Features
  - add support for url-safe hash-only pseudonym encoding format (use case to simplify lookup table JOINs)


### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205734997101067