### PR TITLE
fix java21

### DIFF
--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Compile
         working-directory: java/
         run: |
-          mvn clean compile -T 2C -Dversions.logOutput=false -DprocessDependencies=false -DprocessDependencyManagement=false
+          mvn clean compile -T 2C -Dversions.logOutput=false
       - name: Test
         working-directory: java/
         run: |

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -29,6 +29,10 @@ jobs:
           java-version: ${{ inputs.java-version }}
           # https://github.com/actions/setup-java#supported-distributions
           distribution: zulu
+      - name: Clear our artifacts from Maven cache # q: does this work!?!?!
+        run: |
+          rm -rf ~/.m2/repository/co/worklytics/
+          rm -rf ~/.m2/repository/com/avaulta/
       - name: Compile
         working-directory: java/
         run: |

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -29,16 +29,6 @@ jobs:
           java-version: ${{ inputs.java-version }}
           # https://github.com/actions/setup-java#supported-distributions
           distribution: zulu
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-v1-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-v1-
-      - name: Clear our artifacts from Maven cache # q: does this work!?!?!
-        run: |
-          rm -rf ~/.m2/repository/co/worklytics/
-          rm -rf ~/.m2/repository/com/avaulta/
       - name: Compile
         working-directory: java/
         run: |

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -11,7 +11,6 @@ on:
     branches:
       - 'main'
       - 'rc-*'
-      - 's162-fix-java21'
 
 jobs:
   # Java 11 - Oracle support ended 30 Sept 2023
@@ -25,22 +24,12 @@ jobs:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '17'
-      
-#  ci_java18:
-#    uses: ./.github/workflows/build-java.yaml
-#    with:
-#      java-version: '18'
-#      
-#  ci_java19:
-#    uses: ./.github/workflows/build-java.yaml
-#    with:
-#      java-version: '19'
 
   # Java 20 - support ended 19 Sept 2023
-  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that. 
+  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that.
   # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
-  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17? 
-  
+  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17?
+
 #  ci_java20:
 #    uses: ./.github/workflows/build-java.yaml
 #    with:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -41,7 +41,7 @@ jobs:
   # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
   # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17? 
   
-   ci_java20:
+  ci_java20:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '20'

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -25,26 +25,26 @@ jobs:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '17'
-
+      
   ci_java18:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '18'
-
+      
   ci_java19:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '19'
 
   # Java 20 - support ended 19 Sept 2023
-  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that.
+  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that. 
   # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
-  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17?
-
-  # ci_java20:
-  #  uses: ./.github/workflows/build-java.yaml
-  #  with:
-  #    java-version: '20'
+  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17? 
+  
+   ci_java20:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '20'
 
   # Java 21 - released 19 Sept 2023, supported until Sept 2028 (LTS)
   ci_java21:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -26,25 +26,25 @@ jobs:
     with:
       java-version: '17'
       
-  ci_java18:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '18'
-      
-  ci_java19:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '19'
+#  ci_java18:
+#    uses: ./.github/workflows/build-java.yaml
+#    with:
+#      java-version: '18'
+#      
+#  ci_java19:
+#    uses: ./.github/workflows/build-java.yaml
+#    with:
+#      java-version: '19'
 
   # Java 20 - support ended 19 Sept 2023
   # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that. 
   # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
   # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17? 
   
-  ci_java20:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '20'
+#  ci_java20:
+#    uses: ./.github/workflows/build-java.yaml
+#    with:
+#      java-version: '20'
 
   # Java 21 - released 19 Sept 2023, supported until Sept 2028 (LTS)
   ci_java21:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -25,26 +25,26 @@ jobs:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '17'
-      
+
   ci_java18:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '18'
-      
+
   ci_java19:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '19'
 
   # Java 20 - support ended 19 Sept 2023
-  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that. 
+  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that.
   # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
-  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17? 
-  
-  ci_java20:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '20'
+  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17?
+
+  # ci_java20:
+  #  uses: ./.github/workflows/build-java.yaml
+  #  with:
+  #    java-version: '20'
 
   # Java 21 - released 19 Sept 2023, supported until Sept 2028 (LTS)
   ci_java21:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -14,7 +14,7 @@ on:
       - 's162-fix-java21'
 
 jobs:
