### PR TITLE
GH examples with multiple orgs for enterprise server

### DIFF
--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -34,10 +34,12 @@ Follow the following steps:
 
 NOTES:
 - We assume that ALL the repositories are going to be list **should be owned by the organization, not the users**.
-- In case of using GitHub Server, you need to populate `github_enterprise_server_host` variable in Terraform with the URL of the API for your GitHub Enterprise Server instance. For example, `https://api.github.your-company.com`.
+- In case of using GitHub Server: 
+  - you need to populate `github_enterprise_server_host` variable in Terraform with the URL of the API for your GitHub Enterprise Server instance. For example, `https://api.github.your-company.com`.
+  - variable `github_organization` can be a list of organizations split by commas (ex: Worklytics,Worklytics2)
 
 Apart from GitHub instructions please review the following:
-  - "Homepage URL" can be anything, not required in this flow but required by Github.
+  - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
 

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -20,8 +20,11 @@ Both share the same configuration and setup instructions except Administration p
 
 Follow the following steps:
 
-1. (Only if you are going to use GitHub Enterprise Server) You have to populate `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
-2. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
+1. Populate `github_organization` variable in Terraform with the name of your GitHub organization.
+2. (Only if you are going to use GitHub Enterprise Server):
+  - You have to populate `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
+  - variable `github_organization` can be a list of organizations split by commas (ex: Worklytics,Worklytics2)
+3. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
    with following permissions with **Read Only**:
     - Repository:
         - Contents: for reading commits and comments
@@ -34,18 +37,15 @@ Follow the following steps:
 
 NOTES:
 - We assume that ALL the repositories are going to be list **should be owned by the organization, not the users**.
-- In case of using GitHub Server: 
-  - you need to populate `github_enterprise_server_host` variable in Terraform with the URL of the API for your GitHub Enterprise Server instance. For example, `https://api.github.your-company.com`.
-  - variable `github_organization` can be a list of organizations split by commas (ex: Worklytics,Worklytics2)
 
 Apart from GitHub instructions please review the following:
   - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
 
-3. Once is created please generate a new `Private Key`.
+4. Once is created please generate a new `Private Key`.
 
-4. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
+5. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
 ```shell
 openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE FILE} -out gh_pk_pkcs8.pem -nocrypt
 ```
@@ -54,9 +54,9 @@ openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE F
 - If the certificate is not converted to PKCS#8 connector will NOT work. You might see in logs a Java error `Invalid PKCS8 data.` if the format is not correct.
 - Command proposed has been successfully tested on Ubuntu; it may differ for other operating systems.
 
-5. Install the application in your organization.
+6. Install the application in your organization.
    Go to your organization settings and then in "Developer Settings". Then, click on "Edit" for your "Github App" and once you are in the app settings, click on "Install App" and click on the "Install" button. Accept the permissions to install it in your whole organization.
