### PR TITLE
GitHub: fix refresh endpoint for enterprise server

### DIFF
--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -28,6 +28,7 @@ module "worklytics_connectors" {
   salesforce_domain             = var.salesforce_domain
   github_api_host               = var.github_api_host
   github_enterprise_server_host = var.github_enterprise_server_host
+  github_enterprise_server_version = var.github_enterprise_server_version
   github_installation_id        = var.github_installation_id
   github_organization           = var.github_organization
   github_example_repository     = var.github_example_repository

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -21,18 +21,18 @@ module "worklytics_connectors" {
   source = "../../modules/worklytics-connectors"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=rc-v0.4.45"
 
-  enabled_connectors            = var.enabled_connectors
-  jira_cloud_id                 = var.jira_cloud_id
-  jira_server_url               = var.jira_server_url
-  jira_example_issue_id         = var.jira_example_issue_id
-  salesforce_domain             = var.salesforce_domain
-  github_api_host               = var.github_api_host
-  github_enterprise_server_host = var.github_enterprise_server_host
+  enabled_connectors               = var.enabled_connectors
+  jira_cloud_id                    = var.jira_cloud_id
+  jira_server_url                  = var.jira_server_url
+  jira_example_issue_id            = var.jira_example_issue_id
+  salesforce_domain                = var.salesforce_domain
+  github_api_host                  = var.github_api_host
+  github_enterprise_server_host    = var.github_enterprise_server_host
   github_enterprise_server_version = var.github_enterprise_server_version
-  github_installation_id        = var.github_installation_id
-  github_organization           = var.github_organization
-  github_example_repository     = var.github_example_repository
-  salesforce_example_account_id = var.salesforce_example_account_id
+  github_installation_id           = var.github_installation_id
+  github_organization              = var.github_organization
+  github_example_repository        = var.github_example_repository
+  salesforce_example_account_id    = var.salesforce_example_account_id
 }
 
 # sources which require additional dependencies are split into distinct Terraform files, following

--- a/infra/examples-dev/aws-all/misc-data-source-variables.tf
+++ b/infra/examples-dev/aws-all/misc-data-source-variables.tf
@@ -39,6 +39,12 @@ variable "github_enterprise_server_host" {
   description = "(Only required if using Github Enterprise Server connector) Host of the Github instance (ex: github.mycompany.com)."
 }
 
+variable "github_enterprise_server_version" {
+  type        = string
+  default     = "v3"
+  description = "(Only required if using Github Enterprise Server connector) Version of the server to use (ex: v3). By default, v3"
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -30,18 +30,18 @@ module "worklytics_connectors" {
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=rc-v0.4.45"
 
 
-  enabled_connectors            = var.enabled_connectors
-  jira_cloud_id                 = var.jira_cloud_id
-  jira_server_url               = var.jira_server_url
-  jira_example_issue_id         = var.jira_example_issue_id
-  salesforce_domain             = var.salesforce_domain
-  github_api_host               = var.github_api_host
-  github_enterprise_server_host = var.github_enterprise_server_host
+  enabled_connectors               = var.enabled_connectors
+  jira_cloud_id                    = var.jira_cloud_id
+  jira_server_url                  = var.jira_server_url
+  jira_example_issue_id            = var.jira_example_issue_id
+  salesforce_domain                = var.salesforce_domain
+  github_api_host                  = var.github_api_host
+  github_enterprise_server_host    = var.github_enterprise_server_host
   github_enterprise_server_version = var.github_enterprise_server_version
-  github_installation_id        = var.github_installation_id
-  github_organization           = var.github_organization
-  github_example_repository     = var.github_example_repository
-  salesforce_example_account_id = var.salesforce_example_account_id
+  github_installation_id           = var.github_installation_id
+  github_organization              = var.github_organization
+  github_example_repository        = var.github_example_repository
+  salesforce_example_account_id    = var.salesforce_example_account_id
 }
 
 # sources which require additional dependencies are split into distinct Terraform files, following

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -37,6 +37,7 @@ module "worklytics_connectors" {
   salesforce_domain             = var.salesforce_domain
   github_api_host               = var.github_api_host
   github_enterprise_server_host = var.github_enterprise_server_host
+  github_enterprise_server_version = var.github_enterprise_server_version
   github_installation_id        = var.github_installation_id
   github_organization           = var.github_organization
   github_example_repository     = var.github_example_repository

--- a/infra/examples-dev/gcp/misc-data-source-variables.tf
+++ b/infra/examples-dev/gcp/misc-data-source-variables.tf
@@ -39,6 +39,12 @@ variable "github_enterprise_server_host" {
   description = "(Only required if using Github Enterprise Server connector) Host of the Github instance (ex: github.mycompany.com)."
 }
 
+variable "github_enterprise_server_version" {
+  type        = string
+  default     = "v3"
+  description = "(Only required if using Github Enterprise Server connector) Version of the server to use (ex: v3). By default, v3"
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -159,6 +159,7 @@ locals {
   jira_example_issue_id         = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
   github_installation_id        = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
   github_enterprise_server_host = coalesce(var.github_api_host, var.github_enterprise_server_host, "YOUR_GITHUB_ENTERPRISE_SERVER_HOST")
+  github_enterprise_server_version = coalesce(var.github_enterprise_server_version, "v3")
   github_organization           = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
   github_example_repository     = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
   salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
@@ -512,7 +513,7 @@ EOT
       environment_variables : {
         GRANT_TYPE : "certificate_credentials"
         TOKEN_RESPONSE_TYPE : "GITHUB_ACCESS_TOKEN"
-        REFRESH_ENDPOINT : "https://${local.github_enterprise_server_host}/app/installations/${local.github_installation_id}/access_tokens"
+        REFRESH_ENDPOINT : "https://${local.github_enterprise_server_host}/api/${local.github_enterprise_server_version}/app/installations/${local.github_installation_id}/access_tokens"
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {
@@ -521,14 +522,14 @@ EOT
       reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       example_api_calls : [
-        "/api/v3/orgs/${local.github_organization}/repos",
-        "/api/v3/orgs/${local.github_organization}/members",
-        "/api/v3/orgs/${local.github_organization}/teams",
-        "/api/v3/orgs/${local.github_organization}/audit-log",
-        "/api/v3/repos/${local.github_organization}/${local.github_example_repository}/events",
-        "/api/v3/repos/${local.github_organization}/${local.github_example_repository}/commits",
-        "/api/v3/repos/${local.github_organization}/${local.github_example_repository}/issues",
-        "/api/v3/repos/${local.github_organization}/${local.github_example_repository}/pulls",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/repos",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/members",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/teams",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/audit-log",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/events",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/commits",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/issues",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/pulls",
       ]
       external_token_todo : <<EOT
   1. You have to populate `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -155,14 +155,14 @@ locals {
   k => merge(v, { example_calls : v.example_api_calls }) }
 
 
-  jira_cloud_id                 = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
-  jira_example_issue_id         = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
-  github_installation_id        = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
-  github_enterprise_server_host = coalesce(var.github_api_host, var.github_enterprise_server_host, "YOUR_GITHUB_ENTERPRISE_SERVER_HOST")
+  jira_cloud_id                    = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
+  jira_example_issue_id            = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
+  github_installation_id           = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
+  github_enterprise_server_host    = coalesce(var.github_api_host, var.github_enterprise_server_host, "YOUR_GITHUB_ENTERPRISE_SERVER_HOST")
   github_enterprise_server_version = coalesce(var.github_enterprise_server_version, "v3")
-  github_organization           = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
-  github_example_repository     = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
-  salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
+  github_organization              = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
+  github_example_repository        = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
+  salesforce_example_account_id    = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 
   # Microsoft 365 sources; add/remove as you wish
   # See https://docs.microsoft.com/en-us/graph/permissions-reference for all the permissions available in AAD Graph API

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -101,6 +101,12 @@ variable "github_enterprise_server_host" {
   description = "(Only required if using Github Enterprise Server connector) Host of the Github instance (ex: github.mycompany.com)."
 }
 
+variable "github_enterprise_server_version" {
+  type        = string
+  default     = "v3"
+  description = "(Only required if using Github Enterprise Server connector) Version of the server to use (ex: v3). By default, v3"
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -10,6 +10,7 @@ module "worklytics_connector_specs" {
   jira_example_issue_id         = var.jira_example_issue_id
   github_api_host               = var.github_api_host
   github_enterprise_server_host = var.github_enterprise_server_host
+  github_enterprise_server_version = var.github_enterprise_server_version
   github_installation_id        = var.github_installation_id
   github_organization           = var.github_organization
   github_example_repository     = var.github_example_repository

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -2,19 +2,19 @@
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
 
-  enabled_connectors            = var.enabled_connectors
-  jira_cloud_id                 = var.jira_cloud_id
-  jira_server_url               = var.jira_server_url
-  salesforce_domain             = var.salesforce_domain
-  example_jira_issue_id         = var.example_jira_issue_id
-  jira_example_issue_id         = var.jira_example_issue_id
-  github_api_host               = var.github_api_host
-  github_enterprise_server_host = var.github_enterprise_server_host
+  enabled_connectors               = var.enabled_connectors
+  jira_cloud_id                    = var.jira_cloud_id
+  jira_server_url                  = var.jira_server_url
+  salesforce_domain                = var.salesforce_domain
+  example_jira_issue_id            = var.example_jira_issue_id
+  jira_example_issue_id            = var.jira_example_issue_id
+  github_api_host                  = var.github_api_host
+  github_enterprise_server_host    = var.github_enterprise_server_host
   github_enterprise_server_version = var.github_enterprise_server_version
-  github_installation_id        = var.github_installation_id
-  github_organization           = var.github_organization
-  github_example_repository     = var.github_example_repository
-  salesforce_example_account_id = var.salesforce_example_account_id
+  github_installation_id           = var.github_installation_id
+  github_organization              = var.github_organization
+  github_example_repository        = var.github_example_repository
+  salesforce_example_account_id    = var.salesforce_example_account_id
 }
 
 

--- a/infra/modules/worklytics-connectors/variables.tf
+++ b/infra/modules/worklytics-connectors/variables.tf
@@ -47,6 +47,12 @@ variable "github_enterprise_server_host" {
   description = "(Only required if using Github Enterprise Server connector) Host of the Github instance (ex: github.mycompany.com)."
 }
 
+variable "github_enterprise_server_version" {
+  type        = string
+  default     = "v3"
+  description = "(Only required if using Github Enterprise Server connector) Version of the server to use (ex: v3). By default, v3"
+}
+
 variable "github_installation_id" {
   type        = string
   default     = null


### PR DESCRIPTION
- Token refresh for server is targeting to `{host}/apps/installations...` where according to [docs](https://docs.github.com/en/enterprise-server@3.11/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#4-make-a-curl-request) all API REST paths should start with *api/v3*.
- Support for providing a server version. By default, v3.

### Fixes
- [bug: weird gh enterprise server case](https://app.asana.com/0/1206296312199462/1206305389814203)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