-  # Java 11 - supported until 30 Sept 2023
+  # Java 11 - Oracle support ended 30 Sept 2023
   ci_java11:
     uses: ./.github/workflows/build-java.yaml
     with:
@@ -25,10 +25,22 @@ jobs:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '17'
+      
+  ci_java18:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '18'
+      
+  ci_java19:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '19'
 
-  # NOTE: java 19 support ended 21 Mar 2023; it's known to be incompatible with our code
-
-  # Java 20 - released 21 Mar 2023, supported until 19 Sept 2023
+  # Java 20 - support ended 19 Sept 2023
+  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that. 
+  # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
+  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17? 
+  
   ci_java20:
     uses: ./.github/workflows/build-java.yaml
     with:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -11,7 +11,7 @@ on:
     branches:
       - 'main'
       - 'rc-*'
-      - 's152-java-20-test'
+      - 's162-fix-java21'
 
 jobs:
   # Java 11 - supported until 30 Sept 2023
@@ -34,3 +34,8 @@ jobs:
     with:
       java-version: '20'
 
+  # Java 21 - released 19 Sept 2023, supported until Sept 2028 (LTS)
+  ci_java21:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '21'

--- a/.github/workflows/ci-java.yaml
+++ b/.github/workflows/ci-java.yaml
@@ -11,4 +11,4 @@ jobs:
   ci_java:
     uses: ./.github/workflows/build-java.yaml
     with:
-      java-version: '17'
+      java-version: '21' # 21 is LTS, so fair that this should be our default

--- a/.github/workflows/ci-java8-core.yaml
+++ b/.github/workflows/ci-java8-core.yaml
@@ -26,18 +26,6 @@ jobs:
           java-version: ${{ env.java-version }}
           # https://github.com/actions/setup-java#supported-distributions
           distribution: zulu
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-v1-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-v1-
-      - name: Clear our artifacts from Maven cache # q: does this work!?!?!
-        working-directory: java/
-        run: |
-          rm -rf ~/.m2/repository/co/worklytics/
-          rm -rf ~/.m2/repository/com/avaulta/
-          mvn clean
       - name: Compile gateway-core
         working-directory: java/gateway-core
         run: |
@@ -54,6 +42,10 @@ jobs:
         run: |
           mvn compile ${{ env.compile-profile }}-T 2C -Dversions.logOutput=false \
             -DprocessDependencies=false -DprocessDependencyManagement=false
+
+# JDK-8 core tests failing after fixes to support JDK-21 (see https://github.com/Worklytics/psoxy/pull/572)
+# not bothering to fix for now, as only used as library in linked builds - deploying to jre-8 is not supported
+# (and actually it compiles, it's just the tests the fail)
       - name: Test core
         working-directory: java/core
         run: |

--- a/.github/workflows/ci-java8-core.yaml
+++ b/.github/workflows/ci-java8-core.yaml
@@ -15,7 +15,7 @@ jobs:
   ci_java8_core:
     env:
       compile-profile: '-P java8 ' # NOTE: trailing space is important