-6. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
+7. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
    click on `Third Party Access`. Click on `Configure` the application you have installed in previous step and you will find the `installationId` at the URL of the browser:
 ```
 https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION_ID}
@@ -67,10 +67,10 @@ Copy the value of `installationId` and assign it to the `github_installation_id`
 - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
 - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
 
-7. Update the variables with values obtained in previous step:
+8. Update the variables with values obtained in previous step:
    - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.
    - `PSOXY_GITHUB_PRIVATE_KEY` with content of the `gh_pk_pkcs8.pem` from previous step. You could open the certificate with VS Code or any other editor and copy all the content *as-is* into this variable.
-8. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+9. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
 
 ## Reference
 These instructions have been derived from [worklytics-connector-specs](../../../infra/modules/worklytics-connector-specs/main.tf); refer to that for definitive information.

--- a/infra/examples-dev/aws-all/misc-data-source-variables.tf
+++ b/infra/examples-dev/aws-all/misc-data-source-variables.tf
@@ -54,7 +54,7 @@ variable "github_installation_id" {
 variable "github_organization" {
   type        = string
   default     = null
-  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
+  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics). NOTE: If using Enterprise Server, this can be a list of organizations split by commas (ex: Worklytics,Worklytics2)"
 }
 
 variable "github_example_repository" {

--- a/infra/examples-dev/gcp/misc-data-source-variables.tf
+++ b/infra/examples-dev/gcp/misc-data-source-variables.tf
@@ -54,7 +54,7 @@ variable "github_installation_id" {
 variable "github_organization" {
   type        = string
   default     = null
-  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
+  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics). NOTE: If using Enterprise Server, this can be a list of organizations split by commas (ex: Worklytics,Worklytics2)"
 }
 
 variable "github_example_repository" {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -161,6 +161,7 @@ locals {
   github_enterprise_server_host    = coalesce(var.github_api_host, var.github_enterprise_server_host, "YOUR_GITHUB_ENTERPRISE_SERVER_HOST")
   github_enterprise_server_version = coalesce(var.github_enterprise_server_version, "v3")
   github_organization              = coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME")
+  github_first_organization        = split(",", coalesce(var.github_organization, "YOUR_GITHUB_ORGANIZATION_NAME"))[0]
   github_example_repository        = coalesce(var.github_example_repository, "YOUR_GITHUB_EXAMPLE_REPOSITORY_NAME")
   salesforce_example_account_id    = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 
@@ -522,14 +523,14 @@ EOT
       reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       example_api_calls : [
-        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/repos",
-        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/members",
-        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/teams",
-        "/api/${local.github_enterprise_server_version}/orgs/${local.github_organization}/audit-log",
-        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/events",
-        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/commits",
-        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/issues",
-        "/api/${local.github_enterprise_server_version}/repos/${local.github_organization}/${local.github_example_repository}/pulls",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_first_organization}/repos",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_first_organization}/members",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_first_organization}/teams",
+        "/api/${local.github_enterprise_server_version}/orgs/${local.github_first_organization}/audit-log",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_first_organization}/${local.github_example_repository}/events",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_first_organization}/${local.github_example_repository}/commits",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_first_organization}/${local.github_example_repository}/issues",
+        "/api/${local.github_enterprise_server_version}/repos/${local.github_first_organization}/${local.github_example_repository}/pulls",
       ]
       external_token_todo : <<EOT
   1. You have to populate `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -443,7 +443,7 @@ EOT
     - Enterprise Cloud is required for this connector.
 
   Apart from Github instructions please review the following:
-  - "Homepage URL" can be anything, not required in this flow but required by Github.
+  - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
   2. Once is created please generate a new `Private Key`.
@@ -550,7 +550,7 @@ EOT
     - Enterprise Cloud is required for this connector.
 
   Apart from Github instructions please review the following:
-  - "Homepage URL" can be anything, not required in this flow but required by Github.
+  - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
   3. Once is created please generate a new `Private Key`.
@@ -653,7 +653,7 @@ EOT
     - We assume that ALL the repositories are going to be listed **should be owned by the organization, not the users**.
 
   Apart from Github instructions please review the following:
-  - "Homepage URL" can be anything, not required in this flow but required by Github.
+  - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
   2. Once is created please generate a new `Private Key`.

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -427,7 +427,8 @@ EOT
         "/repos/${local.github_organization}/${local.github_example_repository}/pulls",
       ]
       external_token_todo : <<EOT
-  1. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
+  1. Populate `github_organization` variable in Terraform with the name of your GitHub organization.
+  2. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
     with following permissions with **Read Only**:
     - Repository:
       - Contents: for reading commits and comments
@@ -446,8 +447,8 @@ EOT
   - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
-  2. Once is created please generate a new `Private Key`.
-  3. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
+  3. Once is created please generate a new `Private Key`.
+  4. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
 ```shell
 openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE FILE} -out gh_pk_pkcs8.pem -nocrypt
 ```
@@ -456,9 +457,9 @@ openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE F
  - If the certificate is not converted to PKCS#8 connector will NOT work. You might see in logs a Java error `Invalid PKCS8 data.` if the format is not correct.
  - Command proposed has been successfully tested on Ubuntu; it may differ for other operating systems.
 
-  4. Install the application in your organization.
+  5. Install the application in your organization.
      Go to your organization settings and then in "Developer Settings". Then, click on "Edit" for your "Github App" and once you are in the app settings, click on "Install App" and click on the "Install" button. Accept the permissions to install it in your whole organization.
