### PR TITLE
Gh nonenterprise connector

### DIFF
--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -7,6 +7,12 @@
 
 ## Steps to Connect
 
+There are two connectors available for Github:
+  - [Github Free/Professional]
+  - [Github Enterprise]
+
+Both share the same configuration and setup instructions except Administration permission for Audit Log events.
+
 Follow the following steps:
 
 1. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
@@ -17,12 +23,12 @@ Follow the following steps:
         - Metadata: for listing repositories and branches
         - Pull requests: for listing pull requests, reviews, comments and commits
     - Organization
-        - Administration: for listing events from audit log
+        - Administration: (Only for GitHub Enterprise) for listing events from audit log
         - Members: for listing teams and their members
 
 NOTES:
 - We assume that ALL the repositories are going to be list **should be owned by the organization, not the users**.
-- Enterprise Cloud is required for this connector.
+- In case of using GitHub Server, you need to populate `github_api_host` variable in Terraform with the URL of the API for your GitHub Server instance. For example, `https://api.github.your-company.com`.
 
 Apart from GitHub instructions please review the following:
   - "Homepage URL" can be anything, not required in this flow but required by Github.

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -148,7 +148,7 @@ variable "api_connectors" {
       value_managed_by_tf = optional(bool, true)
       })),
     [])
-
+    settings_to_provide = optional(map(string), {})
   }))
 
   description = "map of API connectors to provision"

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -134,7 +134,7 @@ variable "api_connectors" {
       description         = optional(string)
       })),
     [])