-      java-version: '17'
+      java-version: '17' # build w java 17, but pom configured to still build java 8 byte code
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You will need all of the following in your deployment environment (eg, your lapt
 |----------------------------------------------|---------------|---------------------------|
 | [git](https://git-scm.com/)                  | 2.17+         | `git --version`           |
 | [Maven](https://maven.apache.org/)           | 3.6+          | `mvn -v`                 |
-| [Java 11+ JDK](https://openjdk.org/install/) | 11+, <=20     | `mvn -v &#124; grep Java` |
+| [Java 11+ JDK](https://openjdk.org/install/) | 11+, <=21     | `mvn -v &#124; grep Java` |
 | [Terraform](https://www.terraform.io/)       | 1.3.x, <= 1.5 | `terraform version`       |
 
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,16 @@ command line tools.
 
 You will need all of the following in your deployment environment (eg, your laptop):
 
-| Tool                                         | Version       | Test Command              |
-|----------------------------------------------|---------------|---------------------------|
-| [git](https://git-scm.com/)                  | 2.17+         | `git --version`           |
-| [Maven](https://maven.apache.org/)           | 3.6+          | `mvn -v`                 |
-| [Java 11+ JDK](https://openjdk.org/install/) | 11+, <=21     | `mvn -v &#124; grep Java` |
-| [Terraform](https://www.terraform.io/)       | 1.3.x, <= 1.5 | `terraform version`       |
+| Tool                                         | Version                | Test Command              |
+|----------------------------------------------|------------------------|---------------------------|
+| [git](https://git-scm.com/)                  | 2.17+                  | `git --version`           |
+| [Maven](https://maven.apache.org/)           | 3.6+                   | `mvn -v`                 |
+| [Java 11+ JDK](https://openjdk.org/install/) | 11, 17, 21 (see notes) | `mvn -v &#124; grep Java` |
+| [Terraform](https://www.terraform.io/)       | 1.3.x, <= 1.5          | `terraform version`       |
 
+NOTE: we will support Java versions for duration of official support windows; as of Nov 2023, we
+still support java 11 but may end this at any time. Minor versions, such as 12-16, and 18-20, which
+are out of official support, may work but are not routinely tested.
 
 NOTE: Using `terraform` is not strictly necessary, but it is the only supported method. You may
 provision your infrastructure via your host's CLI, web console, or another infrastructure provisioning

--- a/README.md
+++ b/README.md
@@ -201,16 +201,17 @@ command line tools.
 
 You will need all of the following in your deployment environment (eg, your laptop):
 
-| Tool                                         | Version                | Test Command              |
-|----------------------------------------------|------------------------|---------------------------|
-| [git](https://git-scm.com/)                  | 2.17+                  | `git --version`           |
-| [Maven](https://maven.apache.org/)           | 3.6+                   | `mvn -v`                 |
-| [Java 11+ JDK](https://openjdk.org/install/) | 11, 17, 21 (see notes) | `mvn -v &#124; grep Java` |
-| [Terraform](https://www.terraform.io/)       | 1.3.x, <= 1.5          | `terraform version`       |
+| Tool                                             | Version                | Test Command              |
+|--------------------------------------------------|------------------------|---------------------------|
+| [git](https://git-scm.com/)                      | 2.17+                  | `git --version`           |
+| [Maven](https://maven.apache.org/)               | 3.6+                   | `mvn -v`                 |
+| [Java JDK 11+ LTS](https://openjdk.org/install/) | 11, 17, 21 (see notes) | `mvn -v &#124; grep Java` |
+| [Terraform](https://www.terraform.io/)           | 1.3.x, <= 1.5          | `terraform version`       |
 
-NOTE: we will support Java versions for duration of official support windows; as of Nov 2023, we
-still support java 11 but may end this at any time. Minor versions, such as 12-16, and 18-20, which
-are out of official support, may work but are not routinely tested.
+NOTE: we will support Java versions for duration of official support windows, in particular the
+LTS versions. As of Nov 2023, we  still support java 11 but may end this at any time. Minor
+versions, such as 12-16, and 18-20, which are out of official support, may work but are not
+routinely tested.
 
 NOTE: Using `terraform` is not strictly necessary, but it is the only supported method. You may
 provision your infrastructure via your host's CLI, web console, or another infrastructure provisioning

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -164,6 +164,26 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- JUnit Jupiter API for writing tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit Jupiter Engine for running tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
@@ -179,15 +199,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.2.2</version>
                 <configuration>
                     <!-- rerun failing tests twice more -->
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
-                    <includes>
-                        <!-- defaults: **/Test*.java, **/*Test.java, **/*TestCase.java -->
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test.java</include>
-                    </includes>
                     <systemProperties>
                         <property>
                             <name>java.util.logging.config.file</name>

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
@@ -5,6 +5,7 @@ import co.worklytics.psoxy.gateway.BulkModeConfigProperty;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.psoxy.storage.StorageHandler;
+import co.worklytics.test.MockModules;
 import co.worklytics.test.TestUtils;
 
 import com.avaulta.gateway.rules.ColumnarRules;
@@ -34,10 +35,13 @@ class RulesUtilsTest {
     @Inject RulesUtils utils;
     @Inject @Named("ForYAML")
     ObjectMapper yamlMapper;
+    @Inject
+    ConfigService config;
 
     @Singleton
     @Component(modules = {
         PsoxyModule.class,
+        MockModules.ForConfigService.class
     })
     public interface Container {
         void inject( RulesUtilsTest test);
@@ -99,8 +103,6 @@ class RulesUtilsTest {
         YAML_RECORD,
     })
     void getRulesFromConfig(String encoded) {
-
-        ConfigService config = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         when(config.getConfigPropertyAsOptional(eq(ProxyConfigProperty.RULES)))
             .thenReturn(Optional.of(encoded));
         when(config.getConfigPropertyOrError(eq(ProxyConfigProperty.SOURCE)))
@@ -126,7 +128,6 @@ class RulesUtilsTest {
     @Test
     public void parseYamlRulesFromConfig() {
 
-        ConfigService config = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.ADDITIONAL_TRANSFORMS)))
             .thenReturn(Optional.of(yamlMapper.writeValueAsString(transformList)));
 

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/RulesUtilsTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockMakers;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,8 +27,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class RulesUtilsTest {
 
@@ -100,7 +100,7 @@ class RulesUtilsTest {
     })
     void getRulesFromConfig(String encoded) {
 
-        ConfigService config = mock(ConfigService.class);
+        ConfigService config = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         when(config.getConfigPropertyAsOptional(eq(ProxyConfigProperty.RULES)))
             .thenReturn(Optional.of(encoded));
         when(config.getConfigPropertyOrError(eq(ProxyConfigProperty.SOURCE)))
@@ -126,7 +126,7 @@ class RulesUtilsTest {
     @Test
     public void parseYamlRulesFromConfig() {
 
-        ConfigService config = mock(ConfigService.class);
+        ConfigService config = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.ADDITIONAL_TRANSFORMS)))
             .thenReturn(Optional.of(yamlMapper.writeValueAsString(transformList)));
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -7,11 +7,14 @@ import co.worklytics.psoxy.gateway.StorageEventRequest;
 import co.worklytics.test.MockModules;
 import com.google.common.collect.ImmutableMap;
 import dagger.Component;
+import dagger.Module;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockMakers;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -23,8 +26,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class StorageHandlerTest {
 
@@ -40,7 +42,17 @@ class StorageHandlerTest {
     }
 
 
+    @Mock(mockMaker = MockMakers.SUBCLASS)
+    InputStreamReader mockReader;
+
+    @Mock(mockMaker = MockMakers.SUBCLASS)
+    OutputStreamWriter mockWriter;
+
+    @Mock(mockMaker = MockMakers.SUBCLASS)
+
+
     @Inject
+
     ConfigService config;
 
     @Inject
@@ -76,8 +88,7 @@ class StorageHandlerTest {
 
 
 
-        StorageEventRequest request = handler.buildRequest(mock(InputStreamReader.class),
-            mock(OutputStreamWriter.class), "bucket-in", "directory/file.csv", handler.buildDefaultTransform());
+        StorageEventRequest request = handler.buildRequest(mockReader, mockWriter, "bucket-in", "directory/file.csv", handler.buildDefaultTransform());
 
         assertEquals("directory/file.csv", request.getDestinationObjectPath());
     }
@@ -100,7 +111,7 @@ class StorageHandlerTest {
         when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.OUTPUT_BASE_PATH)))
             .thenReturn(Optional.ofNullable(outputBasePath));
 
-        StorageEventRequest request = handler.buildRequest(mock(InputStreamReader.class), mock(OutputStreamWriter.class), "bucket-in", "directory/file.csv", handler.buildDefaultTransform());
+        StorageEventRequest request = handler.buildRequest(mockReader, mockWriter, "bucket-in", "directory/file.csv", handler.buildDefaultTransform());
 
         assertEquals("bucket-in", request.getSourceBucketName());
         assertEquals("directory/file.csv", request.getSourceObjectPath());

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockMakers;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -40,8 +41,7 @@ import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class BulkDataSanitizerImplTest {
 
@@ -78,7 +78,7 @@ public class BulkDataSanitizerImplTest {
     public interface ForPlaceholderRules {
         @Provides @Singleton
         static ColumnarRules ruleSet() {
-            return mock(ColumnarRules.class);
+            return mock(ColumnarRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         }
     }
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -78,7 +78,11 @@ public class BulkDataSanitizerImplTest {
     public interface ForPlaceholderRules {
         @Provides @Singleton
         static ColumnarRules ruleSet() {
-            return mock(ColumnarRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            if (MockModules.isAtLeastJava17()) {
+                return mock(ColumnarRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            } else {
+                return mock(ColumnarRules.class);
+            }
         }
     }
 

--- a/java/core/src/test/java/co/worklytics/test/MockModules.java
+++ b/java/core/src/test/java/co/worklytics/test/MockModules.java
@@ -16,6 +16,7 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.JavaVersion;
 import org.mockito.MockMakers;
 
 import javax.inject.Singleton;
@@ -24,11 +25,23 @@ import static org.mockito.Mockito.*;
 
 public class MockModules {
 
+
+    public static boolean isAtLeastJava17() {
+        JavaVersion version = JavaVersion.valueOf(System.getProperty("java.version"));
+        return version.atLeast(JavaVersion.JAVA_17);
+    }
+
     @Module
     public interface ForConfigService {
         @Provides @Singleton
         static ConfigService configService() {
-            ConfigService mock = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            ConfigService mock;
+
+            if (isAtLeastJava17()) {
+                mock = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            } else {
+                mock = mock(ConfigService.class);
+            }
             TestModules.withMockEncryptionKey(mock);
             return mock;
         }
@@ -57,12 +70,20 @@ public class MockModules {
         @Provides @Singleton
         static BulkDataRules bulkDataRules() {
             // why is INLINE mock maker a propblem ehre???
-            return mock(ColumnarRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            if (isAtLeastJava17()) {
+                return mock(ColumnarRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            } else {
+                return mock(ColumnarRules.class);
+            }
         }
 
         @Provides @Singleton
         static RESTRules restRules() {
-            return mock(RESTRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            if (isAtLeastJava17()) {
+                return mock(RESTRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+            } else {
+                return mock(RESTRules.class);
+            }
         }
 
         @Provides @Singleton

--- a/java/core/src/test/java/co/worklytics/test/MockModules.java
+++ b/java/core/src/test/java/co/worklytics/test/MockModules.java
@@ -16,11 +16,11 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
 import lombok.SneakyThrows;
+import org.mockito.MockMakers;
 
 import javax.inject.Singleton;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class MockModules {
 
@@ -28,7 +28,7 @@ public class MockModules {
     public interface ForConfigService {
         @Provides @Singleton
         static ConfigService configService() {
-            ConfigService mock = mock(ConfigService.class);
+            ConfigService mock = mock(ConfigService.class, withSettings().mockMaker(MockMakers.SUBCLASS));
             TestModules.withMockEncryptionKey(mock);
             return mock;
         }
@@ -56,12 +56,13 @@ public class MockModules {
 
         @Provides @Singleton
         static BulkDataRules bulkDataRules() {
-            return mock(ColumnarRules.class);
+            // why is INLINE mock maker a propblem ehre???
+            return mock(ColumnarRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         }
 
         @Provides @Singleton
         static RESTRules restRules() {
-            return mock(RESTRules.class);
+            return mock(RESTRules.class, withSettings().mockMaker(MockMakers.SUBCLASS));
         }
 
         @Provides @Singleton

--- a/java/core/src/test/java/co/worklytics/test/MockModules.java
+++ b/java/core/src/test/java/co/worklytics/test/MockModules.java
@@ -17,6 +17,7 @@ import dagger.Provides;
 import dagger.multibindings.IntoSet;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
 import org.mockito.MockMakers;
 
 import javax.inject.Singleton;
@@ -26,9 +27,11 @@ import static org.mockito.Mockito.*;
 public class MockModules {
 
 
-    public static boolean isAtLeastJava17() {
-        JavaVersion version = JavaVersion.valueOf(System.getProperty("java.version"));
-        return version.atLeast(JavaVersion.JAVA_17);
+    /**
+     * helper to downgrade behavior of mockito to pre-java17 behavior
+     */
+    public static boolean isAtLeastJava17(){
+        return SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_17);
     }
 
     @Module

--- a/java/gateway-core/pom.xml
+++ b/java/gateway-core/pom.xml
@@ -102,29 +102,36 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.junit/junit-bom -->
+
+        <!-- JUnit Jupiter API for writing tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${dependency.junit-jupiter.version}</version>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
 
-    </dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
 
+        <!-- JUnit Jupiter Engine for running tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.2.2</version>
                 <configuration>
-                    <includes>
-                        <!-- defaults: **/Test*.java, **/*Test.java, **/*TestCase.java -->
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test.java</include>
-                    </includes>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>

--- a/java/impl/aws/pom.xml
+++ b/java/impl/aws/pom.xml
@@ -150,6 +150,26 @@
 
 
         <!-- Test dependencies -->
+        <!-- JUnit Jupiter API for writing tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit Jupiter Engine for running tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/ParameterStoreConfigServiceTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/ParameterStoreConfigServiceTest.java
@@ -2,9 +2,11 @@ package co.worklytics.psoxy.aws;
 
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockMakers;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.*;
@@ -15,12 +17,16 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ParameterStoreConfigServiceTest {
 
 
+    SsmClient client;
+    @BeforeEach
+    public void setup() {
+       client = mock(SsmClient.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+    }
 
     @CsvSource({
         ",ACCESS_TOKEN",
@@ -51,7 +57,6 @@ class ParameterStoreConfigServiceTest {
         // based on those assumptions, which is fairly simple
 
         //setup test
-        SsmClient client = mock(SsmClient.class);
         parameterStoreConfigService.client = client;
         parameterStoreConfigService.clock = Clock.systemUTC();
         when(client.putParameter(any(PutParameterRequest.class)))
@@ -102,7 +107,6 @@ class ParameterStoreConfigServiceTest {
             new ParameterStoreConfigService("");
 
         //setup test
-        SsmClient client = mock(SsmClient.class);
         parameterStoreConfigService.client = client;
         parameterStoreConfigService.clock = Clock.systemUTC();
         parameterStoreConfigService.envVarsConfig = new EnvVarsConfigService();

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/ParameterStoreConfigServiceTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/ParameterStoreConfigServiceTest.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.aws;
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
 import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,8 +25,7 @@ class ParameterStoreConfigServiceTest {
 
 
     public static boolean isAtLeastJava17() {
-        JavaVersion version = JavaVersion.valueOf(System.getProperty("java.version"));
-        return version.atLeast(JavaVersion.JAVA_17);
+        return SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_17);
     }
     SsmClient client;
     @BeforeEach

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/ParameterStoreConfigServiceTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/ParameterStoreConfigServiceTest.java
@@ -2,6 +2,7 @@ package co.worklytics.psoxy.aws;
 
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
+import org.apache.commons.lang3.JavaVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,10 +23,18 @@ import static org.mockito.Mockito.*;
 class ParameterStoreConfigServiceTest {
 
 
+    public static boolean isAtLeastJava17() {
+        JavaVersion version = JavaVersion.valueOf(System.getProperty("java.version"));
+        return version.atLeast(JavaVersion.JAVA_17);
+    }
     SsmClient client;
     @BeforeEach
     public void setup() {
-       client = mock(SsmClient.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+        if (isAtLeastJava17()) {
+            client = mock(SsmClient.class, withSettings().mockMaker(MockMakers.SUBCLASS));
+        } else {
+            client = mock(SsmClient.class);
+        }
     }
 
     @CsvSource({

--- a/java/impl/cmd-line/pom.xml
+++ b/java/impl/cmd-line/pom.xml
@@ -88,6 +88,27 @@
         </dependency>
 
 
+
+        <!-- JUnit Jupiter API for writing tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit Jupiter Engine for running tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
@@ -151,15 +172,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.2.2</version>
                 <configuration>
                     <!-- rerun failing tests twice more -->
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
-                    <includes>
-                        <!-- defaults: **/Test*.java, **/*Test.java, **/*TestCase.java -->
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test.java</include>
-                    </includes>
                     <systemProperties>
                         <property>
                             <name>java.util.logging.config.file</name>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -108,12 +108,35 @@
             <artifactId>google-cloud-secretmanager</artifactId>
         </dependency>
 
+
+        <!-- JUnit Jupiter API for writing tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit Jupiter Engine for running tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${dependency.mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+
+
     </dependencies>
 
     <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,8 +23,8 @@
         <dependency.google-cloud-bom.version>0.198.0</dependency.google-cloud-bom.version>
         <dependency.google-http-client.version>1.43.3</dependency.google-http-client.version>
         <dependency.google-auth-library-oauth2-http.version>1.18.0</dependency.google-auth-library-oauth2-http.version>
-        <dependency.junit-jupiter.version>5.9.1</dependency.junit-jupiter.version>
-        <dependency.mockito-junit-jupiter.version>4.11.0</dependency.mockito-junit-jupiter.version>
+        <dependency.junit-jupiter.version>5.10.1</dependency.junit-jupiter.version>
+        <dependency.mockito-junit-jupiter.version>5.0.0</dependency.mockito-junit-jupiter.version>
         <dependency.json-path.version>2.8.0</dependency.json-path.version>
         <dependency.bettercloud-vault-java-driver>5.1.0</dependency.bettercloud-vault-java-driver>
     </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <revision>0.4.41</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dependency.lombok.version>1.18.28</dependency.lombok.version>
+        <dependency.lombok.version>1.18.30</dependency.lombok.version> <!-- 1.18.30 is min compatible with jdk 21+ -->
         <dependency.dagger.version>2.40.5</dependency.dagger.version>
         <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <dependency.apache-commons-lang3.version>3.12.0</dependency.apache-commons-lang3.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,7 +15,7 @@
         <dependency.lombok.version>1.18.30</dependency.lombok.version> <!-- 1.18.30 is min compatible with jdk 21+ -->
         <dependency.dagger.version>2.40.5</dependency.dagger.version>
         <dependency.jackson.version>2.15.2</dependency.jackson.version>
-        <dependency.apache-commons-lang3.version>3.12.0</dependency.apache-commons-lang3.version>
+        <dependency.apache-commons-lang3.version>3.13.0</dependency.apache-commons-lang3.version> <!-- July 2023 release, doesn't actually have constants for java after 17 yet -->
         <dependency.apache-commons-csv.version>1.10.0</dependency.apache-commons-csv.version>
         <dependency.guava.version>32.0.1-jre</dependency.guava.version>
         <dependency.commons-io.version>2.13.0</dependency.commons-io.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,6 +29,19 @@
         <dependency.bettercloud-vault-java-driver>5.1.0</dependency.bettercloud-vault-java-driver>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- https://mvnrepository.com/artifact/org.junit/junit-bom -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${dependency.junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>gateway-core</module>
         <module>core</module>
@@ -87,12 +100,4 @@
         </plugins>
     </build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${dependency.junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -39,7 +39,7 @@ printf "\n"
 JAVA_VERSION=`mvn -v | grep Java`
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
-printf "\t- if that is a Java version < 11, you must upgrade to 11. Java >= 11, <= 20 are supported.\n"
+printf "\t- if that is a Java version < 11, you must upgrade to 11. Java >= 11, <= 21 are supported.\n"
 printf "\t- if you have a Java JDK of the right version installed on your machine *other* than the one referenced there, set your ${BLUE}JAVA_HOME${NC} to its location.\n"
 
 printf "\n"

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -37,10 +37,15 @@ printf "\t- Maven is used to build the package that will be deployed to your hos
 printf "\n"
 
 JAVA_VERSION=`mvn -v | grep Java`
+JAVA_VERSION_MAJOR=$(echo $JAVA_VERSION | sed -n 's/^Java version: \([0-9]*\).*/\1/p')}
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
-printf "\t- if that is a Java version < 11, you must upgrade to 11. Java >= 11, <= 21 are supported.\n"
-printf "\t- if you have a Java JDK of the right version installed on your machine *other* than the one referenced there, set your ${BLUE}JAVA_HOME${NC} to its location.\n"
+
+if [[ "$JAVA_VERSION_MAJOR" != 11 && "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21 ]]; then
+  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires a supported version of Java 11 or later; as of Nov 2023, this includes Java 11, 17, or 21. See https://maven.apache.org/install.html\n"
+  if $HOMEBREW_AVAILABLE; then printf "or as you have Homebrew available, run ${BLUE}brew install openjdk@17${NC}\n"; fi
+  printf "If you have an alternative JDK installed, then you must update your ${BLUE}JAVA_HOME${NC} environment variable to point to it.\n"
+fi
 
 printf "\n"
 

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -22,22 +22,31 @@ if ! terraform -v &> /dev/null ; then
   exit 1
 fi
 
+# Check Maven installation
+
 if ! mvn -v &> /dev/null ; then
   printf "${RED}Maven not installed.${NC} See https://maven.apache.org/install.html\n"
   if $HOMEBREW_AVAILABLE; then printf " or, as you have Homebrew available, run ${BLUE}brew install maven${NC}\n"; fi
   exit 1
 fi
 
-MVN_VERSION=`mvn -v | grep "Apache Maven"`
 
+MVN_VERSION=`mvn -v | grep "Apache Maven"`
+MVN_VERSION_MAJOR_MINOR=$(echo $MVN_VERSION | sed -n 's/^Apache Maven \([0-9]*\.[0-9]*\).*$/\1/p')
 printf "Your Maven version is ${BLUE}${MVN_VERSION}${NC}.\n"
-printf "\t- if that is a version < 3.6, we recommend you upgrade. See https://maven.apache.org/install.html\n"
-printf "\t- Maven is used to build the package that will be deployed to your host platform as an AWS lambda or a GCP Cloud Function\n"
+
+if (( $(echo "$MVN_VERSION_MAJOR_MINOR < 3.6" | bc ) == 1 )); then
+  printf "${RED}This Maven version appears to be unsupported.${NC} Psoxy requires a supported version of Maven 3.6 or later.\n"
+  printf "We recommend you upgrade. See https://maven.apache.org/install.html\n"
+  printf "Maven is used to build the package that will be deployed to your host platform as an AWS lambda or a GCP Cloud Function\n"
+fi
 
 printf "\n"
 
+# Check Java installation
+
 JAVA_VERSION=`mvn -v | grep Java`
-JAVA_VERSION_MAJOR=$(echo $JAVA_VERSION | sed -n 's/^Java version: \([0-9]*\).*/\1/p')}
+JAVA_VERSION_MAJOR=$(echo $JAVA_VERSION | sed -n 's/^Java version: \([0-9]*\).*/\1/p')
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
 
@@ -49,11 +58,15 @@ fi
 
 printf "\n"
 
+# Check NPM installation
+
 if ! npm -v &> /dev/null ; then
   printf "${RED}Node Package Manager (npm) is not installed and is required for some testing to work.${NC} See https://nodejs.org/\n"
   if $HOMEBREW_AVAILABLE; then printf " or, as you have Homebrew available, run ${BLUE}brew install node${NC}\n"; fi
 fi
 
+
+# Check AWS installation
 AWSCLI_REASON="It is used if you're deploying to AWS."
 if ! aws --version &> /dev/null ; then
   printf "${RED}AWS CLI is not installed.${NC} ${AWSCLI_REASON} See https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html\n"
@@ -66,6 +79,7 @@ fi
 
 printf "\n"
 
+# Check GCloud CLI installation
 GCLOUD_REASON="It is used if you're deploying to GCP or using Google Workspace data sources."
 if ! gcloud --version &> /dev/null ; then
   printf "${RED}Google Cloud SDK is not installed.${NC} ${GCLOUD_REASON} See https://cloud.google.com/sdk/docs/install\n"
@@ -77,6 +91,7 @@ fi
 
 printf "\n"
 
+# Check Azure CLI installation
 AZCLI_REASON="It is used if you're deploying to Azure or using Microsoft 365 data sources."
 if ! az --version &> /dev/null ; then
   printf "${RED}Azure CLI is not installed.${NC} ${AZCLI_REASON} See https://docs.microsoft.com/en-us/cli/azure/install-azure-cli\n"


### PR DESCRIPTION
### Fixes
 - build breaks with jdk >= 21, which is now the default


as with past breakages in jdk 19/20, lombok is culprit: https://projectlombok.org/changelog - and in this case first fix was 1 day after the jdk 21 release, so 🤷 


--> change req'd is deeper than that; jdk 21 has broken Mockito, thus broken our tests; https://github.com/Worklytics/psoxy/actions/runs/6856732245/job/18644471668?pr=572 ; fix requires upgrade to Mockito v5, which has issues with java8 ...

### Change implications

 - dependencies added/changed? **yes**, bumped lombok from 1.18.28 --> 1.18.30; mockito to v5
 - something to note in `CHANGELOG.md`? **no**