-  5. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
+  6. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
 click on `Third Party Access`. Click on `Configure` the application you have installed in previous step and you will find the `installationId` at the URL of the browser:
 ```
 https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION_ID}
@@ -469,10 +470,10 @@ https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION
  - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
  - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
 
-  6. Update the variables with values obtained in previous step:
+  7. Update the variables with values obtained in previous step:
      - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.
      - `PSOXY_GITHUB_PRIVATE_KEY` with content of the `gh_pk_pkcs8.pem` from previous step. You could open the certificate with VS Code or any other editor and copy all the content *as-is* into this variable.
-  7. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+  8. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
 
 EOT
     }
@@ -533,7 +534,9 @@ EOT
         "/api/${local.github_enterprise_server_version}/repos/${local.github_first_organization}/${local.github_example_repository}/pulls",
       ]
       external_token_todo : <<EOT
-  1. You have to populate `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
+  1. You have to populate:
+     - `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
+     - `github_organization` variable in Terraform with the name of your organization in Github Enterprise Server. You can put more than one, just split them in commas (example: `org1,org2`).
   2. From your organization, register a [GitHub App](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
     with following permissions with **Read Only**:
     - Repository:
@@ -639,7 +642,8 @@ EOT
         "/repos/${local.github_organization}/${local.github_example_repository}/pulls",
       ]
       external_token_todo : <<EOT
-  1. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
+  1. Populate `github_organization` variable in Terraform with the name of your GitHub organization.
+  2. From your organization, register a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
     with following permissions with **Read Only**:
     - Repository:
       - Contents: for reading commits and comments
@@ -656,8 +660,8 @@ EOT
   - "Homepage URL" can be anything, not required in this flow but required by GitHub.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
-  2. Once is created please generate a new `Private Key`.
-  3. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
+  3. Once is created please generate a new `Private Key`.
+  4. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
 ```shell
 openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE FILE} -out gh_pk_pkcs8.pem -nocrypt
 ```
@@ -666,9 +670,9 @@ openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE F
  - If the certificate is not converted to PKCS#8 connector will NOT work. You might see in logs a Java error `Invalid PKCS8 data.` if the format is not correct.
  - Command proposed has been successfully tested on Ubuntu; it may differ for other operating systems.
 
-  4. Install the application in your organization.
+  5. Install the application in your organization.
      Go to your organization settings and then in "Developer Settings". Then, click on "Edit" for your "Github App" and once you are in the app settings, click on "Install App" and click on the "Install" button. Accept the permissions to install it in your whole organization.
-  5. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
+  6. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
 click on `Third Party Access`. Click on `Configure` the application you have installed in previous step and you will find the `installationId` at the URL of the browser:
 ```
 https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION_ID}
@@ -679,10 +683,10 @@ https://github.com/organizations/{YOUR ORG}/settings/installations/{INSTALLATION
  - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
  - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
 
-  6. Update the variables with values obtained in previous step:
+  7. Update the variables with values obtained in previous step:
      - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.
      - `PSOXY_GITHUB_PRIVATE_KEY` with content of the `gh_pk_pkcs8.pem` from previous step. You could open the certificate with VS Code or any other editor and copy all the content *as-is* into this variable.
-  7. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+  8. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
 
 EOT
     }

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -116,7 +116,7 @@ variable "github_installation_id" {
 variable "github_organization" {
   type        = string
   default     = null
-  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
+  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics). NOTE: If using Enterprise Server, this can be a list of organizations split by commas (ex: Worklytics,Worklytics2)"
 }
 
 variable "github_example_repository" {

--- a/infra/modules/worklytics-connectors/variables.tf
+++ b/infra/modules/worklytics-connectors/variables.tf
@@ -62,7 +62,7 @@ variable "github_installation_id" {
 variable "github_organization" {
   type        = string
   default     = null
-  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics)"
+  description = "(Only required if using Github connector) Name of the organization to be used as part of example calls for Github (ex: Worklytics). NOTE: If using Enterprise Server, this can be a list of organizations split by commas (ex: Worklytics,Worklytics2)"
 }
 
 variable "github_example_repository" {


### PR DESCRIPTION
For GH Enterprise Server: 
- if more than one organization is provided, examples will show the first one
- update docs in both docs/specs to reflect the setting and how to use it.

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
- [github: support CSV for `Github Organization` setting](https://app.asana.com/0/1204736724839176/1206131565521989)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
