### PR TITLE
Gh onprem connector

### DIFF
--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -53,10 +53,12 @@ Copy the value of `installationId` and assign it to the `github_installation_id`
 - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
 - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
 
-6. Update the variables with values obtained in previous step:
+6. (Only for GitHub Server) If you are using GitHub Server, you will need to set the `github_api_host` variable in Terraform to the URL of your GitHub Server instance. You will need to redeploy the proxy again if that value was not populated before.
+
+7. Update the variables with values obtained in previous step:
    - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.
    - `PSOXY_GITHUB_PRIVATE_KEY` with content of the `gh_pk_pkcs8.pem` from previous step. You could open the certificate with VS Code or any other editor and copy all the content *as-is* into this variable.
-7. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+8. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
 
 ## Reference
 These instructions have been derived from [worklytics-connector-specs](../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -61,4 +61,4 @@ Copy the value of `installationId` and assign it to the `github_installation_id`
 8. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
 
 ## Reference
-These instructions have been derived from [worklytics-connector-specs](../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.
+These instructions have been derived from [worklytics-connector-specs](../../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.

--- a/docs/sources/salesforce/README.md
+++ b/docs/sources/salesforce/README.md
@@ -51,4 +51,4 @@ Before running the example, you have to populate the following variables in terr
 
    However, if running any of the queries you receive a 401/403/500/512. A 401/403 it might be related to some misconfiguration in the Salesforce Application due lack of permissions;
    a 500/512 it could be related to missing parameter in the function configuration (for example, a missing value for `salesforce_domain` variable in your terraform vars)
-NOTE: derived from [worklytics-connector-specs](../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.
+NOTE: derived from [worklytics-connector-specs](../../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -26,6 +26,7 @@ module "worklytics_connectors" {
   jira_server_url               = var.jira_server_url
   jira_example_issue_id         = var.jira_example_issue_id
   salesforce_domain             = var.salesforce_domain
+  github_api_host               = var.github_api_host
   github_installation_id        = var.github_installation_id
   github_organization           = var.github_organization
   github_example_repository     = var.github_example_repository

--- a/infra/examples-dev/aws-all/misc-data-source-variables.tf
+++ b/infra/examples-dev/aws-all/misc-data-source-variables.tf
@@ -26,6 +26,12 @@ variable "jira_example_issue_id" {
   description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -35,6 +35,7 @@ module "worklytics_connectors" {
   jira_server_url               = var.jira_server_url
   jira_example_issue_id         = var.jira_example_issue_id
   salesforce_domain             = var.salesforce_domain
+  github_api_host               = var.github_api_host
   github_installation_id        = var.github_installation_id
   github_organization           = var.github_organization
   github_example_repository     = var.github_example_repository

--- a/infra/examples-dev/gcp/misc-data-source-variables.tf
+++ b/infra/examples-dev/gcp/misc-data-source-variables.tf
@@ -26,6 +26,12 @@ variable "jira_example_issue_id" {
   description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -32,6 +32,7 @@ module "worklytics_connector_specs" {
   jira_server_url                = var.jira_server_url
   jira_cloud_id                  = var.jira_cloud_id
   example_jira_issue_id          = var.example_jira_issue_id
+  github_api_host                = var.github_api_host
   github_installation_id         = var.github_installation_id
   github_organization            = var.github_organization
   github_example_repository      = var.github_example_repository

--- a/infra/modular-examples/aws-google-workspace/variables.tf
+++ b/infra/modular-examples/aws-google-workspace/variables.tf
@@ -289,6 +289,12 @@ variable "example_jira_issue_id" {
   description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -35,6 +35,7 @@ module "worklytics_connector_specs" {
   jira_server_url           = var.jira_server_url
   jira_cloud_id             = var.jira_cloud_id
   example_jira_issue_id     = var.example_jira_issue_id
+  github_api_host           = var.github_api_host
   github_installation_id    = var.github_installation_id
   github_organization       = var.github_organization
   github_example_repository = var.github_example_repository

--- a/infra/modular-examples/aws-msft-365/variables.tf
+++ b/infra/modular-examples/aws-msft-365/variables.tf
@@ -268,6 +268,12 @@ variable "example_jira_issue_id" {
   description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -43,6 +43,7 @@ module "worklytics_connector_specs" {
   jira_server_url                = var.jira_server_url
   jira_cloud_id                  = var.jira_cloud_id
   example_jira_issue_id          = var.example_jira_issue_id
+  github_api_host                = var.github_api_host
   github_installation_id         = var.github_installation_id
   github_organization            = var.github_organization
   github_example_repository      = var.github_example_repository

--- a/infra/modular-examples/aws/variables.tf
+++ b/infra/modular-examples/aws/variables.tf
@@ -296,6 +296,12 @@ variable "example_jira_issue_id" {
   description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -24,6 +24,7 @@ module "worklytics_connector_specs" {
   jira_server_url                = var.jira_server_url
   jira_cloud_id                  = var.jira_cloud_id
   example_jira_issue_id          = var.example_jira_issue_id
+  github_api_host                = var.github_api_host
   github_installation_id         = var.github_installation_id
   github_organization            = var.github_organization
   github_example_repository      = var.github_example_repository

--- a/infra/modular-examples/gcp-google-workspace/variables.tf
+++ b/infra/modular-examples/gcp-google-workspace/variables.tf
@@ -191,6 +191,12 @@ variable "example_jira_issue_id" {
   description = "(Only required if using Jira Server/Cloud connector) Id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -157,6 +157,7 @@ locals {
 
   jira_cloud_id                 = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
   jira_example_issue_id         = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
+  github_api_host               = coalesce(var.github_api_host, "api.github.com")
   github_installation_id        = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
   github_organization           = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
   github_example_repository     = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
@@ -298,7 +299,7 @@ EOT
       display_name : "Github"
       identifier_scope_id : "github"
       worklytics_connector_name : "Github via Psoxy"
-      target_host : "api.github.com"
+      target_host : local.github_api_host
       source_auth_strategy : "oauth2_refresh_token"
       secured_variables : [
         {
@@ -330,7 +331,7 @@ EOT
       environment_variables : {
         GRANT_TYPE : "certificate_credentials"
         TOKEN_RESPONSE_TYPE : "GITHUB_ACCESS_TOKEN"
-        REFRESH_ENDPOINT : "https://api.github.com/app/installations/${local.github_installation_id}/access_tokens"
+        REFRESH_ENDPOINT : "https://${local.github_api_host}/app/installations/${local.github_installation_id}/access_tokens"
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -58,6 +58,11 @@ variable "jira_example_issue_id" {
   description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com). If not provided, it will use 'api.github.com' as default value"
+}
 
 variable "github_installation_id" {
   type        = string

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -8,6 +8,7 @@ module "worklytics_connector_specs" {
   salesforce_domain             = var.salesforce_domain
   example_jira_issue_id         = var.example_jira_issue_id
   jira_example_issue_id         = var.jira_example_issue_id
+  github_api_host               = var.github_api_host
   github_installation_id        = var.github_installation_id
   github_organization           = var.github_organization
   github_example_repository     = var.github_example_repository

--- a/infra/modules/worklytics-connectors/variables.tf
+++ b/infra/modules/worklytics-connectors/variables.tf
@@ -34,6 +34,12 @@ variable "jira_example_issue_id" {
   description = "If using Jira Server/Cloud connector, provide id of an issue for only to be used as part of example calls for Jira (ex: ETV-12)"
 }
 
+variable "github_api_host" {
+  type        = string
+  default     = null
+  description = "(Only required if using Github connector for on premises) Host of the Github instance (ex: github.mycompany.com)."
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null


### PR DESCRIPTION
- Adding support for customizing host on GH connector, useful for creating connections based on GitHubServer. If no setting is provided, it will use default endpoints for GitHub Cloud.
- Fixed couple of links broken in docs.

### Fixes
- [broken link in proxy github documentation](https://app.asana.com/0/1205931096230893/1205996119283958)

### Features
- [Proxy support for on prem](https://app.asana.com/0/0/1206000002219879)

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change **no**
