### PR TITLE
retry refresh token writes

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ConfigService.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ConfigService.java
@@ -1,5 +1,6 @@
 package co.worklytics.psoxy.gateway;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,7 @@ import lombok.Value;
 import lombok.extern.java.Log;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -68,7 +70,8 @@ public interface ConfigService {
                 putConfigProperty(property, value);
                 return;
             } catch (Exception ignore) {
-                // retry
+                // retry - wait slightly
+                Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(150));
             }
         } while (--retries > 0);
         throw new WritePropertyRetriesExhaustedException("Failed to write config property " + property);

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ConfigService.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ConfigService.java
@@ -65,16 +65,18 @@ public interface ConfigService {
             // use the non-retry version
             throw new IllegalArgumentException("retries must be > 0");
         }
+        Exception lastException;
         do {
             try {
                 putConfigProperty(property, value);
                 return;
-            } catch (Exception ignore) {
+            } catch (Exception e) {
                 // retry - wait slightly
+                lastException = e;
                 Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(150));
             }
         } while (--retries > 0);
-        throw new WritePropertyRetriesExhaustedException("Failed to write config property " + property);
+        throw new WritePropertyRetriesExhaustedException("Failed to write config property " + property, lastException);
     }
 
     /**

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/WritePropertyRetriesExhaustedException.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/WritePropertyRetriesExhaustedException.java
@@ -1,0 +1,16 @@
+package co.worklytics.psoxy.gateway;
+
+/**
+ * Used to indicate that a write operation failed after exhausting all retries.
+ * Checked to enforce the caller to handle the exception.
+ */
+public class WritePropertyRetriesExhaustedException extends Exception {
+
+    public WritePropertyRetriesExhaustedException(String message) {
+        super(message);
+    }
+
+    public WritePropertyRetriesExhaustedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -304,8 +304,8 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                 } else {
                     //re-try recursively, w/ linear backoff
                     Uninterruptibles.sleepUninterruptibly(WAIT_AFTER_FAILED_LOCK_ATTEMPTS
-                        .multipliedBy(attempt + 1)
-                        .plusMillis(randomNumberGenerator.nextInt(200)));
+                        .plusMillis(randomNumberGenerator.nextInt(250))
+                        .multipliedBy(attempt + 1));
 
                     token = refreshAccessToken(attempt + 1);
                 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -287,7 +287,8 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                     tokenResponse = exchangeRefreshTokenForAccessToken();
                     token = asAccessToken(tokenResponse);
 
