### PR TITLE
fix gcp host module bad role

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
  - dependencies added/changed? **yes (explain) / no**
  - something important to note in future release notes?
-   - NOTE in `CHANGELOG.md`anything that will show up in `terraform plan`/`apply` that isn't
+   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
      obviously a no-op?
    - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
      change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,8 @@
 ### Change implications
 
  - dependencies added/changed? **yes (explain) / no**
- - something to note in `CHANGELOG.md`? 
-   - anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? 
-   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
+ - something important to note in future release notes?
+   - NOTE in `CHANGELOG.md`anything that will show up in `terraform plan`/`apply` that isn't
+     obviously a no-op?
+   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
+     change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-Working tracking of changes, updated as work done prior to release.  Please review [releases](https://github.com/Worklytics/psoxy/releases) for ultimate versions.
+Please review [releases](https://github.com/Worklytics/psoxy/releases) for full details of changes
+in each release's notes.
+
+Changes to be including in future/planned release notes will be added here.
 
 ## Next
 

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -303,7 +303,7 @@ resource "google_secret_manager_secret_iam_member" "additional_transforms_viewer
 
   secret_id = google_secret_manager_secret.additional_transforms[each.key].id
   member    = "serviceAccount:${module.bulk_connector[each.key].instance_sa_email}"
-  role      = "roles/secretmanager.secretViewer"
+  role      = "roles/secretmanager.viewer"
 }
 
 # needs to access payload of the versions


### PR DESCRIPTION
### Fixes
 - `roles/secretmanager.secretViewer` is not a role; `roles/secretmanager.viewer` is the correct one 

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
