### PR TITLE
S167 test call post request

### DIFF
--- a/tools/psoxy-test/cli-call.js
+++ b/tools/psoxy-test/cli-call.js
@@ -33,6 +33,7 @@ const AWS_ACCESS_DENIED_EXCEPTION_REGEXP = new RegExp(/(?<arn>arn:aws:iam::\d+:\
     .option('-v, --verbose', 'Verbose output', false)
     .option('-z, --gzip [type]', 'Add gzip compression header (default: true, "-z false" to remove)', true)
     .option('--health-check', 'Health Check call: check Psoxy deploy is running')
+    .option('-b, --body <body>', 'Body to send in request (it expects a JSON string)')
     .addOption(new Option('-d, --data-source <name>',
       'Data source to test all available endpoints').choices([
         'asana',

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -49,7 +49,7 @@ function isValidURL(url) {
 async function call(options = {}) {
   const logger = getLogger(options.verbose);
   const url = new URL(options.url);
-  const method = options.method || resolveHTTPMethod(url.pathname);
+  const method = options.method || resolveHTTPMethod(url.pathname, options);
 
   if (_.isEmpty(options.region)) {
     options.region = resolveAWSRegion(url);
@@ -59,7 +59,8 @@ async function call(options = {}) {
 
   logger.verbose('Signing request');
 
-  const signed = signAWSRequestURL(url, method, credentials, options.region);
+  const signed = signAWSRequestURL(url, method, options.body, credentials,
+     options.region);
   const headers = {
     ...getCommonHTTPHeaders(options),
     ...signed.headers,
@@ -67,9 +68,9 @@ async function call(options = {}) {
 
   logger.info(`Calling Psoxy and waiting response: ${options.url.toString()}`);
   logger.verbose('Request Options:', { additional: options });
-  logger.verbose('Request Headers: ', { additional: headers })
+  logger.verbose('Request Headers: ', { additional: headers });
 
-  return await request(url, method, headers);
+  return await request(url, method, headers, options.body);
 }
 
 /**

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -61,9 +61,9 @@ async function call(options = {}) {
   logger.verbose('Request Headers:', { additional: headers });
 
   const url = new URL(options.url);
-  const method = options.method || resolveHTTPMethod(url.pathname);
+  const method = options.method || resolveHTTPMethod(url.pathname, options);
 
-  return await request(url, method, headers);
+  return await request(url, method, headers, options.body);
 }
 
 /**

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -93,7 +93,7 @@ function getCommonHTTPHeaders(options = {}) {
  * @param {Object} body
  * @return {Promise}
  */
-function requestWrapper(url, method = 'GET', headers, body) {
+function requestWrapper(url, method = 'GET', headers, body = {}) {
   url = typeof url === 'string' ? new URL(url) : url;
   const params = url.searchParams.toString();
   const responseBody = [];

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -90,22 +90,24 @@ function getCommonHTTPHeaders(options = {}) {
  * @param {String|URL} url
  * @param {Object} headers
  * @param {String} method
+ * @param {Object} body
  * @return {Promise}
  */
-function requestWrapper(url, method = 'GET', headers) {
+function requestWrapper(url, method = 'GET', headers, body) {
   url = typeof url === 'string' ? new URL(url) : url;
   const params = url.searchParams.toString();
   const responseBody = [];
+  const requestOptions = {
+    hostname: url.host,
+    port: 443,
+    path: url.pathname + (params !== '' ? `?${params}` : ''),
+    method: method,
+    headers: headers,
+    timeout: REQUEST_TIMEOUT_MS,
+  }
+
   return new Promise((resolve, reject) => {
-    const req = https.request(
-      {
-        hostname: url.host,
-        port: 443,
-        path: url.pathname + (params !== '' ? `?${params}` : ''),
-        method: method,
-        headers: headers,
-        timeout: REQUEST_TIMEOUT_MS,
-      },
+    const req = https.request(requestOptions,
       (res) => {
         res.on('data', (data) => {
           responseBody.push(data);
@@ -142,6 +144,10 @@ function requestWrapper(url, method = 'GET', headers) {
         });
       }
     );
+    if (!_.isEmpty(body)) {
+      req.write(JSON.stringify(body));
+    }
+
     req.on('timeout', () => {
       req.destroy();
       reject({ statusMessage: 'Psoxy is taking too long to respond' });
@@ -157,18 +163,19 @@ function requestWrapper(url, method = 'GET', headers) {
  * Simple wrapper around `aws4` to ease testing.
  *
  * TODO aws4 is not able to resolve region nor service (see how we try to
- *  resolve the "service" here)from the URL for our use cases, so we need to
+ *  resolve the "service" here) from the URL for our use cases, so we need to
  *  improve the resolution of those values
  *
  * Ref: https://github.com/mhart/aws4#api
  *
  * @param {URL} url
  * @param {String} method
+ * @param {Object} body
  * @param {Object} credentials
  * @param {String} region
  * @return {Object}
  */
-function signAWSRequestURL(url, method = 'GET', credentials, region) {
+function signAWSRequestURL(url, method = 'GET', body = {}, credentials, region) {
   // According to aws4 docs, search params should be part of the "path"
   const params = url.searchParams.toString();
 
@@ -178,6 +185,14 @@ function signAWSRequestURL(url, method = 'GET', credentials, region) {
     method: method,
     region: region,
   };
+
+  if (method === 'POST' && !_.isEmpty(body)) {
+    requestOptions.body = JSON.stringify(body);
+    // `aws4` will infer the rest
+    requestOptions.headers = {
+      'content-type': 'application/json',
+    }
+  }
 
   // Closer look at aws4 source code: region and service are calculated from
   // URL's host, but for Lambda functions it doesn't translate the URL part
@@ -241,13 +256,21 @@ function transformSpecWithResponse(endpointName = '', sourceData = {}, spec = {}
  * Resolve HTTP method based on known API paths (defined in spec module)
  *
  * @param {string} path - path to inspect
+ * @param {object} options - see `../index.js`
  * @returns {string}
  */
-function resolveHTTPMethod(path = '') {
-  const endpointMatch = Object.values(spec)
+function resolveHTTPMethod(path = '', options = {}) {
+  let method = 'GET';
+  if (!_.isEmpty(options.body)) {
+    method = 'POST';
+  } else {
+    const endpointMatch = Object.values(spec)
     .reduce((acc, value) => acc.concat(value.endpoints), [])
     .find(endpoint => endpoint.path === path);
-  return endpointMatch?.method || 'GET';
+    method = endpointMatch?.method || method;
+  }
+
+  return method;
 }
 
 /**

--- a/tools/psoxy-test/psoxy-test-call.js
+++ b/tools/psoxy-test/psoxy-test-call.js
@@ -33,6 +33,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * @param {boolean} options.verbose - Verbose ouput
  * @param {boolean} options.saveToFile - Whether to save successful responses to a file (responses/[api-path]-[ISO8601 timestamp].json)
  * @param {string} options.method - HTTP request method
+ * @param {string} options.body - HTTP request body (JSON string, GitHub use-case)
  * @param {boolean} options.healthCheck - Run "Health Check" call against Psoxy deploy
  * @return {PsoxyResponse}
  */
@@ -45,6 +46,14 @@ export default async function (options = {}) {
     url = new URL(options.url);
   } catch (error) {
     throw new Error(`"${error.input}" is not a valid URL`, { cause: error });
+  }
+
+  if (!_.isEmpty(options.body)) {
+    try {
+      options.body = JSON.parse(options.body);
+    } catch(error) {
+      throw new Error(`Body option must be a JSON string: ${error.message}`);
+    }
   }
 
   const isAWS = aws.isValidURL(url);

--- a/tools/psoxy-test/test/aws.test.js
+++ b/tools/psoxy-test/test/aws.test.js
@@ -46,6 +46,7 @@ test.beforeEach(async (t) => {
     t.context.utils.signAWSRequestURL(
       td.matchers.isA(URL),
       td.matchers.contains('GET'),
+      td.matchers.anything(),
       credentials,
       options.region,
     )
@@ -113,7 +114,8 @@ test.serial('Psoxy call: works as expected', async (t) => {
     utils.request(
       td.matchers.isA(URL),
       td.matchers.contains('GET'),
-      td.matchers.contains(signedRequest.headers)
+      td.matchers.contains(signedRequest.headers),
+      td.matchers.anything()
     )
   ).thenReturn({ status: httpCodes.HTTP_STATUS_OK });
 
@@ -131,7 +133,8 @@ test.serial('Psoxy call: pathless URL results 500', async (t) => {
     utils.request(
       td.matchers.isA(URL),
       td.matchers.contains('GET'),
-      td.matchers.contains(signedRequest.headers)
+      td.matchers.contains(signedRequest.headers),
+      td.matchers.anything(),
     )
   ).thenReturn({
     status: 500,

--- a/tools/psoxy-test/test/gcp.test.js
+++ b/tools/psoxy-test/test/gcp.test.js
@@ -77,7 +77,8 @@ test('Psoxy Call: get identity token when option missing', async (t) => {
       td.matchers.contains('GET'),
       td.matchers.contains({
         Authorization: `Bearer ${TOKEN}`,
-      })
+      }),
+      td.matchers.anything()
     )
   ).thenReturn({ status: httpCodes.HTTP_STATUS_OK });
 

--- a/tools/psoxy-test/test/utils.test.js
+++ b/tools/psoxy-test/test/utils.test.js
@@ -52,6 +52,8 @@ test('Resolve HTTP method', (t) => {
   // Unknown endpoint (not in spec), defaults to 'GET'
   t.is(resolveHTTPMethod('/foo/bar'), 'GET');
   t.is(resolveHTTPMethod('/2/team/members/list_v2'), 'POST');
+  // if body is specified, defaults to 'POST'
+  t.is(resolveHTTPMethod('/foo/bar', { body: 'baz' }), 'POST');
 });
 
 test('Execute with retry: make "n" attempts if conditions met', async (t) => {


### PR DESCRIPTION
### Fixes
.

### Features
- [Pass body in psoxy-test tool and add to aws4 sign](https://app.asana.com/0/1206395718784320/1206447542630254/f); test command: 
````
# replace `<role>`, `<lambda>`, and `org` value in graphql query 
node cli-call.js  -r <role> -re "us-east-1" -u https://<lamdba>.us-east-1.on.aws/graphql -b '{"variables":{"org":"foo"},"query":"query ($endCursor: String, $org: String!) {  organization(login:$org) {      membersWithRole(first: 100, after: $endCursor) {        pageInfo {      hasNextPage          endCursor        }        edges {          node {                       login  email           organizationVerifiedDomainEmails(login:$org)          }        }      }  }}"}' -v

````
### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
