### PR TITLE
improve RecordRules, add tests

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/RecordBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/RecordBulkDataSanitizerImpl.java
@@ -107,7 +107,7 @@ public class RecordBulkDataSanitizerImpl implements BulkDataSanitizer {
             return (currentValue, configuration) -> {
                 if (currentValue == null) {
                     return null;
-                } else if (currentValue instanceof String) {
+                } else if (currentValue instanceof String || currentValue instanceof Long || currentValue instanceof Integer) {
                     PseudonymizedIdentity pseudonymizedIdentity = pseudonymizer.pseudonymize(currentValue);
 
                     if (pseudonymizer.getOptions().getPseudonymImplementation() != PseudonymImplementation.DEFAULT) {
@@ -118,7 +118,7 @@ public class RecordBulkDataSanitizerImpl implements BulkDataSanitizer {
                     return encoder.encode(pseudonymizedIdentity.asPseudonym());
                     //.firstNonNull(pseudonymizedIdentity.getReversible(), pseudonymizedIdentity.getHash());
                 } else {
-                    throw new IllegalArgumentException("Pseudonymize transform only supports String values");
+                    throw new IllegalArgumentException("Pseudonymize transform only supports string/integer values");
                 }
             };
         } else {

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/BulkDataTestUtils.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/BulkDataTestUtils.java
@@ -1,0 +1,33 @@
+package co.worklytics.psoxy.storage;
+
+import co.worklytics.psoxy.gateway.StorageEventRequest;
+import co.worklytics.test.TestUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Writer;
+
+public class BulkDataTestUtils {
+
+
+    /**
+     * build a prototype request for testing
+     * @param sourceObjectPath
+     * @param filePath
+     * @param writer
+     * @return
+     */
+    public static StorageEventRequest request(String sourceObjectPath, String filePath, Writer writer) {
+        Reader reader = new InputStreamReader(new ByteArrayInputStream(TestUtils.getData(filePath)));
+
+        return StorageEventRequest.builder()
+            .sourceBucketName("bucket")
+            .sourceObjectPath(sourceObjectPath)
+            .sourceReader(reader)
+            .destinationWriter(writer)
+            .destinationBucketName("bucket")
+            .destinationObjectPath(sourceObjectPath)
+            .build();
+    }
+}

--- a/java/core/src/test/resources/bulk/example-sanitized.ndjson
+++ b/java/core/src/test/resources/bulk/example-sanitized.ndjson
@@ -1,0 +1,2 @@
+{"foo":null,"bar":"t~bRA7u8gkRFVS4a7u1BzBPsFttCTbbW7ICsUN2N9CVso","other":"three"}
+{"foo":null,"bar":"t~JoRciV9pgnaBd-s4kJk8yF2WsYtl8l8a3Gi4fTOnpw0","other":"six"}

--- a/java/core/src/test/resources/bulk/example.ndjson
+++ b/java/core/src/test/resources/bulk/example.ndjson
@@ -1,0 +1,2 @@
+{"foo":1,"bar":2,"other":"three"}
+{"foo":4,"bar":5,"other":"six"}

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/RecordRules.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/RecordRules.java
@@ -4,6 +4,7 @@ import com.avaulta.gateway.rules.transforms.RecordTransform;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -47,7 +48,16 @@ public class RecordRules implements BulkDataRules {
      *
      */
     @Singular
-    List<RecordTransform> transforms;
+    List<RecordTransform> transforms = new LinkedList<>();
+
+    //setter to ensure we get a List, even when coming through jackson
+    public void setTransforms(List<RecordTransform> transforms) {
+        if (transforms == null) {
+            this.transforms = new LinkedList<>();
+        } else {
+            this.transforms = transforms;
+        }
+    }
 
 
 }


### PR DESCRIPTION
### Features
 - recordRules support having no transforms (eg, when customer just wants to pass through file, unaltered)
 - recordRules can pseudonymize String, Int/Long (JSON Integer); this avoids us assuming that customers have semantically correct field types in their source data. 

### Change implications

 - dependencies added/changed? **no**
 - something to note in `CHANGELOG.md`? **no**