-
+    settings_to_provide = optional(map(string), {})
   }))
 
   description = "map of API connectors to provision"

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -296,9 +296,9 @@ EOT
     github = {
       source_kind : "github",
       worklytics_connector_id : "github-enterprise-psoxy"
-      display_name : "Github"
+      display_name : "Github Enterprise"
       identifier_scope_id : "github"
-      worklytics_connector_name : "Github via Psoxy"
+      worklytics_connector_name : "Github Enterprise via Psoxy"
       target_host : local.github_api_host
       source_auth_strategy : "oauth2_refresh_token"
       secured_variables : [
@@ -344,6 +344,111 @@ EOT
         "/orgs/${local.github_organization}/members",
         "/orgs/${local.github_organization}/teams",
         "/orgs/${local.github_organization}/audit-log",
+        "/repos/${local.github_organization}/${local.github_example_repository}/events",
+        "/repos/${local.github_organization}/${local.github_example_repository}/commits",
+        "/repos/${local.github_organization}/${local.github_example_repository}/issues",
+        "/repos/${local.github_organization}/${local.github_example_repository}/pulls",
+      ]
+      external_token_todo : <<EOT
+  1. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
+    with following permissions with **Read Only**:
+    - Repository:
+      - Contents: for reading commits and comments
+      - Issues: for listing issues, comments, assignees, etc.
+      - Metadata: for listing repositories and branches
+      - Pull requests: for listing pull requests, reviews, comments and commits
+    - Organization
+      - Administration: for listing events from audit log
+      - Members: for listing teams and their members
+
+  NOTES:
+    - We assume that ALL the repositories are going to be list **should be owned by the organization, not the users**.
+    - Enterprise Cloud is required for this connector.
+
+  Apart from Github instructions please review the following:
+  - "Homepage URL" can be anything, not required in this flow but required by Github.
+  - Webhooks check can be disabled as this connector is not using them
+  - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
+  2. Once is created please generate a new `Private Key`.
+  3. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
+```shell
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE FILE} -out gh_pk_pkcs8.pem -nocrypt
+```
+
+**NOTES**:
+ - If the certificate is not converted to PKCS#8 connector will NOT work. You might see in logs a Java error `Invalid PKCS8 data.` if the format is not correct.
+ - Command proposed has been successfully tested on Ubuntu; it may differ for other operating systems.
+
+  4. Install the application in your organization.
+     Go to your organization settings and then in "Developer Settings". Then, click on "Edit" for your "Github App" and once you are in the app settings, click on "Install App" and click on the "Install" button. Accept the permissions to install it in your whole organization.
+  5. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
+click on `Third Party Access`. Click on `Configure` the application you have installed in previous step and you will find the `installationId` at the URL of the browser:
+```
+https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION_ID}
+```
+  Copy the value of `installationId` and assign it to the `github_installation_id` variable in Terraform. You will need to redeploy the proxy again if that value was not populated before.
+
+**NOTE**:
+ - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
+ - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
+
+  6. Update the variables with values obtained in previous step:
+     - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.
+     - `PSOXY_GITHUB_PRIVATE_KEY` with content of the `gh_pk_pkcs8.pem` from previous step. You could open the certificate with VS Code or any other editor and copy all the content *as-is* into this variable.
+  7. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+
+EOT
+    }
+    github-non-enterprise = {
+      source_kind : "github",
+      worklytics_connector_id : "github-free-team-psoxy"
+      display_name : "Github"
+      identifier_scope_id : "github"
+      worklytics_connector_name : "Github Free/Professional via Psoxy"
+      target_host : local.github_api_host
+      source_auth_strategy : "oauth2_refresh_token"
+      secured_variables : [
+        {
+          name : "ACCESS_TOKEN"
+          writable : true
+          sensitive : true
+          value_managed_by_tf : false
+        },
+        {
+          name : "PRIVATE_KEY"
+          writable : false
+          sensitive : true
+          value_managed_by_tf : false
+        },
+        {
+          name : "CLIENT_ID"
+          writable : false
+          sensitive : true
+          value_managed_by_tf : false
+        },
+        {
+          name : "OAUTH_REFRESH_TOKEN"
+          writable : true
+          lockable : true
+          sensitive : true
+          value_managed_by_tf : false
+        }
+      ],
+      environment_variables : {
+        GRANT_TYPE : "certificate_credentials"
+        TOKEN_RESPONSE_TYPE : "GITHUB_ACCESS_TOKEN"
+        REFRESH_ENDPOINT : "https://${local.github_api_host}/app/installations/${local.github_installation_id}/access_tokens"
+        USE_SHARED_TOKEN : "TRUE"
+      }
+      settings_to_provide = {
+        "GitHub Organization" = local.github_organization
+      }
+      reserved_concurrent_executions : null
+      example_api_calls_user_to_impersonate : null
+      example_api_calls : [
+        "/orgs/${local.github_organization}/repos",
+        "/orgs/${local.github_organization}/members",
+        "/orgs/${local.github_organization}/teams",
         "/repos/${local.github_organization}/${local.github_example_repository}/events",
         "/repos/${local.github_organization}/${local.github_example_repository}/commits",
         "/repos/${local.github_organization}/${local.github_example_repository}/issues",

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -362,7 +362,7 @@ EOT
       - Members: for listing teams and their members
 
   NOTES:
-    - We assume that ALL the repositories are going to be list **should be owned by the organization, not the users**.
+    - We assume that ALL the repositories are going to be listed **should be owned by the organization, not the users**.
     - Enterprise Cloud is required for this connector.
 
   Apart from Github instructions please review the following:
@@ -463,12 +463,10 @@ EOT
       - Metadata: for listing repositories and branches
       - Pull requests: for listing pull requests, reviews, comments and commits
     - Organization
-      - Administration: for listing events from audit log
       - Members: for listing teams and their members
 
   NOTES:
-    - We assume that ALL the repositories are going to be list **should be owned by the organization, not the users**.
-    - Enterprise Cloud is required for this connector.
+    - We assume that ALL the repositories are going to be listed **should be owned by the organization, not the users**.
 
   Apart from Github instructions please review the following:
   - "Homepage URL" can be anything, not required in this flow but required by Github.


### PR DESCRIPTION
- Added a non enterprise connector for Github; tested with https://github.com/Worklytics/evalengin/pull/6187
- Updated documentation for referring on both connectors and server parameters
- Fixed deep linking for api connectors; settings were not included in the link on the 3rd TODO.

### Features
- [Github: Add non-enterprise connector in Proxy](https://app.asana.com/0/1206031814402298/1206033653446145)

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no** 
   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change **no**
