### PR TITLE
rules relative to target api host, even if there's a path 

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -115,16 +115,10 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
 
     @Override
     public Optional<Collection<String>> getAllowedHeadersToForward(String httpMethod, URL url) {
-        Optional<Pair<Pattern, Endpoint>> endpoint = getEndpoint(httpMethod, url);
-
-        if (endpoint.isPresent()) {
-            return endpoint.get().getValue().getAllowedRequestHeaderesToForward();
-        } else {
-            return Optional.empty();
-        }
+        return getEndpoint(httpMethod, url)
+            .map(Pair::getRight)
+            .map(Endpoint::getAllowedRequestHeadersToForward);
     }
-
-
 
     @Override
     public String sanitize(String httpMethod, URL url, String jsonResponse) {        //extra check ...

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -117,7 +117,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     public Optional<Collection<String>> getAllowedHeadersToForward(String httpMethod, URL url) {
         return getEndpoint(httpMethod, url)
             .map(Pair::getRight)
-            .map(Endpoint::getAllowedRequestHeadersToForward);
+            .map(endpoint -> endpoint.getAllowedRequestHeadersToForward().get());
     }
 
     @Override

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -560,6 +560,9 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
                     targetHostPath = configService.getConfigPropertyAsOptional(ProxyConfigProperty.TARGET_HOST)
                         .map(s -> {
                             try {
+                                if (!s.startsWith("https://")) {
+                                    s = "https://" + s;
+                                }
                                 return new URL(s).getPath();
                             } catch (MalformedURLException e) {
                                 log.log(Level.WARNING, "Invalid API_HOST: " + s, e);

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -86,6 +86,9 @@ class RESTApiSanitizerImplTest {
             TestModules.withMockEncryptionKey(mock);
             when(mock.getConfigPropertyOrError(eq(ProxyConfigProperty.SOURCE)))
                 .thenReturn("gmail");
+            when(mock.getConfigPropertyAsOptional(eq(ProxyConfigProperty.TARGET_HOST)))
+                .thenReturn(Optional.of("gmail.googleapis.com"));
+
             return mock;
         }
     }

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -678,4 +678,15 @@ class RESTApiSanitizerImplTest {
         }
     }
 
+    @Test
+    public void stripTargetHostPath() {
+       assertEquals("/path", sanitizer.stripTargetHostPath("/path"));
+       sanitizer.targetHostPath = "/api/v1";
+       assertEquals("/path", sanitizer.stripTargetHostPath("/api/v1/path"));
+
+       //only at beginning of path
+       assertEquals("/path/api/v1", sanitizer.stripTargetHostPath("/api/v1/path/api/v1"));
+       assertEquals("/path/api/v1", sanitizer.stripTargetHostPath("/path/api/v1"));
+    }
+
 }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
@@ -107,7 +107,7 @@ public class Endpoint {
     Collection<String> allowedRequestHeadersToForward;
 
     @JsonIgnore
-    public Optional<Collection<String>> getAllowedRequestHeaderesToForward() {
+    public Optional<Collection<String>> getAllowedRequestHeadersToForward() {
         return Optional.ofNullable(allowedRequestHeadersToForward);
     }
 


### PR DESCRIPTION
### Fixes
 - rules should be relative to value of `TARGET_HOST`, even if there's a path

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - breaking changes? **YES; if you have set `TARGET_HOST` config parameter including a path, that path will now be REMOVED before URL is matched in rules; likely you set custom rules with the path segment as a prefix - so those will need to be updated**


NOTE: this isn't actually urgent/needed, as to date we've only encountered one case of someone needing to customize the `TARGET_HOST` with a value that includes a path ... but imho the behavior in that situation is broken, as it is not what users would expect. So I prefer to fix this broken behavior now, rather than maintain it till next 0.x version, so we don't end up with more people dependent on a bug.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206130935971141