-                    storeSharedAccessTokenIfSupported(token);
+                    storeSharedAccessTokenIfSupported(token, lockNeeded);
+                    storeRefreshTokenIfRotated(tokenResponse);
 
                     if (isAccessTokenCacheable()) {
                         this.cachedToken = token;
@@ -320,12 +321,8 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
             payloadBuilder.addHeaders(tokenRequest.getHeaders());
 
             HttpResponse response = tokenRequest.execute();
-            CanonicalOAuthAccessTokenResponseDto tokenResponse =
-                    tokenResponseParser.parseTokenResponse(response);
 
-            storeRefreshTokenIfRotated(tokenResponse);
-
-            return tokenResponse;
+            return tokenResponseParser.parseTokenResponse(response);
         }
 
         /**
@@ -451,8 +448,8 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
         }
 
         @VisibleForTesting
-        void storeSharedAccessTokenIfSupported(@NonNull AccessToken accessToken) {
-            if (useSharedToken()) {
+        void storeSharedAccessTokenIfSupported(@NonNull AccessToken accessToken, boolean useSharedToken) {
+            if (useSharedToken) {
                 try {
                     config.putConfigProperty(ConfigProperty.ACCESS_TOKEN,
                         objectMapper.writerFor(AccessTokenDto.class)

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -303,7 +303,10 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                     }
                 } else {
                     //re-try recursively, w/ linear backoff
-                    Uninterruptibles.sleepUninterruptibly(WAIT_AFTER_FAILED_LOCK_ATTEMPTS.multipliedBy(attempt + 1));
+                    Uninterruptibles.sleepUninterruptibly(WAIT_AFTER_FAILED_LOCK_ATTEMPTS
+                        .multipliedBy(attempt + 1)
+                        .plusMillis(randomNumberGenerator.nextInt(200)));
+
                     token = refreshAccessToken(attempt + 1);
                 }
             }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -177,7 +177,8 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
     public static class TokenRefreshHandlerImpl implements OAuth2CredentialsWithRefresh.OAuth2RefreshHandler,
             RequiresConfiguration {
 
-        private static final int WRITE_RETRIES = 3;
+        @VisibleForTesting
+        static final int WRITE_RETRIES = 3;
 
         @Inject
         ConfigService config;

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
@@ -148,7 +148,7 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
 
         AccessToken token = new AccessToken("my-token", Date.from(anyTime.plus(10_000L, ChronoUnit.MILLIS)));
 
-        tokenRefreshHandler.storeSharedAccessTokenIfSupported(token);
+        tokenRefreshHandler.storeSharedAccessTokenIfSupported(token, true);
 
         verify(tokenRefreshHandler.config, times(1)).putConfigProperty(eq(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.ACCESS_TOKEN),
             eq("{\"token\":\"my-token\",\"expirationDate\":1639526410000}"));

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
@@ -133,6 +133,7 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
         assertTrue(tokenRefreshHandler.shouldRefresh(token, fixed));
     }
 
+    @SneakyThrows
     @Test
     public void serializesAccessTokenDTO() {
         OAuthRefreshTokenSourceAuthStrategy.TokenRefreshHandlerImpl tokenRefreshHandler = new OAuthRefreshTokenSourceAuthStrategy.TokenRefreshHandlerImpl();
@@ -151,7 +152,8 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
         tokenRefreshHandler.storeSharedAccessTokenIfSupported(token, true);
 
         verify(tokenRefreshHandler.config, times(1)).putConfigProperty(eq(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.ACCESS_TOKEN),
-            eq("{\"token\":\"my-token\",\"expirationDate\":1639526410000}"));
+            eq("{\"token\":\"my-token\",\"expirationDate\":1639526410000}"),
+            eq(OAuthRefreshTokenSourceAuthStrategy.TokenRefreshHandlerImpl.WRITE_RETRIES));
     }
 
     @Test
@@ -180,6 +182,7 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
         );
     }
 
+    @SneakyThrows
     @ParameterizedTest
     @MethodSource
     public void refreshTokenNotRotated(String originalToken, String newToken, boolean shouldRotate) {
@@ -195,7 +198,7 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
         exampleResponse.refreshToken = newToken;
         tokenRefreshHandler.storeRefreshTokenIfRotated(exampleResponse);
 
-        verify(tokenRefreshHandler.config, times(shouldRotate ? 1 : 0)).putConfigProperty(eq(RefreshTokenTokenRequestBuilder.ConfigProperty.REFRESH_TOKEN), eq(newToken));
+        verify(tokenRefreshHandler.config, times(shouldRotate ? 1 : 0)).putConfigProperty(eq(RefreshTokenTokenRequestBuilder.ConfigProperty.REFRESH_TOKEN), eq(newToken), eq(OAuthRefreshTokenSourceAuthStrategy.TokenRefreshHandlerImpl.WRITE_RETRIES));
     }
 
     @Test

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -187,7 +187,7 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
                 .build());
             // assuming two threads at the same time trying to write on a deleted parameter might
             // not get ParameterAlreadyExistsException and last one wins.
-            Uninterruptibles.sleepUninterruptibly(100 + randomNumberGenerator.nextInt(200), TimeUnit.MILLISECONDS);
+            Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(100).plusMillis(randomNumberGenerator.nextInt(200)));
             // if value doesn't match what we wrote, someone else got it, race condition.
             Parameter parameter = readParameter(lockParameterName);
             return Objects.equals(lockValue, parameter.value());

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -3,8 +3,10 @@ package co.worklytics.psoxy.aws;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.LockService;
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
+import co.worklytics.psoxy.utils.RandomNumberGenerator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Uninterruptibles;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedInject;
 import lombok.Getter;
@@ -22,6 +24,7 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Level;
 
@@ -51,6 +54,9 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
 
     @Inject
     EnvVarsConfigService envVarsConfig;
+
+    @Inject
+    RandomNumberGenerator randomNumberGenerator;
 
     @Inject
     Clock clock;
@@ -171,38 +177,47 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
 
         final String lockParameterName = lockParameterName(lockId);
         try {
-            client.putParameter(PutParameterRequest.builder()
+            Instant instant = clock.instant();
+            String lockValue = String.format("locked_%d", instant.toEpochMilli());
+            PutParameterResponse locked = client.putParameter(PutParameterRequest.builder()
                 .name(lockParameterName)
                 .type(ParameterType.STRING)
-                .value("locked")
+                .value(lockValue)
                 .overwrite(false)
                 .build());
-            return true;
+            // assuming two threads at the same time trying to write on a deleted parameter might
+            // not get ParameterAlreadyExistsException and last one wins.
+            Uninterruptibles.sleepUninterruptibly(100 + randomNumberGenerator.nextInt(200), TimeUnit.MILLISECONDS);
+            // if value doesn't match what we wrote, someone else got it, race condition.
+            Parameter parameter = readParameter(lockParameterName);
+            return Objects.equals(lockValue, parameter.value());
         } catch (ParameterAlreadyExistsException e) {
             try {
-                Instant lockedAt = client.getParameter(GetParameterRequest.builder()
-                    .name(lockParameterName)
-                    .build()).parameter().lastModifiedDate();
-
+                Instant lockedAt = readParameter(lockParameterName).lastModifiedDate();
 
                 if (lockedAt.isBefore(clock.instant().minusSeconds(expires.getSeconds()))) {
                     log.warning("Lock " + lockParameterName + " is stale, removing");
 
-                    //q: add random delay here, in case multiple instances have been waiting to
-                    // acquire the lock?
+                    // release it and let the caller decide if the retry
                     release(lockId);
-
-                    return acquire(lockId);
                 }
             } catch (SsmException ssmException) {
                 log.log(Level.SEVERE, "Could not read lock " + lockParameterName, ssmException);
             }
-            return false;
         } catch (SsmException e) {
             log.log(Level.SEVERE, "Could not acquire lock " + lockParameterName, e);
-            return false;
         }
+        return false;
     }
+
+    private Parameter readParameter(String parameterName) {
+        GetParameterRequest parameterRequest = GetParameterRequest.builder()
+            .name(parameterName)
+            .build();
+        GetParameterResponse parameterResponse = client.getParameter(parameterRequest);
+        return parameterResponse.parameter();
+    }
+
 
     @Override
     public void release(@NonNull String lockId) {
@@ -216,7 +231,7 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
         } catch (ParameterNotFoundException e) {
             log.log(Level.WARNING, "Lock " + lockParameterName + " not found; OK, but may indicate a problem", e);
         } catch (SsmException e) {
-            //should go stale in this case ...
+            // should go stale in this case ...
             log.log(Level.SEVERE, "Could not release lock " + lockParameterName, e);
         }
     }

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -171,14 +171,19 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
         return this.namespace + "lock_" + lockId;
     }
 
+    @VisibleForTesting
+    String lockParameterValue() {
+        Instant instant = clock.instant();
+        return String.format("locked_%d", instant.toEpochMilli());
+    }
+
     @Override
     public boolean acquire(@NonNull String lockId, @NonNull Duration expires) {
         Preconditions.checkArgument(StringUtils.isNotBlank(lockId), "lockId must be non-blank");
 
         final String lockParameterName = lockParameterName(lockId);
         try {
-            Instant instant = clock.instant();
-            String lockValue = String.format("locked_%d", instant.toEpochMilli());
+            String lockValue = lockParameterValue();
             PutParameterResponse locked = client.putParameter(PutParameterRequest.builder()
                 .name(lockParameterName)
                 .type(ParameterType.STRING)


### PR DESCRIPTION
### Fixes
Related to https://app.asana.com/0/1205088991476808/1206353682725974 
Perform few attempts upon write access and refresh token attempts, to minimize lost tokens if write failure happens.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? no
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change - no
