### PR TITLE
S162: MSFT Teams via Proxy  - Endpoints

### DIFF
--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_callRecords_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_callRecords_beta.json
@@ -1,0 +1,251 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#communications/callRecords(sessions(segments()))/$entity",
+  "version": 1,
+  "type": "peerToPeer",
+  "modalities": [
+    "audio"
+  ],
+  "lastModifiedDateTime": "2020-02-25T19:00:24.582757Z",
+  "startDateTime": "2020-02-25T18:52:21.2169889Z",
+  "endDateTime": "2020-02-25T18:52:46.7640013Z",
+  "id": "e523d2ed-2966-4b6b-925b-754a88034cc5",
+  "organizer": {
+    "user": {
+      "id": "821809f5-0000-0000-0000-3b5136c0e777",
+      "displayName": "Abbie Wilkins",
+      "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+    }
+  },
+  "participants": [
+    {
+      "user": {
+        "id": "821809f5-0000-0000-0000-3b5136c0e777",
+        "displayName": "Abbie Wilkins",
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+      }
+    },
+    {
+      "user": {
+        "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+        "displayName": "Owen Franklin",
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+      }
+    }
+  ],
+  "sessions": [
+    {
+      "modalities": [
+        "audio"
+      ],
+      "startDateTime": "2020-02-25T18:52:21.2169889Z",
+      "endDateTime": "2020-02-25T18:52:46.7640013Z",
+      "id": "e523d2ed-2966-4b6b-925b-754a88034cc5",
+      "isTest": false,
+      "caller": {
+        "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+        "name": "machineName_2",
+        "cpuName": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
+        "cpuCoresCount": 2,
+        "cpuProcessorSpeedInMhz": 2594,
+        "userAgent": {
+          "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+          "headerValue": "RTCC/7.0.0.0 UCWA/7.0.0.0 AndroidLync/6.25.0.27 (SM-G930U Android 8.0.0)",
+          "platform": "android",
+          "productFamily": "skypeForBusiness"
+        },
+        "identity": {
+          "@odata.type": "#microsoft.graph.identitySet",
+          "user": {
+            "id": "821809f5-0000-0000-0000-3b5136c0e777",
+            "displayName": "Abbie Wilkins",
+            "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+          }
+        }
+      },
+      "callee": {
+        "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+        "name": "machineName_4",
+        "cpuName": "Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz",
+        "cpuCoresCount": 8,
+        "cpuProcessorSpeedInMhz": 2295,
+        "userAgent": {
+          "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+          "headerValue": "UCCAPI/16.0.12527.20122 OC/16.0.12527.20194 (Skype for Business)",
+          "platform": "windows",
+          "productFamily": "skypeForBusiness"
+        },
+        "identity": {
+          "user": {
+            "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+            "displayName": "Owen Franklin",
+            "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+          }
+        },
+        "feedback": {
+          "rating": "poor",
+          "tokens": {
+            "NoSound": false,
+            "OtherNoSound": false,
+            "Echo": false,
+            "Noisy": true,
+            "LowVolume": false,
+            "Stopped": false,
+            "DistortedSound": false,
+            "Interruptions": false
+          }
+        }
+      },
+      "segments": [
+        {
+          "startDateTime": "2020-02-25T18:52:21.2169889Z",
+          "endDateTime": "2020-02-25T18:52:46.7640013Z",
+          "id": "e523d2ed-2966-4b6b-925b-754a88034cc5",
+          "caller": {
+            "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+            "name": "machineName_4",
+            "cpuName": "Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz",
+            "cpuCoresCount": 8,
+            "cpuProcessorSpeedInMhz": 2295,
+            "userAgent": {
+              "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+              "headerValue": "RTCC/7.0.0.0 UCWA/7.0.0.0 AndroidLync/6.25.0.27 (SM-G930U Android 8.0.0)",
+              "platform": "android",
+              "productFamily": "skypeForBusiness"
+            },
+            "identity": {
+              "user": {
+                "id": "821809f5-0000-0000-0000-3b5136c0e777",
+                "displayName": "Abbie Wilkins",
+                "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+              }
+            }
+          },
+          "callee": {
+            "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+            "name": "machineName_6",
+            "cpuName": "Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz",
+            "cpuCoresCount": 8,
+            "cpuProcessorSpeedInMhz": 2295,
+            "userAgent": {
+              "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+              "headerValue": "UCCAPI/16.0.12527.20122 OC/16.0.12527.20194 (Skype for Business)",
+              "platform": "windows",
+              "productFamily": "skypeForBusiness"
+            },
+            "identity": {
+              "user": {
+                "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+                "displayName": "Owen Franklin",
+                "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+              }
+            }
+          },
+          "media": [
+            {
+              "label": "main-audio",
+              "callerNetwork": {
+                "ipAddress": "10.150.0.2",
+                "subnet": "10.150.0.0",
+                "linkSpeed": 54000000,
+                "connectionType": "wifi",
+                "port": 27288,
+                "reflexiveIPAddress": "127.0.0.2",
+                "relayIPAddress": "52.114.188.32",
+                "relayPort": 53889,
+                "macAddress": "00-00-00-00-00-00",
+                "dnsSuffix": null,
+                "sentQualityEventRatio": 0,
+                "receivedQualityEventRatio": 0.27,
+                "delayEventRatio": 0,
+                "bandwidthLowEventRatio": 0
+              },
+              "calleeNetwork": {
+                "ipAddress": "10.139.0.12",
+                "subnet": "10.139.80.0",
+                "linkSpeed": 4294967295,
+                "connectionType": "wired",
+                "port": 50011,
+                "reflexiveIPAddress": "127.0.0.2",
+                "relayIPAddress": "52.114.188.102",
+                "relayPort": 52810,
+                "macAddress": "00-00-00-00-00-00-00-00",
+                "dnsSuffix": null,
+                "sentQualityEventRatio": 0.31,
+                "receivedQualityEventRatio": 0,
+                "delayEventRatio": 0,
+                "bandwidthLowEventRatio": 0
+              },
+              "callerDevice": {
+                "captureDeviceName": "Default input device",
+                "renderDeviceName": "Default output device",
+                "receivedSignalLevel": -10,
+                "receivedNoiseLevel": -68,
+                "initialSignalLevelRootMeanSquare": 60.25816,
+                "renderZeroVolumeEventRatio": 1,
+                "renderMuteEventRatio": 1,
+                "micGlitchRate": 23,
+                "speakerGlitchRate": 3830
+              },
+              "calleeDevice": {
+                "captureDeviceName": "Microphone (Microsoft Virtual Audio Device (Simple) (WDM))",
+                "captureDeviceDriver": "Microsoft: 5.0.8638.1100",
+                "renderDeviceName": "Speakers (Microsoft Virtual Audio Device (Simple) (WDM))",
+                "renderDeviceDriver": "Microsoft: 5.0.8638.1100",
+                "receivedSignalLevel": -14,
+                "receivedNoiseLevel": -86,
+                "initialSignalLevelRootMeanSquare": 146.7885,
+                "micGlitchRate": 143,
+                "speakerGlitchRate": 182
+              },
+              "streams": [
+                {
+                  "streamId": "1504545584",
+                  "streamDirection": "callerToCallee",
+                  "averageAudioDegradation": null,
+                  "averageJitter": "PT0.016S",
+                  "maxJitter": "PT0.021S",
+                  "averagePacketLossRate": 0,
+                  "maxPacketLossRate": 0,
+                  "averageRatioOfConcealedSamples": null,
+                  "maxRatioOfConcealedSamples": null,
+                  "averageRoundTripTime": "PT0.061S",
+                  "maxRoundTripTime": "PT0.079S",
+                  "packetUtilization": 67,
+                  "averageBandwidthEstimate": 9965083,
+                  "wasMediaBypassed": false,
+                  "averageAudioNetworkJitter": "PT0.043S",
+                  "maxAudioNetworkJitter": "PT0.046S",
+                  "rmsFreezeDuration": null,
+                  "averageFreezeDuration": null,
+                  "isAudioForwardErrorCorrectionUsed": false
+                },
+                {
+                  "streamId": "1785122252",
+                  "streamDirection": "calleeToCaller",
+                  "averageAudioDegradation": 1.160898,
+                  "averageJitter": "PT0.007S",
+                  "maxJitter": "PT0.012S",
+                  "averagePacketLossRate": 0.01381693,
+                  "maxPacketLossRate": 0.03738318,
+                  "averageRatioOfConcealedSamples": 0.06233422,
+                  "maxRatioOfConcealedSamples": 0.07192807,
+                  "averageRoundTripTime": "PT0.064S",
+                  "maxRoundTripTime": "PT0.106S",
+                  "packetUtilization": 709,
+                  "averageBandwidthEstimate": 15644878,
+                  "wasMediaBypassed": false,
+                  "averageAudioNetworkJitter": "PT0.266S",
+                  "maxAudioNetworkJitter": "PT0.474S",
+                  "rmsFreezeDuration": null,
+                  "averageFreezeDuration": null,
+                  "isAudioForwardErrorCorrectionUsed": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sessions@odata.nextLink": "https://graph.microsoft.com/v1.0/$metadata#communications/callRecords('e523d2ed-2966-4b6b-925b-754a88034cc5')/sessions?$expand=segments&$skiptoken=abc"
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_callRecords_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_callRecords_v1.0.json
@@ -1,0 +1,251 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#communications/callRecords(sessions(segments()))/$entity",
+  "version": 1,
+  "type": "peerToPeer",
+  "modalities": [
+    "audio"
+  ],
+  "lastModifiedDateTime": "2020-02-25T19:00:24.582757Z",
+  "startDateTime": "2020-02-25T18:52:21.2169889Z",
+  "endDateTime": "2020-02-25T18:52:46.7640013Z",
+  "id": "e523d2ed-2966-4b6b-925b-754a88034cc5",
+  "organizer": {
+    "user": {
+      "id": "821809f5-0000-0000-0000-3b5136c0e777",
+      "displayName": "Abbie Wilkins",
+      "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+    }
+  },
+  "participants": [
+    {
+      "user": {
+        "id": "821809f5-0000-0000-0000-3b5136c0e777",
+        "displayName": "Abbie Wilkins",
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+      }
+    },
+    {
+      "user": {
+        "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+        "displayName": "Owen Franklin",
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+      }
+    }
+  ],
+  "sessions": [
+    {
+      "modalities": [
+        "audio"
+      ],
+      "startDateTime": "2020-02-25T18:52:21.2169889Z",
+      "endDateTime": "2020-02-25T18:52:46.7640013Z",
+      "id": "e523d2ed-2966-4b6b-925b-754a88034cc5",
+      "isTest": false,
+      "caller": {
+        "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+        "name": "machineName_2",
+        "cpuName": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
+        "cpuCoresCount": 2,
+        "cpuProcessorSpeedInMhz": 2594,
+        "userAgent": {
+          "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+          "headerValue": "RTCC/7.0.0.0 UCWA/7.0.0.0 AndroidLync/6.25.0.27 (SM-G930U Android 8.0.0)",
+          "platform": "android",
+          "productFamily": "skypeForBusiness"
+        },
+        "identity": {
+          "@odata.type": "#microsoft.graph.identitySet",
+          "user": {
+            "id": "821809f5-0000-0000-0000-3b5136c0e777",
+            "displayName": "Abbie Wilkins",
+            "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+          }
+        }
+      },
+      "callee": {
+        "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+        "name": "machineName_4",
+        "cpuName": "Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz",
+        "cpuCoresCount": 8,
+        "cpuProcessorSpeedInMhz": 2295,
+        "userAgent": {
+          "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+          "headerValue": "UCCAPI/16.0.12527.20122 OC/16.0.12527.20194 (Skype for Business)",
+          "platform": "windows",
+          "productFamily": "skypeForBusiness"
+        },
+        "identity": {
+          "user": {
+            "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+            "displayName": "Owen Franklin",
+            "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+          }
+        },
+        "feedback": {
+          "rating": "poor",
+          "tokens": {
+            "NoSound": false,
+            "OtherNoSound": false,
+            "Echo": false,
+            "Noisy": true,
+            "LowVolume": false,
+            "Stopped": false,
+            "DistortedSound": false,
+            "Interruptions": false
+          }
+        }
+      },
+      "segments": [
+        {
+          "startDateTime": "2020-02-25T18:52:21.2169889Z",
+          "endDateTime": "2020-02-25T18:52:46.7640013Z",
+          "id": "e523d2ed-2966-4b6b-925b-754a88034cc5",
+          "caller": {
+            "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+            "name": "machineName_4",
+            "cpuName": "Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz",
+            "cpuCoresCount": 8,
+            "cpuProcessorSpeedInMhz": 2295,
+            "userAgent": {
+              "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+              "headerValue": "RTCC/7.0.0.0 UCWA/7.0.0.0 AndroidLync/6.25.0.27 (SM-G930U Android 8.0.0)",
+              "platform": "android",
+              "productFamily": "skypeForBusiness"
+            },
+            "identity": {
+              "user": {
+                "id": "821809f5-0000-0000-0000-3b5136c0e777",
+                "displayName": "Abbie Wilkins",
+                "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+              }
+            }
+          },
+          "callee": {
+            "@odata.type": "#microsoft.graph.callRecords.participantEndpoint",
+            "name": "machineName_6",
+            "cpuName": "Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz",
+            "cpuCoresCount": 8,
+            "cpuProcessorSpeedInMhz": 2295,
+            "userAgent": {
+              "@odata.type": "#microsoft.graph.callRecords.clientUserAgent",
+              "headerValue": "UCCAPI/16.0.12527.20122 OC/16.0.12527.20194 (Skype for Business)",
+              "platform": "windows",
+              "productFamily": "skypeForBusiness"
+            },
+            "identity": {
+              "user": {
+                "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+                "displayName": "Owen Franklin",
+                "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+              }
+            }
+          },
+          "media": [
+            {
+              "label": "main-audio",
+              "callerNetwork": {
+                "ipAddress": "10.150.0.2",
+                "subnet": "10.150.0.0",
+                "linkSpeed": 54000000,
+                "connectionType": "wifi",
+                "port": 27288,
+                "reflexiveIPAddress": "127.0.0.2",
+                "relayIPAddress": "52.114.188.32",
+                "relayPort": 53889,
+                "macAddress": "00-00-00-00-00-00",
+                "dnsSuffix": null,
+                "sentQualityEventRatio": 0,
+                "receivedQualityEventRatio": 0.27,
+                "delayEventRatio": 0,
+                "bandwidthLowEventRatio": 0
+              },
+              "calleeNetwork": {
+                "ipAddress": "10.139.0.12",
+                "subnet": "10.139.80.0",
+                "linkSpeed": 4294967295,
+                "connectionType": "wired",
+                "port": 50011,
+                "reflexiveIPAddress": "127.0.0.2",
+                "relayIPAddress": "52.114.188.102",
+                "relayPort": 52810,
+                "macAddress": "00-00-00-00-00-00-00-00",
+                "dnsSuffix": null,
+                "sentQualityEventRatio": 0.31,
+                "receivedQualityEventRatio": 0,
+                "delayEventRatio": 0,
+                "bandwidthLowEventRatio": 0
+              },
+              "callerDevice": {
+                "captureDeviceName": "Default input device",
+                "renderDeviceName": "Default output device",
+                "receivedSignalLevel": -10,
+                "receivedNoiseLevel": -68,
+                "initialSignalLevelRootMeanSquare": 60.25816,
+                "renderZeroVolumeEventRatio": 1,
+                "renderMuteEventRatio": 1,
+                "micGlitchRate": 23,
+                "speakerGlitchRate": 3830
+              },
+              "calleeDevice": {
+                "captureDeviceName": "Microphone (Microsoft Virtual Audio Device (Simple) (WDM))",
+                "captureDeviceDriver": "Microsoft: 5.0.8638.1100",
+                "renderDeviceName": "Speakers (Microsoft Virtual Audio Device (Simple) (WDM))",
+                "renderDeviceDriver": "Microsoft: 5.0.8638.1100",
+                "receivedSignalLevel": -14,
+                "receivedNoiseLevel": -86,
+                "initialSignalLevelRootMeanSquare": 146.7885,
+                "micGlitchRate": 143,
+                "speakerGlitchRate": 182
+              },
+              "streams": [
+                {
+                  "streamId": "1504545584",
+                  "streamDirection": "callerToCallee",
+                  "averageAudioDegradation": null,
+                  "averageJitter": "PT0.016S",
+                  "maxJitter": "PT0.021S",
+                  "averagePacketLossRate": 0,
+                  "maxPacketLossRate": 0,
+                  "averageRatioOfConcealedSamples": null,
+                  "maxRatioOfConcealedSamples": null,
+                  "averageRoundTripTime": "PT0.061S",
+                  "maxRoundTripTime": "PT0.079S",
+                  "packetUtilization": 67,
+                  "averageBandwidthEstimate": 9965083,
+                  "wasMediaBypassed": false,
+                  "averageAudioNetworkJitter": "PT0.043S",
+                  "maxAudioNetworkJitter": "PT0.046S",
+                  "rmsFreezeDuration": null,
+                  "averageFreezeDuration": null,
+                  "isAudioForwardErrorCorrectionUsed": false
+                },
+                {
+                  "streamId": "1785122252",
+                  "streamDirection": "calleeToCaller",
+                  "averageAudioDegradation": 1.160898,
+                  "averageJitter": "PT0.007S",
+                  "maxJitter": "PT0.012S",
+                  "averagePacketLossRate": 0.01381693,
+                  "maxPacketLossRate": 0.03738318,
+                  "averageRatioOfConcealedSamples": 0.06233422,
+                  "maxRatioOfConcealedSamples": 0.07192807,
+                  "averageRoundTripTime": "PT0.064S",
+                  "maxRoundTripTime": "PT0.106S",
+                  "packetUtilization": 709,
+                  "averageBandwidthEstimate": 15644878,
+                  "wasMediaBypassed": false,
+                  "averageAudioNetworkJitter": "PT0.266S",
+                  "maxAudioNetworkJitter": "PT0.474S",
+                  "rmsFreezeDuration": null,
+                  "averageFreezeDuration": null,
+                  "isAudioForwardErrorCorrectionUsed": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "sessions@odata.nextLink": "https://graph.microsoft.com/v1.0/$metadata#communications/callRecords('e523d2ed-2966-4b6b-925b-754a88034cc5')/sessions?$expand=segments&$skiptoken=abc"
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_calls_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_calls_beta.json
@@ -1,0 +1,59 @@
+{
+  "@odata.type": "#microsoft.graph.call",
+  "state": "established",
+  "direction": "outgoing",
+  "callbackUri": "https://bot.contoso.com/callback",
+  "source": {
+    "@odata.type": "#microsoft.graph.participantInfo",
+    "identity": {
+      "@odata.type": "#microsoft.graph.identitySet",
+      "application": {
+        "@odata.type": "#microsoft.graph.identity",
+        "displayName": "Calling Bot",
+        "id": "2891555a-92ff-42e6-80fa-6e1300c6b5c6"
+      }
+    },
+    "region": null,
+    "languageId": null
+  },
+  "targets": [
+    {
+      "@odata.type": "#microsoft.graph.invitationParticipantInfo",
+      "identity": {
+        "@odata.type": "#microsoft.graph.identitySet",
+        "user": {
+          "@odata.type": "#microsoft.graph.identity",
+          "displayName": "John",
+          "id": "112f7296-5fa4-42ca-bae8-6a692b15d4b8"
+        }
+      }
+    }
+  ],
+  "requestedModalities": [
+    "audio"
+  ],
+  "mediaConfig": {
+    "@odata.type": "#microsoft.graph.serviceHostedMediaConfig",
+    "preFetchMedia": [
+      {
+        "uri": "https://cdn.contoso.com/beep.wav",
+        "resourceId": "f8971b04-b53e-418c-9222-c82ce681a582"
+      },
+      {
+        "uri": "https://cdn.contoso.com/cool.wav",
+        "resourceId": "86dc814b-c172-4428-9112-60f8ecae1edb"
+      }
+    ]
+  },
+  "myParticipantId": "499ff390-7a72-40e8-83a0-8fac6295ae7e",
+  "id": "2e1a0b00-2db4-4022-9570-243709c565ab",
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#communications/calls/$entity",
+  "subject": null,
+  "ringingTimeoutInSeconds": null,
+  "resultInfo": null,
+  "answeredBy": null,
+  "chatInfo": null,
+  "meetingInfo": null,
+  "transcription": null,
+  "toneInfo": null
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_calls_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Communications_calls_v1.0.json
@@ -1,0 +1,59 @@
+{
+  "@odata.type": "#microsoft.graph.call",
+  "state": "established",
+  "direction": "outgoing",
+  "callbackUri": "https://bot.contoso.com/callback",
+  "source": {
+    "@odata.type": "#microsoft.graph.participantInfo",
+    "identity": {
+      "@odata.type": "#microsoft.graph.identitySet",
+      "application": {
+        "@odata.type": "#microsoft.graph.identity",
+        "displayName": "Calling Bot",
+        "id": "2891555a-92ff-42e6-80fa-6e1300c6b5c6"
+      }
+    },
+    "region": null,
+    "languageId": null
+  },
+  "targets": [
+    {
+      "@odata.type": "#microsoft.graph.invitationParticipantInfo",
+      "identity": {
+        "@odata.type": "#microsoft.graph.identitySet",
+        "user": {
+          "@odata.type": "#microsoft.graph.identity",
+          "displayName": "John",
+          "id": "112f7296-5fa4-42ca-bae8-6a692b15d4b8"
+        }
+      }
+    }
+  ],
+  "requestedModalities": [
+    "audio"
+  ],
+  "mediaConfig": {
+    "@odata.type": "#microsoft.graph.serviceHostedMediaConfig",
+    "preFetchMedia": [
+      {
+        "uri": "https://cdn.contoso.com/beep.wav",
+        "resourceId": "f8971b04-b53e-418c-9222-c82ce681a582"
+      },
+      {
+        "uri": "https://cdn.contoso.com/cool.wav",
+        "resourceId": "86dc814b-c172-4428-9112-60f8ecae1edb"
+      }
+    ]
+  },
+  "myParticipantId": "499ff390-7a72-40e8-83a0-8fac6295ae7e",
+  "id": "2e1a0b00-2db4-4022-9570-243709c565ab",
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#communications/calls/$entity",
+  "subject": null,
+  "ringingTimeoutInSeconds": null,
+  "resultInfo": null,
+  "answeredBy": null,
+  "chatInfo": null,
+  "meetingInfo": null,
+  "transcription": null,
+  "toneInfo": null
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_allChannels_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_allChannels_beta.json
@@ -1,0 +1,21 @@
+{
+  "value": [
+    {
+      "@odata.id": "https://graph.microsoft.com/v1.0/tenants/b3246f44-b4gb-4627-96c6-25b18fa2c910/teams/893075dd-2487-4122-925f-022c42e20265/channels/19:561fbdbbfca848a484f0a6f00ce9dbbd@thread.tacv2",
+      "id": "19:561fbdbbfca848a484f0a6f00ce9dbbd@thread.tacv2",
+      "createdDateTime": "2020-05-27T19:22:25.692Z",
+      "displayName": "General",
+      "description": "AutoTestTeam_20210311_150740.2550_fim3udfdjen9",
+      "membershipType": "standard",
+      "tenantId": "b3246f44-b4gb-4627-96c6-25b18fa2c910"
+    },
+    {
+      "@odata.id": "https://graph.microsoft.com/v1.0/tenants/b3246f44-b4gb-5678-96c6-25b18fa2c910/teams/893075dd-5678-5634-925f-022c42e20265/channels/19:561fbdbbfca848a484gabdf00ce9dbbd@thread.tacv",
+      "id": "19:561fbdbbfca848a484gabdf00ce9dbbd@thread.tacv2",
+      "createdDateTime": "2020-05-27T19:22:25.692Z",
+      "displayName": "Shared channel from Contoso",
+      "membershipType": "shared",
+      "tenantId": "b3246f44-b4gb-5678-96c6-25b18fa2c910"
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_allChannels_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_allChannels_v1.0.json
@@ -1,0 +1,21 @@
+{
+  "value": [
+    {
+      "@odata.id": "https://graph.microsoft.com/v1.0/tenants/b3246f44-b4gb-4627-96c6-25b18fa2c910/teams/893075dd-2487-4122-925f-022c42e20265/channels/19:561fbdbbfca848a484f0a6f00ce9dbbd@thread.tacv2",
+      "id": "19:561fbdbbfca848a484f0a6f00ce9dbbd@thread.tacv2",
+      "createdDateTime": "2020-05-27T19:22:25.692Z",
+      "displayName": "General",
+      "description": "AutoTestTeam_20210311_150740.2550_fim3udfdjen9",
+      "membershipType": "standard",
+      "tenantId": "b3246f44-b4gb-4627-96c6-25b18fa2c910"
+    },
+    {
+      "@odata.id": "https://graph.microsoft.com/v1.0/tenants/b3246f44-b4gb-5678-96c6-25b18fa2c910/teams/893075dd-5678-5634-925f-022c42e20265/channels/19:561fbdbbfca848a484gabdf00ce9dbbd@thread.tacv",
+      "id": "19:561fbdbbfca848a484gabdf00ce9dbbd@thread.tacv2",
+      "createdDateTime": "2020-05-27T19:22:25.692Z",
+      "displayName": "Shared channel from Contoso",
+      "membershipType": "shared",
+      "tenantId": "b3246f44-b4gb-5678-96c6-25b18fa2c910"
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_beta.json
@@ -1,0 +1,16 @@
+{
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.associatedTeamInfo",
+      "id": "b695c5a5-c5a5-b695-a5c5-95b6a5c595b6",
+      "tenantId": "172b0cce-e65d-7hd4-9a49-91d9f2e8493a",
+      "displayName": "Contoso Team"
+    },
+    {
+      "@odata.type": "#microsoft.graph.associatedTeamInfo",
+      "id": "b695c5a5-8934-b695-a5c5-95b6a5c595b6",
+      "tenantId": "172b0cce-8961-7hd4-9a49-91d9f2e8493a",
+      "displayName": "Fabrikam Team"
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_beta.json
@@ -1,0 +1,144 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams('fbe2bf47-16c8-47cf-b4a5-4b9b187c508b')/channels('19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2')/messages",
+  "@odata.count": 3,
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages?$skiptoken=%5b%7B%22token%22%3a%22%2bRID%3a~vpsQAJ9uAC047gwAAACcBQ%3d%3d%23RT%3a1%23TRC%3a20%23RTD%3aAyAER1ygxSHVHGAn2S99BTI6OzViOjZnOGU5ZWM1ZDVmOGdiZjk2OGNkZmNmMTczNGY3QXVpc2ZiZS91YmR3MzwyNzIyNDY2OTU0NTg6AA%3d%3d%23ISV%3a2%23IEO%3a65551%23QCF%3a3%23FPC%3aAggEAAAAcBYAABUFAADQKgAABAAAAHAWAAACALu4GwAAAHAWAAACAPSTMwAAAHAWAACaAFWa84BXgQKAEIAMgBaAE4AUgAuAAoAIwAIgACAAAiAACAABACCAAAEVgBSAI4AYgA%2bAGQAEEAAQAAEABACAAAIEEBBAACAYgB%2bAH4AbgBqACoAHwAICCBAEEIAAAgEQAACAIoAZgB2ADoAMgAKAPoAZgB2AJoAXgBIAgiAAQUqLF4AJgALACARAgBCACoAfgB6AIwABgYCQAAFXAAAAcBYAAAYA%2f50ZgGeEXwAAAHAWAAAEAPaBS4V7AAAAcBYAAAIA1aSJAAAAcBYAAAIAtLmbAAAAcBYAAAIAqKXdAAAAcBYAAAQAppUugOMAAABwFgAABADQoAWA6wAAAHAWAAAEABGl94M5AAAA0CoAAAYA6pF7iYOBaQIAANAqAAAcAEUPAMAAMAACAQCBAHQAADDAgCAAQgByAQAzUJDRBAAA0CoAAAQAETwKAA4FAADQKgAAAgBekRUFAADQKgAAHAB2pQCABYAMgJeAH4ATgAGAvIIIgASABIAFgCWA%22%2c%22range%22%3a%7B%22min%22%3a%2205C1D79B33ADE4%22%2c%22max%22%3a%2205C1D7A52F89EC%22%7D%7D%5d",
+  "value": [
+    {
+      "id": "1616965872395",
+      "replyToId": null,
+      "etag": "1616965872395",
+      "messageType": "message",
+      "createdDateTime": "2021-03-28T21:11:12.395Z",
+      "lastModifiedDateTime": "2021-03-28T21:11:12.395Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616965872395?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616965872395&parentMessageId=1616965872395",
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "html",
+        "content": "Hello World <at id=\"0\">Jane Smith</at>"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [
+        {
+          "id": 0,
+          "mentionText": "Jane Smith",
+          "mentioned": {
+            "application": null,
+            "device": null,
+            "conversation": null,
+            "user": {
+              "id": "ef1c916a-3135-4417-ba27-8eb7bd084193",
+              "displayName": "Jane Smith",
+              "userIdentityType": "aadUser"
+            }
+          }
+        }
+      ],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1616963377068",
+      "replyToId": null,
+      "etag": "1616963377068",
+      "messageType": "message",
+      "createdDateTime": "2021-03-28T20:29:37.068Z",
+      "lastModifiedDateTime": "2021-03-28T20:29:37.068Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": "",
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616963377068?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616963377068&parentMessageId=1616963377068",
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "html",
+        "content": "<div><div><div><span><img height=\"145\" src=\"https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/1616963377068/hostedContents/aWQ9eF8wLXd1cy1kMS02YmI3Nzk3ZGU2MmRjODdjODA4YmQ1ZmI0OWM4NjI2ZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kMS02YmI3Nzk3ZGU2MmRjODdjODA4YmQ1ZmI0OWM4NjI2ZC92aWV3cy9pbWdv/$value\" width=\"131\" style=\"vertical-align:bottom; width:131px; height:145px\"></span><div>&nbsp;</div></div><div><div><span><img height=\"65\" src=\"https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/1616963377068/hostedContents/aWQ9eF8wLXd1cy1kNi0xMzY3OTE4MzVlODIxOGZlMmUwZWEwYTA1ODAxNjRiNCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0xMzY3OTE4MzVlODIxOGZlMmUwZWEwYTA1ODAxNjRiNC92aWV3cy9pbWdv/$value\" width=\"79\" style=\"vertical-align:bottom; width:79px; height:65px\"></span></div></div></div></div>"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1616883610266",
+      "replyToId": null,
+      "etag": "1616883610266",
+      "messageType": "unknownFutureValue",
+      "createdDateTime": "2021-03-28T03:50:10.266Z",
+      "lastModifiedDateTime": "2021-03-28T03:50:10.266Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616883610266?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616883610266&parentMessageId=1616883610266",
+      "policyViolation": null,
+      "from": null,
+      "body": {
+        "contentType": "html",
+        "content": "<systemEventMessage/>"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": [],
+      "eventDetail": {
+        "@odata.type": "#microsoft.graph.teamDescriptionUpdatedEventMessageDetail",
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "teamDescription": "Team for Microsoft Teams members",
+        "initiator": {
+          "application": null,
+          "device": null,
+          "user": {
+            "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+            "displayName": null,
+            "userIdentityType": "aadUser"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_delta_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_delta_beta.json
@@ -1,0 +1,92 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(chatMessage)",
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/delta?$skiptoken=-FG3FPHv7HuyuazNLuy3eXlzQGbEjYLUsW9-pYkmXgn5KGsaOwrCoor2W23dGNNM1KtAX4AyvpFQNVsBgsEwUOX9lw8x9zDumgJy-C-UbjZLlZDQACyC9FyrVelZus9n.--rshdLwy_WBFJd8anPXJPbSUtUD7r3V4neB5tcrG58",
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.chatMessage",
+      "replyToId": null,
+      "etag": "1606515483514",
+      "messageType": "message",
+      "createdDateTime": "2020-11-27T22:18:03.514Z",
+      "lastModifiedDateTime": "2020-11-27T22:18:03.514Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1606515483514?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1606515483514&parentMessageId=1606515483514",
+      "policyViolation": null,
+      "eventDetail": null,
+      "id": "1606515483514",
+      "from": {
+        "application": null,
+        "device": null,
+        "conversation": null,
+        "user": {
+          "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser",
+          "tenantId": "e61ef81e-8bd8-476a-92e8-4a62f8426fca"
+        }
+      },
+      "body": {
+        "contentType": "text",
+        "content": "Test"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "@odata.type": "#microsoft.graph.chatMessage",
+      "replyToId": null,
+      "etag": "1606691795113",
+      "messageType": "message",
+      "createdDateTime": "2020-11-29T23:16:35.113Z",
+      "lastModifiedDateTime": "2020-11-29T23:16:35.113Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1606691795113?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1606691795113&parentMessageId=1606691795113",
+      "policyViolation": null,
+      "eventDetail": null,
+      "id": "1606691795113",
+      "from": {
+        "application": null,
+        "device": null,
+        "conversation": null,
+        "user": {
+          "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser",
+          "tenantId": "e61ef81e-8bd8-476a-92e8-4a62f8426fca"
+        }
+      },
+      "body": {
+        "contentType": "text",
+        "content": "HelloWorld 11/29/2020 3:16:31 PM -08:00"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_delta_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_delta_v1.0.json
@@ -1,0 +1,92 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(chatMessage)",
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/delta?$skiptoken=-FG3FPHv7HuyuazNLuy3eXlzQGbEjYLUsW9-pYkmXgn5KGsaOwrCoor2W23dGNNM1KtAX4AyvpFQNVsBgsEwUOX9lw8x9zDumgJy-C-UbjZLlZDQACyC9FyrVelZus9n.--rshdLwy_WBFJd8anPXJPbSUtUD7r3V4neB5tcrG58",
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.chatMessage",
+      "replyToId": null,
+      "etag": "1606515483514",
+      "messageType": "message",
+      "createdDateTime": "2020-11-27T22:18:03.514Z",
+      "lastModifiedDateTime": "2020-11-27T22:18:03.514Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1606515483514?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1606515483514&parentMessageId=1606515483514",
+      "policyViolation": null,
+      "eventDetail": null,
+      "id": "1606515483514",
+      "from": {
+        "application": null,
+        "device": null,
+        "conversation": null,
+        "user": {
+          "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser",
+          "tenantId": "e61ef81e-8bd8-476a-92e8-4a62f8426fca"
+        }
+      },
+      "body": {
+        "contentType": "text",
+        "content": "Test"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "@odata.type": "#microsoft.graph.chatMessage",
+      "replyToId": null,
+      "etag": "1606691795113",
+      "messageType": "message",
+      "createdDateTime": "2020-11-29T23:16:35.113Z",
+      "lastModifiedDateTime": "2020-11-29T23:16:35.113Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1606691795113?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1606691795113&parentMessageId=1606691795113",
+      "policyViolation": null,
+      "eventDetail": null,
+      "id": "1606691795113",
+      "from": {
+        "application": null,
+        "device": null,
+        "conversation": null,
+        "user": {
+          "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser",
+          "tenantId": "e61ef81e-8bd8-476a-92e8-4a62f8426fca"
+        }
+      },
+      "body": {
+        "contentType": "text",
+        "content": "HelloWorld 11/29/2020 3:16:31 PM -08:00"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_channels_messages_v1.0.json
@@ -1,0 +1,144 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams('fbe2bf47-16c8-47cf-b4a5-4b9b187c508b')/channels('19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2')/messages",
+  "@odata.count": 3,
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages?$skiptoken=%5b%7B%22token%22%3a%22%2bRID%3a~vpsQAJ9uAC047gwAAACcBQ%3d%3d%23RT%3a1%23TRC%3a20%23RTD%3aAyAER1ygxSHVHGAn2S99BTI6OzViOjZnOGU5ZWM1ZDVmOGdiZjk2OGNkZmNmMTczNGY3QXVpc2ZiZS91YmR3MzwyNzIyNDY2OTU0NTg6AA%3d%3d%23ISV%3a2%23IEO%3a65551%23QCF%3a3%23FPC%3aAggEAAAAcBYAABUFAADQKgAABAAAAHAWAAACALu4GwAAAHAWAAACAPSTMwAAAHAWAACaAFWa84BXgQKAEIAMgBaAE4AUgAuAAoAIwAIgACAAAiAACAABACCAAAEVgBSAI4AYgA%2bAGQAEEAAQAAEABACAAAIEEBBAACAYgB%2bAH4AbgBqACoAHwAICCBAEEIAAAgEQAACAIoAZgB2ADoAMgAKAPoAZgB2AJoAXgBIAgiAAQUqLF4AJgALACARAgBCACoAfgB6AIwABgYCQAAFXAAAAcBYAAAYA%2f50ZgGeEXwAAAHAWAAAEAPaBS4V7AAAAcBYAAAIA1aSJAAAAcBYAAAIAtLmbAAAAcBYAAAIAqKXdAAAAcBYAAAQAppUugOMAAABwFgAABADQoAWA6wAAAHAWAAAEABGl94M5AAAA0CoAAAYA6pF7iYOBaQIAANAqAAAcAEUPAMAAMAACAQCBAHQAADDAgCAAQgByAQAzUJDRBAAA0CoAAAQAETwKAA4FAADQKgAAAgBekRUFAADQKgAAHAB2pQCABYAMgJeAH4ATgAGAvIIIgASABIAFgCWA%22%2c%22range%22%3a%7B%22min%22%3a%2205C1D79B33ADE4%22%2c%22max%22%3a%2205C1D7A52F89EC%22%7D%7D%5d",
+  "value": [
+    {
+      "id": "1616965872395",
+      "replyToId": null,
+      "etag": "1616965872395",
+      "messageType": "message",
+      "createdDateTime": "2021-03-28T21:11:12.395Z",
+      "lastModifiedDateTime": "2021-03-28T21:11:12.395Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616965872395?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616965872395&parentMessageId=1616965872395",
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "html",
+        "content": "Hello World <at id=\"0\">Jane Smith</at>"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [
+        {
+          "id": 0,
+          "mentionText": "Jane Smith",
+          "mentioned": {
+            "application": null,
+            "device": null,
+            "conversation": null,
+            "user": {
+              "id": "ef1c916a-3135-4417-ba27-8eb7bd084193",
+              "displayName": "Jane Smith",
+              "userIdentityType": "aadUser"
+            }
+          }
+        }
+      ],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1616963377068",
+      "replyToId": null,
+      "etag": "1616963377068",
+      "messageType": "message",
+      "createdDateTime": "2021-03-28T20:29:37.068Z",
+      "lastModifiedDateTime": "2021-03-28T20:29:37.068Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": "",
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616963377068?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616963377068&parentMessageId=1616963377068",
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "html",
+        "content": "<div><div><div><span><img height=\"145\" src=\"https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/1616963377068/hostedContents/aWQ9eF8wLXd1cy1kMS02YmI3Nzk3ZGU2MmRjODdjODA4YmQ1ZmI0OWM4NjI2ZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kMS02YmI3Nzk3ZGU2MmRjODdjODA4YmQ1ZmI0OWM4NjI2ZC92aWV3cy9pbWdv/$value\" width=\"131\" style=\"vertical-align:bottom; width:131px; height:145px\"></span><div>&nbsp;</div></div><div><div><span><img height=\"65\" src=\"https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/1616963377068/hostedContents/aWQ9eF8wLXd1cy1kNi0xMzY3OTE4MzVlODIxOGZlMmUwZWEwYTA1ODAxNjRiNCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0xMzY3OTE4MzVlODIxOGZlMmUwZWEwYTA1ODAxNjRiNC92aWV3cy9pbWdv/$value\" width=\"79\" style=\"vertical-align:bottom; width:79px; height:65px\"></span></div></div></div></div>"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1616883610266",
+      "replyToId": null,
+      "etag": "1616883610266",
+      "messageType": "unknownFutureValue",
+      "createdDateTime": "2021-03-28T03:50:10.266Z",
+      "lastModifiedDateTime": "2021-03-28T03:50:10.266Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": null,
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616883610266?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616883610266&parentMessageId=1616883610266",
+      "policyViolation": null,
+      "from": null,
+      "body": {
+        "contentType": "html",
+        "content": "<systemEventMessage/>"
+      },
+      "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": [],
+      "eventDetail": {
+        "@odata.type": "#microsoft.graph.teamDescriptionUpdatedEventMessageDetail",
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "teamDescription": "Team for Microsoft Teams members",
+        "initiator": {
+          "application": null,
+          "device": null,
+          "user": {
+            "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+            "displayName": null,
+            "userIdentityType": "aadUser"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Teams_v1.0.json
@@ -1,0 +1,16 @@
+{
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.associatedTeamInfo",
+      "id": "b695c5a5-c5a5-b695-a5c5-95b6a5c595b6",
+      "tenantId": "172b0cce-e65d-7hd4-9a49-91d9f2e8493a",
+      "displayName": "Contoso Team"
+    },
+    {
+      "@odata.type": "#microsoft.graph.associatedTeamInfo",
+      "id": "b695c5a5-8934-b695-a5c5-95b6a5c595b6",
+      "tenantId": "172b0cce-8961-7hd4-9a49-91d9f2e8493a",
+      "displayName": "Fabrikam Team"
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_beta.json
@@ -1,0 +1,42 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#chats",
+  "@odata.count": 3,
+  "value": [
+    {
+      "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2",
+      "topic": "Meeting chat sample",
+      "createdDateTime": "2020-12-08T23:53:05.801Z",
+      "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z",
+      "chatType": "meeting",
+      "chatViewpoint": {
+        "isHidden": false,
+        "lastMessageReadDateTime": "2021-06-03T08:05:49.521Z"
+      },
+      "webUrl": "https://teams.microsoft.com/l/chat/19%3Ameeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+    },
+    {
+      "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2",
+      "topic": "Group chat sample",
+      "createdDateTime": "2020-12-03T19:41:07.054Z",
+      "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z",
+      "chatType": "group",
+      "chatViewpoint": {
+        "isHidden": false,
+        "lastMessageReadDateTime": "2021-05-27T22:13:01.577Z"
+      },
+      "webUrl": "https://teams.microsoft.com/l/chat/19%3A561082c0f3f847a58069deb8eb300807@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+    },
+    {
+      "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces",
+      "topic": null,
+      "createdDateTime": "2020-12-04T23:10:28.51Z",
+      "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z",
+      "chatType": "oneOnOne",
+      "chatViewpoint": {
+        "isHidden": false,
+        "lastMessageReadDateTime": "0001-01-01T00:00:00Z"
+      },
+      "webUrl": "https://teams.microsoft.com/l/chat/19%3Ad74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_messages_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_messages_beta.json
@@ -1,0 +1,120 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#chats('19%3A2da4c29f6d7041eca70b638b43d45437%40thread.v2')/messages",
+  "@odata.count": 3,
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$skiptoken=M2UyZDAwMDAwMDMxMzkzYTMyNjQ2MTM0NjMzMjM5NjYzNjY0MzczMDM0MzE2NTYzNjEzNzMwNjIzNjMzMzg2MjM0MzM2NDM0MzUzNDMzMzc0MDc0Njg3MjY1NjE2NDJlNzYzMjAxZThmYjY4M2Y3ODAxMDAwMDg4NjA5ODdhNzgwMTAwMDB8MTYxNjk2NDUwOTgzMg%3d%3d",
+  "value": [
+    {
+      "id": "1616964509832",
+      "replyToId": null,
+      "etag": "1616964509832",
+      "messageType": "message",
+      "createdDateTime": "2021-03-28T20:48:29.832Z",
+      "lastModifiedDateTime": "2021-03-28T20:48:29.832Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": null,
+      "channelIdentity": null,
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "text",
+        "content": "Hello world"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1615971548136",
+      "replyToId": null,
+      "etag": "1615971548136",
+      "messageType": "message",
+      "createdDateTime": "2021-03-17T08:59:08.136Z",
+      "lastModifiedDateTime": "2021-03-17T08:59:08.136Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": null,
+      "channelIdentity": null,
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "html",
+        "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1615943825123",
+      "replyToId": null,
+      "etag": "1615943825123",
+      "messageType": "unknownFutureValue",
+      "createdDateTime": "2021-03-1706:47:05.123Z",
+      "lastModifiedDateTime": "2021-03-1706:47:05.123Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": null,
+      "channelIdentity": null,
+      "policyViolation": null,
+      "from": null,
+      "body": {
+        "contentType": "html",
+        "content": "<systemEventMessage/>"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": [],
+      "eventDetail": {
+        "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail",
+        "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+        "chatDisplayName": "Graph Members",
+        "initiator": {
+          "application": null,
+          "device": null,
+          "user": {
+            "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+            "displayName": null,
+            "userIdentityType": "aadUser"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_messages_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_messages_v1.0.json
@@ -1,0 +1,120 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#chats('19%3A2da4c29f6d7041eca70b638b43d45437%40thread.v2')/messages",
+  "@odata.count": 3,
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$skiptoken=M2UyZDAwMDAwMDMxMzkzYTMyNjQ2MTM0NjMzMjM5NjYzNjY0MzczMDM0MzE2NTYzNjEzNzMwNjIzNjMzMzg2MjM0MzM2NDM0MzUzNDMzMzc0MDc0Njg3MjY1NjE2NDJlNzYzMjAxZThmYjY4M2Y3ODAxMDAwMDg4NjA5ODdhNzgwMTAwMDB8MTYxNjk2NDUwOTgzMg%3d%3d",
+  "value": [
+    {
+      "id": "1616964509832",
+      "replyToId": null,
+      "etag": "1616964509832",
+      "messageType": "message",
+      "createdDateTime": "2021-03-28T20:48:29.832Z",
+      "lastModifiedDateTime": "2021-03-28T20:48:29.832Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": null,
+      "channelIdentity": null,
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "text",
+        "content": "Hello world"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1615971548136",
+      "replyToId": null,
+      "etag": "1615971548136",
+      "messageType": "message",
+      "createdDateTime": "2021-03-17T08:59:08.136Z",
+      "lastModifiedDateTime": "2021-03-17T08:59:08.136Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": null,
+      "channelIdentity": null,
+      "policyViolation": null,
+      "eventDetail": null,
+      "from": {
+        "application": null,
+        "device": null,
+        "user": {
+          "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+          "displayName": "Robin Kline",
+          "userIdentityType": "aadUser"
+        }
+      },
+      "body": {
+        "contentType": "html",
+        "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": []
+    },
+    {
+      "id": "1615943825123",
+      "replyToId": null,
+      "etag": "1615943825123",
+      "messageType": "unknownFutureValue",
+      "createdDateTime": "2021-03-1706:47:05.123Z",
+      "lastModifiedDateTime": "2021-03-1706:47:05.123Z",
+      "lastEditedDateTime": null,
+      "deletedDateTime": null,
+      "subject": null,
+      "summary": null,
+      "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+      "importance": "normal",
+      "locale": "en-us",
+      "webUrl": null,
+      "channelIdentity": null,
+      "policyViolation": null,
+      "from": null,
+      "body": {
+        "contentType": "html",
+        "content": "<systemEventMessage/>"
+      },
+      "attachments": [],
+      "mentions": [],
+      "reactions": [],
+      "messageHistory": [],
+      "eventDetail": {
+        "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail",
+        "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+        "chatDisplayName": "Graph Members",
+        "initiator": {
+          "application": null,
+          "device": null,
+          "user": {
+            "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+            "displayName": null,
+            "userIdentityType": "aadUser"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_chats_v1.0.json
@@ -1,0 +1,42 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#chats",
+  "@odata.count": 3,
+  "value": [
+    {
+      "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2",
+      "topic": "Meeting chat sample",
+      "createdDateTime": "2020-12-08T23:53:05.801Z",
+      "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z",
+      "chatType": "meeting",
+      "chatViewpoint": {
+        "isHidden": false,
+        "lastMessageReadDateTime": "2021-06-03T08:05:49.521Z"
+      },
+      "webUrl": "https://teams.microsoft.com/l/chat/19%3Ameeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+    },
+    {
+      "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2",
+      "topic": "Group chat sample",
+      "createdDateTime": "2020-12-03T19:41:07.054Z",
+      "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z",
+      "chatType": "group",
+      "chatViewpoint": {
+        "isHidden": false,
+        "lastMessageReadDateTime": "2021-05-27T22:13:01.577Z"
+      },
+      "webUrl": "https://teams.microsoft.com/l/chat/19%3A561082c0f3f847a58069deb8eb300807@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+    },
+    {
+      "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces",
+      "topic": null,
+      "createdDateTime": "2020-12-04T23:10:28.51Z",
+      "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z",
+      "chatType": "oneOnOne",
+      "chatViewpoint": {
+        "isHidden": false,
+        "lastMessageReadDateTime": "0001-01-01T00:00:00Z"
+      },
+      "webUrl": "https://teams.microsoft.com/l/chat/19%3Ad74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_onlineMeetings_beta.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_onlineMeetings_beta.json
@@ -1,0 +1,60 @@
+{
+  "@odata.type": "#microsoft.graph.onlineMeeting",
+  "autoAdmittedUsers": "everyone",
+  "audioConferencing": {
+    "tollNumber": "5552478",
+    "tollFreeNumber": "5550588",
+    "ConferenceId": "9999999",
+    "dialinUrl": "https://dialin.teams.microsoft.com/6787A136-B9B8-4D39-846C-C0F1FF937F10?id=xxxxxxx"
+  },
+  "chatInfo": {
+    "@odata.type": "#microsoft.graph.chatInfo",
+    "threadId": "19:cbee7c1c860e465cebf7bee0d@thread.skype",
+    "messageId": "153367081"
+  },
+  "creationDateTime": "2018-05-30T00:12:19.0726086Z",
+  "endDateTime": "2018-05-30T01:00:00Z",
+  "id": "112f7296-5fa4-42ca-bae8-6a692b15d4b8_19:cbee7c1c860e465f8258e3cebf7bee0d@thread.skype",
+  "joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3a:meeting_NTg0NmQ3NTctZDVkZC00YzRhLThmNmEtOGQDdmZDZk@thread.v2/0?context=%7b%22Tid%22%3a%aa67bd4c-8475-432d-bd41-39f255720e0a%22%2c%22Oid%22%3a%22112f7296-5fa4-42ca-bb15d4b8%22%7d",
+  "participants": {
+    "@odata.type": "#microsoft.graph.meetingParticipants",
+    "attendees": [
+      {
+        "@odata.type": "#microsoft.graph.identitySet",
+        "identity": {
+          "user": {
+            "@odata.type": "#microsoft.graph.identity",
+            "id": "112f7296-5ca-bae8-6a692b15d4b8",
+            "displayName": "Tyler Stein"
+          }
+        },
+        "upn": "upn-value"
+      }
+    ],
+    "organizer": {
+      "@odata.type": "#microsoft.graph.identitySet",
+      "identity": {
+        "user": {
+          "@odata.type": "#microsoft.graph.identity",
+          "id": "5810cedeb-b2c1-e9bd5d53ec96",
+          "displayName": "Jasmine Miller"
+        }
+      },
+      "upn": "upn-value"
+    }
+  },
+  "startDateTime": "2018-05-30T00:30:00Z",
+  "subject": "Test Meeting.",
+  "videoTeleconferenceId": "123456789",
+  "lobbyBypassSettings": {
+    "scope": "everyone",
+    "isDialInBypassEnabled": true
+  },
+  "joinMeetingIdSettings": {
+    "isPasscodeRequired": false,
+    "joinMeetingId": "1234567890",
+    "passcode": null
+  },
+  "isEntryExitAnnounced": true,
+  "allowedPresenters": "everyone"
+}

--- a/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_onlineMeetings_v1.0.json
+++ b/docs/sources/microsoft-365/ms-teams/example-api-responses/original/Users_onlineMeetings_v1.0.json
@@ -1,0 +1,60 @@
+{
+  "@odata.type": "#microsoft.graph.onlineMeeting",
+  "autoAdmittedUsers": "everyone",
+  "audioConferencing": {
+    "tollNumber": "5552478",
+    "tollFreeNumber": "5550588",
+    "ConferenceId": "9999999",
+    "dialinUrl": "https://dialin.teams.microsoft.com/6787A136-B9B8-4D39-846C-C0F1FF937F10?id=xxxxxxx"
+  },
+  "chatInfo": {
+    "@odata.type": "#microsoft.graph.chatInfo",
+    "threadId": "19:cbee7c1c860e465cebf7bee0d@thread.skype",
+    "messageId": "153367081"
+  },
+  "creationDateTime": "2018-05-30T00:12:19.0726086Z",
+  "endDateTime": "2018-05-30T01:00:00Z",
+  "id": "112f7296-5fa4-42ca-bae8-6a692b15d4b8_19:cbee7c1c860e465f8258e3cebf7bee0d@thread.skype",
+  "joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3a:meeting_NTg0NmQ3NTctZDVkZC00YzRhLThmNmEtOGQDdmZDZk@thread.v2/0?context=%7b%22Tid%22%3a%aa67bd4c-8475-432d-bd41-39f255720e0a%22%2c%22Oid%22%3a%22112f7296-5fa4-42ca-bb15d4b8%22%7d",
+  "participants": {
+    "@odata.type": "#microsoft.graph.meetingParticipants",
+    "attendees": [
+      {
+        "@odata.type": "#microsoft.graph.identitySet",
+        "identity": {
+          "user": {
+            "@odata.type": "#microsoft.graph.identity",
+            "id": "112f7296-5ca-bae8-6a692b15d4b8",
+            "displayName": "Tyler Stein"
+          }
+        },
+        "upn": "upn-value"
+      }
+    ],
+    "organizer": {
+      "@odata.type": "#microsoft.graph.identitySet",
+      "identity": {
+        "user": {
+          "@odata.type": "#microsoft.graph.identity",
+          "id": "5810cedeb-b2c1-e9bd5d53ec96",
+          "displayName": "Jasmine Miller"
+        }
+      },
+      "upn": "upn-value"
+    }
+  },
+  "startDateTime": "2018-05-30T00:30:00Z",
+  "subject": "Test Meeting.",
+  "videoTeleconferenceId": "123456789",
+  "lobbyBypassSettings": {
+    "scope": "everyone",
+    "isDialInBypassEnabled": true
+  },
+  "joinMeetingIdSettings": {
+    "isPasscodeRequired": false,
+    "joinMeetingId": "1234567890",
+    "passcode": null
+  },
+  "isEntryExitAnnounced": true,
+  "allowedPresenters": "everyone"
+}

--- a/docs/sources/microsoft-365/ms-teams/ms-teams.yaml
+++ b/docs/sources/microsoft-365/ms-teams/ms-teams.yaml
@@ -1,0 +1,232 @@
+---
+endpoints:
+  - pathRegex: "^/(v1.0|beta)/users/?[^/]*"
+    allowedQueryParams:
+      - "$top"
+      - "$select"
+      - "$skiptoken"
+      - "$orderBy"
+      - "$count"
+    transforms:
+      - !<pseudonymizeRegexMatches>
+        jsonPaths:
+          - "$..proxyAddresses[*]"
+        regex: "(?i)^smtp:(.*)$"
+      - !<redact>
+        jsonPaths:
+          - "$..displayName"
+          - "$..aboutMe"
+          - "$..mySite"
+          - "$..preferredName"
+          - "$..givenName"
+          - "$..surname"
+          - "$..mailNickname"
+          - "$..responsibilities"
+          - "$..skills"
+          - "$..faxNumber"
+          - "$..mobilePhone"
+          - "$..businessPhones[*]"
+          - "$..onPremisesExtensionAttributes"
+          - "$..onPremisesSecurityIdentifier"
+          - "$..securityIdentifier"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..employeeId"
+          - "$..userPrincipalName"
+          - "$..imAddresses[*]"
+          - "$..mail"
+          - "$..otherMails[*]"
+          - "$..onPremisesSamAccountName"
+          - "$..onPremisesUserPrincipalName"
+          - "$..onPremisesDistinguishedName"
+          - "$..onPremisesImmutableId"
+          - "$..identities[*].issuerAssignedId"
+        encoding: "JSON"
+  - pathRegex: "^/(v1.0|beta)/groups/?[^/]*"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..owners"
+          - "$..rejectedSenders"
+          - "$..acceptedSenders"
+          - "$..members"
+          - "$..membersWithLicenseErrors"
+          - "$..mailNickname"
+          - "$..description"
+          - "$..resourceBehaviorOptions"
+          - "$..resourceProvisioningOptions"
+          - "$..onPremisesSamAccountName"
+          - "$..onPremisesSecurityIdentifier"
+          - "$..onPremisesProvisioningErrors"
+          - "$..securityIdentifier"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..mail"
+        includeOriginal: true
+        encoding: "JSON"
+  - pathRegex: "^/(v1.0|beta)/groups/[^/]*/members.*"
+    allowedQueryParams:
+      - "$top"
+      - "$select"
+      - "$skiptoken"
+      - "$orderBy"
+      - "$count"
+    transforms:
+      - !<pseudonymizeRegexMatches>
+        jsonPaths:
+          - "$..proxyAddresses[*]"
+        regex: "(?i)^smtp:(.*)$"
+      - !<redact>
+        jsonPaths:
+          - "$..displayName"
+          - "$..aboutMe"
+          - "$..mySite"
+          - "$..preferredName"
+          - "$..givenName"
+          - "$..surname"
+          - "$..mailNickname"
+          - "$..responsibilities"
+          - "$..skills"
+          - "$..faxNumber"
+          - "$..mobilePhone"
+          - "$..businessPhones[*]"
+          - "$..onPremisesExtensionAttributes"
+          - "$..onPremisesSecurityIdentifier"
+          - "$..securityIdentifier"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..employeeId"
+          - "$..userPrincipalName"
+          - "$..imAddresses[*]"
+          - "$..mail"
+          - "$..otherMails[*]"
+          - "$..onPremisesSamAccountName"
+          - "$..onPremisesUserPrincipalName"
+          - "$..onPremisesDistinguishedName"
+          - "$..onPremisesImmutableId"
+          - "$..identities[*].issuerAssignedId"
+        encoding: "JSON"
+  - pathRegex: "^/(v1.0|beta)/teams"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$skipToken"
+      - "$filter"
+      - "$count"
+    transforms:
+    - !<redact>
+      jsonPaths:
+        - "$..displayName"
+        - "$..description"
+  - pathRegex: "^/(v1.0|beta)/teams/[^/]*/allChannels"
+    allowedQueryParams:
+      - "$select"
+      - "$filter"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..displayName"
+          - "$..description"
+  - pathRegex: "^/(v1.0|beta)/users/[^/]*/chats"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$skipToken"
+      - "$filter"
+      - "$orderBy"
+      - "$expand"
+  - pathRegex: "^/(v1.0|beta)/teams/[^/]*/channels/[^/]*/messages"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$skipToken"
+      - "$expand"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..from.user.displayName"
+          - "$..body.content"
+          - "$..attachments"
+          - "$..mentions[*].mentionText"
+          - "$..mentions[*].mentioned.user.displayName"
+          - "$..eventDetail.teamDescription"
+          - "$..eventDetail.initiator.user.displayName"
+  - pathRegex: "^/(v1.0|beta)/teams/[^/]*/channels/[^/]*/messages/delta"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$skipToken"
+      - "$expand"
+      - "$deltaToken"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..from.user.displayName"
+          - "$..body.content"
+          - "$..attachments"
+          - "$..mentions[*].mentionText"
+          - "$..mentions[*].mentioned.user.displayName"
+          - "$..eventDetail.teamDescription"
+          - "$..eventDetail.initiator.user.displayName"
+  - pathRegex: "^/(v1.0|beta)/users/chats/[^/]*/messages"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$skipToken"
+      - "$filter"
+      - "$orderBy"
+      - "$count"
+      - "$expand"
+      - "$format"
+      - "$search"
+      - "$skip"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..from.user.displayName"
+          - "$..body.content"
+          - "$..attachments"
+          - "$..mentions[*].mentionText"
+          - "$..mentions[*].mentioned.user.displayName"
+          - "$..eventDetail.teamDescription"
+          - "$..eventDetail.initiator.user.displayName"
+  - pathRegex: "^/(v1.0|beta)/communications/calls/[^/]*"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$expand"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..displayName"
+  - pathRegex: "^/(v1.0|beta)/communications/callRecords/[^/]*"
+    allowedQueryParams:
+      - "$select"
+      - "$expand"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..organizer.user.displayName"
+          - "$..participants[*].user.displayName"
+          - "$..sessions[*].caller.identity.user.displayName"
+          - "$..sessions[*].callee.identity.user.displayName"
+          - "$..sessions[*].segments[*].caller.identity.user.displayName"
+          - "$..sessions[*].segments[*].callee.identity.user.displayName"
+  - pathRegex: "^/(v1.0|beta)/users/[^/]*/onlineMeetings"
+    allowedQueryParams:
+      - "$select"
+      - "$top"
+      - "$skipToken"
+      - "$filter"
+      - "$orderBy"
+      - "$count"
+      - "$expand"
+      - "$format"
+      - "$search"
+      - "$skip"
+    transforms:
+      - !<redact>
+        jsonPaths:
+          - "$..participants.attendees[*].identity.user.displayName"
+          - "$..participants.organizer.identity.user.displayName"
+          - "$..subject"

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -14,3 +14,5 @@ target
 
 # don't catch config.yaml, may contain secret salt
 impl/cmd-line/config.yaml
+
+.idea/

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -275,6 +275,112 @@ public class PrebuiltSanitizerRules {
             REDACT_CALENDAR_ODATA_LINKS);
 
 
+    static final String MS_TEAMS_PATH_REGEX_TEAMS = "^/(v1.0|beta)/teams";
+    static final String MS_TEAMS_PATH_REGEX_TEAMS_ALL_CHANNELS = "^/(v1.0|beta)/teams/[^/]*/allChannels";
+    static final String MS_TEAMS_PATH_REGEX_USERS_CHATS = "^/(v1.0|beta)/users/[^/]*/chats";
+    static final String MS_TEAMS_PATH_REGEX_TEAMS_CHANNELS_MESSAGES = "^/(v1.0|beta)/teams/[^/]*/channels/[^/]*/messages";
+    static final String MS_TEAMS_PATH_REGEX_TEAMS_CHANNELS_MESSAGES_DELTA = "^/(v1.0|beta)/teams/[^/]*/channels/[^/]*/messages/delta";
+    static final String MS_TEAMS_PATH_REGEX_USERS_CHATS_MESSAGES = "^/(v1.0|beta)/users/chats/[^/]*/messages";
+    static final String MS_TEAMS_PATH_REGEX_COMMUNICATIONS_CALLS = "^/(v1.0|beta)/communications/calls/[^/]*";
+    static final String MS_TEAMS_PATH_REGEX_COMMUNICATIONS_CALLRECORDS = "^/(v1.0|beta)/communications/callRecords/[^/]*";
+    static final String MS_TEAMS_PATH_REGEX_USERS_ONLINEMEETINGS = "^/(v1.0|beta)/users/[^/]*/onlineMeetings";
+
+
+    static final List<Endpoint>  MS_TEAMS_ENDPOINTS = Arrays.asList(
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_TEAMS)
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..displayName")
+                .jsonPath("$..description")
+                .build())
+            .allowedQueryParams(List.of("$select","$top","$skipToken","$filter", "$count"))
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_TEAMS_ALL_CHANNELS)
+            .allowedQueryParams(List.of("$select","$filter"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..displayName")
+                .jsonPath("$..description")
+                .build())
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_USERS_CHATS)
+            .allowedQueryParams(List.of("$select","$top","$skipToken", "$filter",  "$orderBy", "$expand"))
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_TEAMS_CHANNELS_MESSAGES)
+            .allowedQueryParams(List.of("$select","$top","$skipToken","$expand"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..from.user.displayName")
+                .jsonPath("$..body.content")
+                .jsonPath("$..attachments")
+                .jsonPath("$..mentions[*].mentionText")
+                .jsonPath("$..mentions[*].mentioned.user.displayName")
+                .jsonPath("$..eventDetail.teamDescription")
+                .jsonPath("$..eventDetail.initiator.user.displayName")
+                .build())
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_TEAMS_CHANNELS_MESSAGES_DELTA)
+            .allowedQueryParams(List.of("$select","$top","$skipToken","$expand", "$deltaToken"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..from.user.displayName")
+                .jsonPath("$..body.content")
+                .jsonPath("$..attachments")
+                .jsonPath("$..mentions[*].mentionText")
+                .jsonPath("$..mentions[*].mentioned.user.displayName")
+                .jsonPath("$..eventDetail.teamDescription")
+                .jsonPath("$..eventDetail.initiator.user.displayName")
+                .build())
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_USERS_CHATS_MESSAGES)
+            .allowedQueryParams(List.of("$select","$top","$skipToken","$filter", "$orderBy", "$count", "$expand", "$format", "$search", "$skip"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..from.user.displayName")
+                .jsonPath("$..body.content")
+                .jsonPath("$..attachments")
+                .jsonPath("$..mentions[*].mentionText")
+                .jsonPath("$..mentions[*].mentioned.user.displayName")
+                .jsonPath("$..eventDetail.teamDescription")
+                .jsonPath("$..eventDetail.initiator.user.displayName")
+                .build())
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_COMMUNICATIONS_CALLS)
+            .allowedQueryParams(List.of("$select","$top","$expand"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..displayName")
+                .build())
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_COMMUNICATIONS_CALLRECORDS)
+            .allowedQueryParams(List.of("$select","$expand"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..organizer.user.displayName")
+                .jsonPath("$..participants[*].user.displayName")
+                .jsonPath("$..sessions[*].caller.identity.user.displayName")
+                .jsonPath("$..sessions[*].callee.identity.user.displayName")
+                .jsonPath("$..sessions[*].segments[*].caller.identity.user.displayName")
+                .jsonPath("$..sessions[*].segments[*].callee.identity.user.displayName")
+                .build())
+            .build(),
+        Endpoint.builder()
+            .pathRegex(MS_TEAMS_PATH_REGEX_USERS_ONLINEMEETINGS)
+            .allowedQueryParams(List.of("$select","$top","$skipToken","$filter", "$orderBy", "$count", "$expand", "$format", "$search", "$skip"))
+            .transform(Transform.Redact.builder()
+                .jsonPath("$..participants.attendees[*].identity.user.displayName")
+                .jsonPath("$..participants.organizer.identity.user.displayName")
+                .jsonPath("$..subject")
+                .build())
+            .build()
+    );
+
+    static final Rules2 MS_TEAMS = DIRECTORY.withAdditionalEndpoints(MS_TEAMS_ENDPOINTS);
+
+    static final Rules2 MS_TEAMS_NO_APP_IDS = DIRECTORY_NO_MSFT_IDS
+        .withAdditionalEndpoints(MS_TEAMS_ENDPOINTS);
+
     public static final Map<String, RESTRules> MSFT_DEFAULT_RULES_MAP =
         ImmutableMap.<String, RESTRules>builder()
             .put("azure-ad", DIRECTORY)
@@ -285,5 +391,7 @@ public class PrebuiltSanitizerRules {
             .put("outlook-mail", OUTLOOK_MAIL)
             .put("outlook-mail" + ConfigRulesModule.NO_APP_IDS_SUFFIX, OUTLOOK_MAIL_NO_APP_IDS)
             .put("outlook-mail" + ConfigRulesModule.NO_APP_IDS_SUFFIX + "-no-groups", OUTLOOK_MAIL_NO_APP_IDS_NO_GROUPS)
+            .put("ms-teams", MS_TEAMS)
+            .put("ms-teams" + ConfigRulesModule.NO_APP_IDS_SUFFIX, MS_TEAMS_NO_APP_IDS)
             .build();
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
@@ -1,0 +1,333 @@
+package co.worklytics.psoxy.rules.msft;
+
+import co.worklytics.psoxy.rules.JavaRulesTestBaseCase;
+import co.worklytics.psoxy.rules.RESTRules;
+import co.worklytics.psoxy.rules.Rules2;
+import jdk.jfr.Description;
+import lombok.Getter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TeamsTests extends JavaRulesTestBaseCase {
+
+    @Getter
+    final Rules2 rulesUnderTest = PrebuiltSanitizerRules.MS_TEAMS;
+
+    @Getter
+    final RulesTestSpec rulesTestSpec = RulesTestSpec.builder()
+        .sourceFamily("microsoft-365")
+        .defaultScopeId("azure-ad")
+        .sourceKind("ms-teams")
+        .build();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /teams")
+    public void teams(String apiVersion) {
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/teams";
+        String jsonResponse = asJson("Teams_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "b695c5a5-c5a5-b695-a5c5-95b6a5c595b6",
+            "172b0cce-e65d-7hd4-9a49-91d9f2e8493a",
+            "Contoso Team"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Contoso Team",
+            "This is a Contoso team, used to showcase the range of properties supported by this API",
+
+            "Contoso General Team",
+            "This is a general Contoso team",
+
+            "Contoso API Team",
+            "This is Contoso API team"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /teams/{teamId}/allChannels")
+    public void teams_allChannels(String apiVersion) {
+        String teamId = "172b0cce-e65d-44ce-9a49-91d9f2e8493a";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/teams/" + teamId + "/allChannels";
+        String jsonResponse = asJson("Teams_allChannels_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "19:561fbdbbfca848a484f0a6f00ce9dbbd@thread.tacv2",
+            "2020-05-27T19:22:25.692Z",
+            "standard",
+            "b3246f44-b4gb-4627-96c6-25b18fa2c910",
+
+            "19:561fbdbbfca848a484gabdf00ce9dbbd@thread.tacv2",
+            "2020-05-27T19:22:25.692Z",
+            "standard",
+            "b3246f44-b4gb-5678-96c6-25b18fa2c910"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "General",
+            "AutoTestTeam_20210311_150740.2550_fim3udfdjen9",
+
+            "Shared channel from Contoso"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /users/{userId}/chats")
+    public void users_chats(String apiVersion) {
+        String userId = "8b081ef6-4792-4def-b2c9-c363a1bf41d5";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/users/" + userId + "/chats";
+        String jsonResponse = asJson("Users_chats_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2",
+            "Meeting chat sample",
+            "2020-12-08T23:53:05.801Z",
+            "2020-12-08T23:58:32.511Z",
+            "meeting",
+            "https://teams.microsoft.com/l/chat/19%3Ameeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f",
+
+           "19:561082c0f3f847a58069deb8eb300807@thread.v2",
+            "Group chat sample",
+            "2020-12-03T19:41:07.054Z",
+            "2020-12-08T23:53:11.012Z",
+            "group",
+            "https://teams.microsoft.com/l/chat/19%3A561082c0f3f847a58069deb8eb300807@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f",
+
+            "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces",
+            "2020-12-04T23:10:28.51Z",
+            "2020-12-04T23:10:36.925Z",
+            "oneOnOne",
+            "https://teams.microsoft.com/l/chat/19%3Ad74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /teams/{teamId}/channels/{channelId}/messages")
+    public void teams_channels_messages(String apiVersion) {
+        String teamId = "172b0cce-e65d-44ce-9a49-91d9f2e8493a";
+        String userId = "8b081ef6-4792-4def-b2c9-c363a1bf41d5";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/teams/" + teamId + "/channels/" + userId + "/messages";
+        String jsonResponse = asJson("Teams_channels_messages_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "1616965872395",
+            "message",
+            "2021-03-28T21:11:12.395Z",
+            "normal",
+            "en-us",
+            "html",
+            "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616965872395?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616965872395&parentMessageId=1616965872395",
+            "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+            "aadUser",
+            "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+            "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2",
+            "ef1c916a-3135-4417-ba27-8eb7bd084193",
+
+            "1616963377068",
+            "message",
+            "2021-03-28T20:29:37.068Z",
+            "normal",
+            "en-us",
+            "html",
+            "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616963377068?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616963377068&parentMessageId=1616963377068",
+            "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+            "aadUser",
+            "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+            "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2",
+
+            "1616883610266",
+            "unknownFutureValue",
+            "2021-03-28T03:50:10.266Z",
+            "normal",
+            "en-us",
+            "html",
+            "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616883610266?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616883610266&parentMessageId=1616883610266",
+            "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+            "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2",
+            "1fb8890f-423e-4154-8fbf-db6809bc8756",
+            "aadUser"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Robin Kline",
+            "Hello World <at id=\\\"0\\\">Jane Smith</at>",
+            "Jane Smith",
+
+            "<div><div><div><span><img height=\\\"145\\\" src=\\\"https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/1616963377068/hostedContents/aWQ9eF8wLXd1cy1kMS02YmI3Nzk3ZGU2MmRjODdjODA4YmQ1ZmI0OWM4NjI2ZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kMS02YmI3Nzk3ZGU2MmRjODdjODA4YmQ1ZmI0OWM4NjI2ZC92aWV3cy9pbWdv/$value\\\" width=\\\"131\\\" style=\\\"vertical-align:bottom; width:131px; height:145px\\\"></span><div>&nbsp;</div></div><div><div><span><img height=\\\"65\\\" src=\\\"https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages/1616963377068/hostedContents/aWQ9eF8wLXd1cy1kNi0xMzY3OTE4MzVlODIxOGZlMmUwZWEwYTA1ODAxNjRiNCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0xMzY3OTE4MzVlODIxOGZlMmUwZWEwYTA1ODAxNjRiNC92aWV3cy9pbWdv/$value\\\" width=\\\"79\\\" style=\\\"vertical-align:bottom; width:79px; height:65px\\\"></span></div></div></div></div>",
+
+            "<systemEventMessage/>",
+            "Team for Microsoft Teams members"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /teams/{teamId}/channels/{channelId}/messages/delta")
+    public void teams_channels_messages_delta(String apiVersion) {
+        String teamId = "172b0cce-e65d-44ce-9a49-91d9f2e8493a";
+        String userId = "8b081ef6-4792-4def-b2c9-c363a1bf41d5";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/teams/" + teamId + "/channels/" + userId + "/messages/delta";
+        String jsonResponse = asJson("Teams_channels_messages_delta_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "1606515483514",
+            "message",
+            "2020-11-27T22:18:03.514Z",
+            "normal",
+            "en-us",
+            "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1606515483514?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1606515483514&parentMessageId=1606515483514",
+            "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+            "aadUser",
+            "e61ef81e-8bd8-476a-92e8-4a62f8426fca",
+            "text",
+            "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+            "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2",
+
+            "1606691795113",
+            "message",
+            "2020-11-29T23:16:35.113Z",
+            "normal",
+            "en-us",
+            "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1606691795113?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1606691795113&parentMessageId=1606691795113",
+            "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+            "aadUser",
+            "e61ef81e-8bd8-476a-92e8-4a62f8426fca",
+            "text",
+            "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+            "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Robin Kline",
+            "Test",
+
+            "Robin Kline",
+            "HelloWorld 11/29/2020 3:16:31 PM -08:00"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /users/chats/{chatId}/messages")
+    public void users_chats_messages(String apiVersion) {
+        String chatId = "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/users/chats/" + chatId + "/messages";
+        String jsonResponse = asJson("Users_chats_messages_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "1616964509832",
+            "message",
+            "2021-03-28T20:48:29.832Z",
+            "normal",
+            "en-us",
+            "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+            "aadUser",
+            "text",
+
+            "1615971548136",
+            "2021-03-17T08:59:08.136Z",
+            "html"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Robin Kline",
+            "Hello world",
+
+            "<div><div><div><span><img height=\\\"63\\\" src=\\\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\\\" width=\\\"67\\\" style=\\\"vertical-align:bottom; width:67px; height:63px\\\"></span></div></div></div>",
+
+            "<systemEventMessage/>"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /communications/calls/{callId}")
+    public void communications_calls(String apiVersion) {
+        String callId = "2f1a1100-b174-40a0-aba7-0b405e01ed92";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/communications/calls/" + callId;
+        String jsonResponse = asJson("Communications_calls_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "established",
+            "outgoing",
+            "https://bot.contoso.com/callback",
+            "2891555a-92ff-42e6-80fa-6e1300c6b5c6"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Calling Bot"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /communications/callRecords/{callChainId}")
+    public void communications_callRecords(String apiVersion) {
+        String callChainId = "2f1a1100-b174-40a0-aba7-0b405e01ed92";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/communications/callRecords/" + callChainId;
+        String jsonResponse = asJson("Communications_callRecords_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "2020-02-25T19:00:24.582757Z",
+            "2020-02-25T18:52:21.2169889Z",
+            "2020-02-25T18:52:46.7640013Z",
+            "e523d2ed-2966-4b6b-925b-754a88034cc5",
+            "821809f5-0000-0000-0000-3b5136c0e777",
+            "dc368399-474c-4d40-900c-6265431fd81f",
+            "821809f5-0000-0000-0000-3b5136c0e777",
+            "dc368399-474c-4d40-900c-6265431fd81f",
+            "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+            "dc368399-474c-4d40-900c-6265431fd81f"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Abbie Wilkins",
+            "Owen Franklin"
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1.0", "beta"})
+    @Description("Test endpoint: /users/{userId}/onlineMeetings")
+    public void users_onlineMeetings(String apiVersion) {
+        String userId = "dc17674c-81d9-4adb-bfb2-8f6a442e4622";
+        String endpoint = "https://graph.microsoft.com/" + apiVersion + "/users/" + userId + "/onlineMeetings";
+        String jsonResponse = asJson("Users_onlineMeetings_"+ apiVersion + ".json");
+        assertNotSanitized(jsonResponse,
+            "everyone",
+            "5552478",
+            "5550588",
+            "9999999",
+            "https://dialin.teams.microsoft.com/6787A136-B9B8-4D39-846C-C0F1FF937F10?id=xxxxxxx",
+            "153367081",
+            "2018-05-30T00:12:19.0726086Z",
+            "2018-05-30T01:00:00Z",
+            "112f7296-5fa4-42ca-bae8-6a692b15d4b8_19:cbee7c1c860e465f8258e3cebf7bee0d@thread.skype",
+            "https://teams.microsoft.com/l/meetup-join/19%3a:meeting_NTg0NmQ3NTctZDVkZC00YzRhLThmNmEtOGQDdmZDZk@thread.v2/0?context=%7b%22Tid%22%3a%aa67bd4c-8475-432d-bd41-39f255720e0a%22%2c%22Oid%22%3a%22112f7296-5fa4-42ca-bb15d4b8%22%7d",
+            "112f7296-5ca-bae8-6a692b15d4b8",
+            "5810cedeb-b2c1-e9bd5d53ec96"
+        );
+
+        String sanitized = sanitize(endpoint, jsonResponse);
+        assertRedacted(sanitized,
+            "Tyler Stein",
+            "Jasmine Miller",
+            "Test Meeting."
+        );
+        assertUrlWithSubResourcesBlocked(endpoint); //paging
+    }
+}


### PR DESCRIPTION
Added rules to expose endpoints we need via MS Team Proxy

* /teams
* /teams/{teamId}/allChannels
* /users/{userId}/chats
* /teams/{teamId}/channels/{channelId}/messages
* /teams/{teamId}/channels/{channelId}/messages/delta
* /chats/{chatId}/messages
* /communications/calls/{callId}
* /communications/callRecords/{callChainId}
* /users/{userId}/onlineMeetings

### Features
[S162: MSFT Teams via Proxy ](https://app.asana.com/0/302559783667519/1205663770851425/f)

### Change implications
 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? 
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? 
