### PR TITLE
MSFT Teams via Proxy - Data Connector via Proxy (Terraform changes)

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -258,13 +258,26 @@ locals {
       target_host : "graph.microsoft.com"
       required_oauth2_permission_scopes : [],
       required_app_roles : [
-        "Team.ReadBasic.All",
-        "Channel.ReadBasic.All",
-        "Chat.ReadBasic",
-        "Chat.Read",
-        "ChannelMessage.Read.All",
-        "CallRecords.Read.All",
-        "OnlineMeetings.Read"
+      # Least privileged permissions
+      "Team.ReadBasic.All",
+      "Channel.ReadBasic.All",
+      "Chat.ReadBasic.All",
+      "Chat.Read.All",
+      #"ChannelMessage.Read.Group*",
+      "ChannelMessage.Read.All",
+      "CallRecords.Read.All",
+      "OnlineMeetings.Read.All"
+
+      # Higher privileged permissions
+#        "TeamSettings.Read.All",
+#        "TeamSettings.ReadWrite.All",
+#        "ChannelSettings.Read.All",
+#        "ChannelSettings.ReadWrite.All",
+#        "Chat.ReadWrite.All",
+#        "ChatMessage.Read.Chat",
+#        "Calls.AccessMedia.All",
+#        "OnlineMeetings.ReadWrite.All",
+#        "OnlineMeetingArtifact.Read.All"
       ],
       environment_variables : {
         GRANT_TYPE : "workload_identity_federation"
@@ -291,6 +304,8 @@ locals {
         "/v1.0/{apiVersion}/chats/{chatId}/messages",
         "/v1.0/{apiVersion}/communications/calls/{callId}",
         "/v1.0/{apiVersion}/communications/callRecords/{callChainId}",
+        "/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)",
+        "/v1.0/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)",
         "/v1.0/{apiVersion}/users/{userId}/onlineMeetings"
       ]
     }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -248,6 +248,51 @@ locals {
         "/v1.0/groups",
         "/v1.0/groups/{group-id}/members"
       ]
+    },
+    "msft-teams" : {
+      source_kind : "msft-teams"
+      worklytics_connector_id : "msft-teams-psoxy",
+      display_name : "Microsoft Teams"
+      identifier_scope_id : "azure-ad"
+      source_auth_strategy : "oauth2_refresh_token"
+      target_host : "graph.microsoft.com"
+      required_oauth2_permission_scopes : [],
+      required_app_roles : [
+        "Team.ReadBasic.All",
+        "Channel.ReadBasic.All",
+        "Chat.ReadBasic",
+        "Chat.Read",
+        "ChannelMessage.Read.All",
+        "CallRecords.Read.All",
+        "OnlineMeetings.Read"
+      ],
+      environment_variables : {
+        GRANT_TYPE : "workload_identity_federation"
+        # by default, assumed to be of type 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+        TOKEN_SCOPE : "https://graph.microsoft.com/.default"
+        REFRESH_ENDPOINT : "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
+      }
+      example_api_calls : [
+        "/beta/{apiVersion}/teams",
+        "/beta/{apiVersion}/teams/{teamId}/allChannels",
+        "/beta/{apiVersion}/users/{userId}/chats",
+        "/beta/{apiVersion}/teams/{teamId}/channels/{channelId}/messages",
+        "/beta/{apiVersion}/teams/{teamId}/channels/{channelId}/messages/delta",
+        "/beta/{apiVersion}/chats/{chatId}/messages",
+        "/beta/{apiVersion}/communications/calls/{callId}",
+        "/beta/{apiVersion}/communications/callRecords/{callChainId}",
+        "/beta/{apiVersion}/users/{userId}/onlineMeetings",
+
+        "/v1.0/{apiVersion}/teams",
+        "/v1.0/{apiVersion}/teams/{teamId}/allChannels",
+        "/v1.0/{apiVersion}/users/{userId}/chats",
+        "/v1.0/{apiVersion}/teams/{teamId}/channels/{channelId}/messages",
+        "/v1.0/{apiVersion}/teams/{teamId}/channels/{channelId}/messages/delta",
+        "/v1.0/{apiVersion}/chats/{chatId}/messages",
+        "/v1.0/{apiVersion}/communications/calls/{callId}",
+        "/v1.0/{apiVersion}/communications/callRecords/{callChainId}",
+        "/v1.0/{apiVersion}/users/{userId}/onlineMeetings"
+      ]
     }
   }
 


### PR DESCRIPTION
Terraform changes to create Data Connector via Proxy.

### Features
[S162: MSFT Teams via Proxy ](https://app.asana.com/0/302559783667519/1205663770851425/f)

### Change implications
 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? 
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op?  **Yes, added terraform configuration for MS Team Proxy endpoints (see /[psoxy/java/core/src/test/resources/sources/microsoft-365/ms-teams/ms-teams.yaml](psoxy/java/core/src/test/resources/sources/microsoft-365/ms-teams/ms-teams.yaml))**