### PR TITLE
AWS Secrets Manager support (alpha)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Changes to be including in future/planned release notes will be added here.
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.47](https://github.com/Worklytics/psoxy/release/tag/v0.4.47)
+  - AWS: some moved resources due to refactoring to accommodate option to use AWS Secrets Manager
+
 ## [0.4.46](https://github.com/Worklytics/psoxy/release/tag/v0.4.46)
   - you'll see several `timestamp_static` resources provisioned by terraform; these are simply
     timestamps persisted into state. various example API calls in TODOs/tests are derived from these.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Changes to be including in future/planned release notes will be added here.
 ## [0.4.47](https://github.com/Worklytics/psoxy/release/tag/v0.4.47)
   - AWS: some moved resources due to refactoring to accommodate option to use AWS Secrets Manager
 
+possibility of breaking due to no longer inferring global SSM parameter prefix?
+
+
 ## [0.4.46](https://github.com/Worklytics/psoxy/release/tag/v0.4.46)
   - you'll see several `timestamp_static` resources provisioned by terraform; these are simply
     timestamps persisted into state. various example API calls in TODOs/tests are derived from these.

--- a/docs/development/alpha-features/aws-secrets-manager.md
+++ b/docs/development/alpha-features/aws-secrets-manager.md
@@ -3,6 +3,15 @@
 With `v0.4.47`, we're adding **alpha** support for AWS Secrets Manager. This feature is not yet
 fully documented or stable.
 
+A couple notes:
+  - some connectors, in particular Zoom/Jira, rotate tokens frequently so will generate a lot of
+    versions of secrets.  AFIAK, AWS will still bill you for just one secret, as only one should be
+    staged as the 'current' version.  But you should monitor this and review the particular terms
+    and pricing model of your AWS contract.
+  - our modules will create secrets ONLY in the region into which your proxy infra is being deployed,
+    based on the value set in your `terraform.tfvars` file.
+
+
 Migration from Parameter Store: the default storage for secrets is as AWS Systems Manager Parameter
 Store SecureString parameters. If you have existing secrets in Parameter Store that *aren't* managed
 by terraform, you can copy them to a secure location to avoid needing to re-create them for every

--- a/docs/development/alpha-features/aws-secrets-manager.md
+++ b/docs/development/alpha-features/aws-secrets-manager.md
@@ -4,7 +4,11 @@ With `v0.4.47`, we're adding **alpha** support for AWS Secrets Manager. This fea
 fully documented or stable.
 
 Migration from Parameter Store: the default storage for secrets is as AWS Systems Manager Parameter
-Store SecureString parameters. If you have existing secrets in Parameter Store, s
+Store SecureString parameters. If you have existing secrets in Parameter Store that *aren't* managed
+by terraform, you can copy them to a secure location to avoid needing to re-create them for every
+source.
+
+
 
 ## Setup
 
@@ -23,7 +27,16 @@ secrets_store_implementation="aws_secrets_manager"
   5. Fill values of secrets in Secrets Manager that you copied from Parameter Store. If you did not
      copy the values, see the `TODO 1..` files for each connector to obtain new values.
 
+## Filling Secret Manager Secret values via AWS Console
 
+Navigate to the AWS Secrets Manager console and find the secret you need to fill. If there's not an
+option to fill the value, click 'Retrieve secret value'; it should then prompt you with option to
+fill it.
+
+IMPORTANT: Choose 'Plain Text' and remove the brackets (`{}`) that AWS prefills the input with!
+
+Then copy-paste the value EXACTLY as-is. Ensure no leading/trailing whitespace or newlines, and no
+encoding problems.
 
 ## NOTES
   - AWS Secret Manager secrets will be stored/accessed with same path as SSM parameters. Eg, at value of

--- a/docs/development/alpha-features/aws-secrets-manager.md
+++ b/docs/development/alpha-features/aws-secrets-manager.md
@@ -1,0 +1,35 @@
+# AWS Secrets Manager Support
+
+With `v0.4.47`, we're adding **alpha** support for AWS Secrets Manager. This feature is not yet
+fully documented or stable.
+
+Migration from Parameter Store: the default storage for secrets is as AWS Systems Manager Parameter
+Store SecureString parameters. If you have existing secrets in Parameter Store, s
+
+## Setup
+
+  1. If you forked the `psoxy-example-aws` repo prior to `v0.4.47`, you should copy a `main.tf` and
+`variables.tf` from that version of later of the repo and unify the version numbers with your own. (>=0.4.47)
+
+  2. Add the following to your `terraform.tfvars`:
+```hcl
+secrets_store_implementation="aws_secrets_manager"
+```
+  3. If you previously filled any secret values via AWS web console (such as API secrets you were
+     directed to create in `TODO 1` files for certain sources, you should copy those values now).
+
+  4. `terraform apply`; review plan and confirm when ready
+
+  5. Fill values of secrets in Secrets Manager that you copied from Parameter Store. If you did not
+     copy the values, see the `TODO 1..` files for each connector to obtain new values.
+
+
+
+## NOTES
+  - AWS Secret Manager secrets will be stored/accessed with same path as SSM parameters. Eg, at value of
+`aws_ssm_param_root_path`, if any.
+
+## Future work
+q: support distinct path for secrets? or generalize parameter naming?
+
+

--- a/docs/development/alpha-features/aws-secrets-manager.md
+++ b/docs/development/alpha-features/aws-secrets-manager.md
@@ -5,7 +5,7 @@ fully documented or stable.
 
 A couple notes:
   - some connectors, in particular Zoom/Jira, rotate tokens frequently so will generate a lot of
-    versions of secrets.  AFIAK, AWS will still bill you for just one secret, as only one should be
+    versions of secrets.  AFAIK, AWS will still bill you for just one secret, as only one should be
     staged as the 'current' version.  But you should monitor this and review the particular terms
     and pricing model of your AWS contract.
   - our modules will create secrets ONLY in the region into which your proxy infra is being deployed,

--- a/docs/development/alpha-features/hashicorp-vault.md
+++ b/docs/development/alpha-features/hashicorp-vault.md
@@ -17,7 +17,7 @@ secret manager for Vault.
        * NOTE: must be accessible from AWS account / GCP project where you're deploying
      * `VAULT_TOKEN` - choose the appropriate token type for your use case; we recommend you use
         a periodic token that can lookup and renew itself, with period of > 8 days. With such a
-        setup, Psoxy will lookup and renew this token as needed. Otherwise, it's your responsibility
+        setup, Psoxy will look up and renew this token as needed. Otherwise, it's your responsibility
         either renew it OR replace it by updating this environment variable before expiration.
      * `VAULT_NAMESPACE` - optional, if you're using Vault Namespaces
      * `PATH_TO_SHARED_CONFIG` - eg, `secret/worklytics_deployment/PSOXY_SHARED/`

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -126,11 +126,11 @@ module "psoxy" {
   custom_bulk_connector_arguments = var.custom_bulk_connector_arguments
   todo_step                       = local.max_auth_todo_step
 
-#  vpc_config = {
-#    vpc_id             = aws_vpc.main.id
-#    security_group_ids = [aws_security_group.main.id]
-#    subnet_ids         = [aws_subnet.main.id]
-#  }
+  #  vpc_config = {
+  #    vpc_id             = aws_vpc.main.id
+  #    security_group_ids = [aws_security_group.main.id]
+  #    subnet_ids         = [aws_subnet.main.id]
+  #  }
 }
 
 ## Worklytics connection configuration

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -99,25 +99,25 @@ module "psoxy" {
   source = "../../modules/aws-host"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-host?ref=rc-v0.4.46"
 
-  environment_name               = var.environment_name
-  aws_account_id                 = var.aws_account_id
-  aws_ssm_param_root_path        = var.aws_ssm_param_root_path
-  psoxy_base_dir                 = var.psoxy_base_dir
-  deployment_bundle              = var.deployment_bundle
-  install_test_tool              = var.install_test_tool
-  provision_testing_infra        = var.provision_testing_infra
-  force_bundle                   = var.force_bundle
-  caller_gcp_service_account_ids = var.caller_gcp_service_account_ids
-  caller_aws_arns                = var.caller_aws_arns
-  non_production_connectors      = var.non_production_connectors
-  custom_api_connector_rules     = var.custom_api_connector_rules
-  lookup_table_builders          = var.lookup_table_builders
-  general_environment_variables  = var.general_environment_variables
-  function_env_kms_key_arn       = var.project_aws_kms_key_arn
-  logs_kms_key_arn               = var.project_aws_kms_key_arn
-  aws_ssm_key_id                 = var.project_aws_kms_key_arn
-  use_api_gateway_v2             = var.use_api_gateway_v2
-
+  environment_name                = var.environment_name
+  aws_account_id                  = var.aws_account_id
+  aws_ssm_param_root_path         = var.aws_ssm_param_root_path
+  psoxy_base_dir                  = var.psoxy_base_dir
+  deployment_bundle               = var.deployment_bundle
+  install_test_tool               = var.install_test_tool
+  provision_testing_infra         = var.provision_testing_infra
+  force_bundle                    = var.force_bundle
+  caller_gcp_service_account_ids  = var.caller_gcp_service_account_ids
+  caller_aws_arns                 = var.caller_aws_arns
+  non_production_connectors       = var.non_production_connectors
+  custom_api_connector_rules      = var.custom_api_connector_rules
+  lookup_table_builders           = var.lookup_table_builders
+  general_environment_variables   = var.general_environment_variables
+  function_env_kms_key_arn        = var.project_aws_kms_key_arn
+  logs_kms_key_arn                = var.project_aws_kms_key_arn
+  aws_ssm_key_id                  = var.project_aws_kms_key_arn
+  use_api_gateway_v2              = var.use_api_gateway_v2
+  secrets_store_implementation    = var.secrets_store_implementation
   bulk_sanitized_expiration_days  = var.bulk_sanitized_expiration_days
   bulk_input_expiration_days      = var.bulk_input_expiration_days
   api_connectors                  = local.api_connectors

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -53,6 +53,12 @@ variable "aws_ssm_param_root_path" {
   }
 }
 
+variable "secrets_store_implementation" {
+  type        = string
+  description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"
+  default     = "aws_ssm_parameter_store"
+}
+
 variable "project_aws_kms_key_arn" {
   type        = string
   description = "AWS KMS key ARN to use to encrypt all AWS components created by this Terraform configuration that support CMEKs. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -116,7 +116,7 @@ module "api_connector" {
   path_to_repo_root                     = var.psoxy_base_dir
   todo_step                             = var.todo_step
   global_parameter_arns                 = try(module.global_secrets_ssm[0].secret_arns, [])
-  global_secrets_manager_secret_arns    = try(module.global_secrets_secrets_manager[0].secret_arns, [])
+  global_secrets_manager_secret_arns    = try(module.global_secrets_secrets_manager[0].secret_arns, {})
   path_to_instance_ssm_parameters       = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
   path_to_shared_ssm_parameters         = var.aws_ssm_param_root_path
   ssm_kms_key_ids                       = local.ssm_key_ids

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -115,6 +115,7 @@ module "api_connector" {
   region                                = data.aws_region.current.id
   path_to_repo_root                     = var.psoxy_base_dir
   todo_step                             = var.todo_step
+  secrets_store_implementation          = var.secrets_store_implementation
   global_parameter_arns                 = try(module.global_secrets_ssm[0].secret_arns, [])
   global_secrets_manager_secret_arns    = try(module.global_secrets_secrets_manager[0].secret_arns, {})
   path_to_instance_ssm_parameters       = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
@@ -169,6 +170,7 @@ module "bulk_connector" {
   psoxy_base_dir                     = var.psoxy_base_dir
   rules                              = try(var.custom_bulk_connector_rules[each.key], each.value.rules)
   rules_file                         = each.value.rules_file
+  secrets_store_implementation       = var.secrets_store_implementation
   global_parameter_arns              = try(module.global_secrets_ssm[0].secret_arns, [])
   global_secrets_manager_secret_arns = try(module.global_secrets_secrets_manager[0].secret_arns, [])
   path_to_instance_ssm_parameters    = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -67,7 +67,7 @@ module "instance_ssm_parameters" {
 
   path       = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
   kms_key_id = var.aws_ssm_key_id
-  secrets    = { for v in each.value.secured_variables :
+  secrets = { for v in each.value.secured_variables :
     v.name => {
       value               = v.value,
       description         = try(v.description, null)
@@ -81,11 +81,11 @@ module "instance_ssm_parameters" {
 module "instance_secrets_secrets_manager" {
   source = "../../modules/aws-secretsmanager-secrets"
 
-  for_each = var.secrets_store_implementation == "aws_secrets_manager"  ? var.api_connectors : {}
+  for_each = var.secrets_store_implementation == "aws_secrets_manager" ? var.api_connectors : {}
 
   path       = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
   kms_key_id = var.aws_ssm_key_id
-  secrets    = { for v in each.value.secured_variables :
+  secrets = { for v in each.value.secured_variables :
     v.name => {
       value               = v.value,
       description         = try(v.description, null)
@@ -153,30 +153,30 @@ module "bulk_connector" {
 
   source = "../../modules/aws-psoxy-bulk"
 
-  aws_account_id                   = var.aws_account_id
-  provision_iam_policy_for_testing = var.provision_testing_infra
-  aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy.api_caller_role_arn : null
-  environment_name                 = var.environment_name
-  instance_id                      = each.key
-  source_kind                      = each.value.source_kind
-  aws_region                       = data.aws_region.current.id
-  path_to_function_zip             = module.psoxy.path_to_deployment_jar
-  function_zip_hash                = module.psoxy.deployment_package_hash
-  function_env_kms_key_arn         = var.function_env_kms_key_arn
-  logs_kms_key_arn                 = var.logs_kms_key_arn
-  psoxy_base_dir                   = var.psoxy_base_dir
-  rules                            = try(var.custom_bulk_connector_rules[each.key], each.value.rules)
-  rules_file                       = each.value.rules_file
+  aws_account_id                     = var.aws_account_id
+  provision_iam_policy_for_testing   = var.provision_testing_infra
+  aws_role_to_assume_when_testing    = var.provision_testing_infra ? module.psoxy.api_caller_role_arn : null
+  environment_name                   = var.environment_name
+  instance_id                        = each.key
+  source_kind                        = each.value.source_kind
+  aws_region                         = data.aws_region.current.id
+  path_to_function_zip               = module.psoxy.path_to_deployment_jar
+  function_zip_hash                  = module.psoxy.deployment_package_hash
+  function_env_kms_key_arn           = var.function_env_kms_key_arn
+  logs_kms_key_arn                   = var.logs_kms_key_arn
+  psoxy_base_dir                     = var.psoxy_base_dir
+  rules                              = try(var.custom_bulk_connector_rules[each.key], each.value.rules)
+  rules_file                         = each.value.rules_file
   global_parameter_arns              = try(module.global_secrets_ssm[0].secret_arns, [])
   global_secrets_manager_secret_arns = try(module.global_secrets_secrets_manager[0].secret_arns, [])
-  path_to_instance_ssm_parameters  = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
-  ssm_kms_key_ids                  = local.ssm_key_ids
-  sanitized_accessor_role_names    = [module.psoxy.api_caller_role_name]
-  memory_size_mb                   = coalesce(try(var.custom_bulk_connector_arguments[each.key].memory_size_mb, null), each.value.memory_size_mb, 1024)
-  sanitized_expiration_days        = var.bulk_sanitized_expiration_days
-  input_expiration_days            = var.bulk_input_expiration_days
-  example_file                     = each.value.example_file
-  vpc_config                       = var.vpc_config
+  path_to_instance_ssm_parameters    = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
+  ssm_kms_key_ids                    = local.ssm_key_ids
+  sanitized_accessor_role_names      = [module.psoxy.api_caller_role_name]
+  memory_size_mb                     = coalesce(try(var.custom_bulk_connector_arguments[each.key].memory_size_mb, null), each.value.memory_size_mb, 1024)
+  sanitized_expiration_days          = var.bulk_sanitized_expiration_days
+  input_expiration_days              = var.bulk_input_expiration_days
+  example_file                       = each.value.example_file
+  vpc_config                         = var.vpc_config
 
   environment_variables = merge(
     var.general_environment_variables,

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -118,6 +118,7 @@ module "api_connector" {
   global_parameter_arns                 = try(module.global_secrets_ssm[0].secret_arns, [])
   global_secrets_manager_secret_arns    = try(module.global_secrets_secrets_manager[0].secret_arns, [])
   path_to_instance_ssm_parameters       = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
+  path_to_shared_ssm_parameters         = var.aws_ssm_param_root_path
   ssm_kms_key_ids                       = local.ssm_key_ids
   target_host                           = each.value.target_host
   source_auth_strategy                  = each.value.source_auth_strategy
@@ -125,6 +126,7 @@ module "api_connector" {
   example_api_calls_user_to_impersonate = each.value.example_api_calls_user_to_impersonate
   vpc_config                            = var.vpc_config
   api_gateway_v2                        = module.psoxy.api_gateway_v2
+
 
   environment_variables = merge(
     var.general_environment_variables,
@@ -170,6 +172,7 @@ module "bulk_connector" {
   global_parameter_arns              = try(module.global_secrets_ssm[0].secret_arns, [])
   global_secrets_manager_secret_arns = try(module.global_secrets_secrets_manager[0].secret_arns, [])
   path_to_instance_ssm_parameters    = "${local.instance_ssm_prefix}${replace(upper(each.key), "-", "_")}_"
+  path_to_shared_ssm_parameters      = var.aws_ssm_param_root_path
   ssm_kms_key_ids                    = local.ssm_key_ids
   sanitized_accessor_role_names      = [module.psoxy.api_caller_role_name]
   memory_size_mb                     = coalesce(try(var.custom_bulk_connector_arguments[each.key].memory_size_mb, null), each.value.memory_size_mb, 1024)
@@ -177,6 +180,7 @@ module "bulk_connector" {
   input_expiration_days              = var.bulk_input_expiration_days
   example_file                       = each.value.example_file
   vpc_config                         = var.vpc_config
+
 
   environment_variables = merge(
     var.general_environment_variables,

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -92,6 +92,7 @@ module "instance_secrets_secrets_manager" {
       sensitive           = try(v.sensitive, true)
       value_managed_by_tf = try(v.value_managed_by_tf, true) # ideally, would be `value != null`, but bc value is sensitive, Terraform doesn't allow for_each over map derived from sensitive values
     }
+    if try(v.sensitive, true)
   }
 }
 

--- a/infra/modules/aws-host/migration_0_4_47.tf
+++ b/infra/modules/aws-host/migration_0_4_47.tf
@@ -1,5 +1,5 @@
 # 0.4.47 will add support for Secrets Manager instead of SSM Parameter Store
-# customers will seem moves
+# customers will see moves
 moved {
   from = module.global_secrets
   to   = module.global_secrets_ssm[0]

--- a/infra/modules/aws-host/migration_0_4_47.tf
+++ b/infra/modules/aws-host/migration_0_4_47.tf
@@ -1,0 +1,11 @@
+# 0.4.47 will add support for Secrets Manager instead of SSM Parameter Store
+# customers will seem moves
+moved {
+  from = module.global_secrets
+  to   = module.global_secrets_ssm[0]
+}
+
+moved {
+  from = module.instance_secrets
+  to   = module.instance_ssm_parameters
+}

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -18,6 +18,7 @@ variable "aws_ssm_param_root_path" {
   }
 }
 
+# TODO: generalize to 'secrets', regardless of store (AWS SSM, AWS Secrets Manager, etc)
 variable "aws_ssm_key_id" {
   type        = string
   description = "KMS key id to use for encrypting SSM SecureString parameters created by this module, in any. (by default, will encrypt with AWS-managed keys)"
@@ -289,6 +290,12 @@ variable "vpc_config" {
   })
   description = "**alpha** VPC configuration for lambda; if not provided, lambda will not be deployed in a VPC. see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config"
   default     = null
+}
+
+variable "secrets_store_implementation" {
+  type        = string
+  description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"
+  default     = "aws_ssm_parameter_store"
 }
 
 variable "todo_step" {

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -13,13 +13,13 @@ module "psoxy_lambda" {
   path_to_function_zip            = var.path_to_function_zip
   function_zip_hash               = var.function_zip_hash
   global_parameter_arns           = var.global_parameter_arns
-
   global_secrets_manager_secrets_arns = var.global_secrets_manager_secrets_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   function_env_kms_key_arn        = var.function_env_kms_key_arn
   logs_kms_key_arn                = var.logs_kms_key_arn
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
   vpc_config                      = var.vpc_config
+  secrets_store_implementation    = var.secrets_store_implementation
 
   environment_variables = merge(
     var.environment_variables,

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -5,21 +5,21 @@
 module "psoxy_lambda" {
   source = "../aws-psoxy-lambda"
 
-  environment_name                = var.environment_name
-  instance_id                     = var.instance_id
-  handler_class                   = "co.worklytics.psoxy.S3Handler"
-  timeout_seconds                 = 600 # 10 minutes
-  memory_size_mb                  = var.memory_size_mb
-  path_to_function_zip            = var.path_to_function_zip
-  function_zip_hash               = var.function_zip_hash
-  global_parameter_arns           = var.global_parameter_arns
+  environment_name                    = var.environment_name
+  instance_id                         = var.instance_id
+  handler_class                       = "co.worklytics.psoxy.S3Handler"
+  timeout_seconds                     = 600 # 10 minutes
+  memory_size_mb                      = var.memory_size_mb
+  path_to_function_zip                = var.path_to_function_zip
+  function_zip_hash                   = var.function_zip_hash
+  global_parameter_arns               = var.global_parameter_arns
   global_secrets_manager_secrets_arns = var.global_secrets_manager_secrets_arns
-  path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
-  function_env_kms_key_arn        = var.function_env_kms_key_arn
-  logs_kms_key_arn                = var.logs_kms_key_arn
-  ssm_kms_key_ids                 = var.ssm_kms_key_ids
-  vpc_config                      = var.vpc_config
-  secrets_store_implementation    = var.secrets_store_implementation
+  path_to_instance_ssm_parameters     = var.path_to_instance_ssm_parameters
+  function_env_kms_key_arn            = var.function_env_kms_key_arn
+  logs_kms_key_arn                    = var.logs_kms_key_arn
+  ssm_kms_key_ids                     = var.ssm_kms_key_ids
+  vpc_config                          = var.vpc_config
+  secrets_store_implementation        = var.secrets_store_implementation
 
   environment_variables = merge(
     var.environment_variables,

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -15,6 +15,7 @@ module "psoxy_lambda" {
   global_parameter_arns               = var.global_parameter_arns
   global_secrets_manager_secrets_arns = var.global_secrets_manager_secrets_arns
   path_to_instance_ssm_parameters     = var.path_to_instance_ssm_parameters
+  path_to_shared_ssm_parameters       = var.path_to_shared_ssm_parameters
   function_env_kms_key_arn            = var.function_env_kms_key_arn
   logs_kms_key_arn                    = var.logs_kms_key_arn
   ssm_kms_key_ids                     = var.ssm_kms_key_ids

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -13,6 +13,8 @@ module "psoxy_lambda" {
   path_to_function_zip            = var.path_to_function_zip
   function_zip_hash               = var.function_zip_hash
   global_parameter_arns           = var.global_parameter_arns
+
+  global_secrets_manager_secrets_arns = var.global_secrets_manager_secrets_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   function_env_kms_key_arn        = var.function_env_kms_key_arn
   logs_kms_key_arn                = var.logs_kms_key_arn

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -150,6 +150,12 @@ variable "vpc_config" {
   default     = null
 }
 
+variable "secrets_store_implementation" {
+  type        = string
+  description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"
+  default     = "aws_ssm_parameter_store"
+}
+
 variable "todo_step" {
   type        = number
   description = "of all todos, where does this one logically fall in sequence"

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -127,6 +127,12 @@ variable "global_parameter_arns" {
   default     = []
 }
 
+variable "global_secrets_manager_secrets_arns" {
+  type        = list(string)
+  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = []
+}
+
 variable "memory_size_mb" {
   # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#memory_size
   type        = number

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -45,6 +45,12 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "path_to_shared_ssm_parameters" {
+  type        = string
+  description = "path to shared global config parameters in SSM Parameter Store"
+  default     = ""
+}
+
 variable "function_env_kms_key_arn" {
   type        = string
   description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -133,10 +133,10 @@ variable "global_parameter_arns" {
   default     = []
 }
 
-variable "global_secrets_manager_secrets_arns" {
-  type        = list(string)
-  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
-  default     = []
+variable "global_secrets_manager_secret_arns" {
+  type        = map(string)
+  description = "Secrets Manager Secrets ARNs to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = {}
 }
 
 variable "memory_size_mb" {

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -38,6 +38,7 @@ module "psoxy_lambda" {
   function_env_kms_key_arn        = var.function_env_kms_key_arn
   logs_kms_key_arn                = var.logs_kms_key_arn
   global_parameter_arns           = var.global_parameter_arns
+  global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
   log_retention_in_days           = var.log_retention_days

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -39,6 +39,7 @@ module "psoxy_lambda" {
   logs_kms_key_arn                = var.logs_kms_key_arn
   global_parameter_arns           = var.global_parameter_arns
   global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
+  secrets_store_implementation    = var.secrets_store_implementation
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
   log_retention_in_days           = var.log_retention_days

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -27,23 +27,23 @@ locals {
 module "psoxy_lambda" {
   source = "../aws-psoxy-lambda"
 
-  environment_name                = var.environment_name
-  instance_id                     = var.instance_id
-  handler_class                   = "co.worklytics.psoxy.S3Handler"
-  timeout_seconds                 = 600 # 10 minutes
-  memory_size_mb                  = var.memory_size_mb
-  source_kind                     = var.source_kind
-  path_to_function_zip            = var.path_to_function_zip
-  function_zip_hash               = var.function_zip_hash
-  function_env_kms_key_arn        = var.function_env_kms_key_arn
-  logs_kms_key_arn                = var.logs_kms_key_arn
-  global_parameter_arns           = var.global_parameter_arns
+  environment_name                   = var.environment_name
+  instance_id                        = var.instance_id
+  handler_class                      = "co.worklytics.psoxy.S3Handler"
+  timeout_seconds                    = 600 # 10 minutes
+  memory_size_mb                     = var.memory_size_mb
+  source_kind                        = var.source_kind
+  path_to_function_zip               = var.path_to_function_zip
+  function_zip_hash                  = var.function_zip_hash
+  function_env_kms_key_arn           = var.function_env_kms_key_arn
+  logs_kms_key_arn                   = var.logs_kms_key_arn
+  global_parameter_arns              = var.global_parameter_arns
   global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
-  secrets_store_implementation    = var.secrets_store_implementation
-  path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
-  ssm_kms_key_ids                 = var.ssm_kms_key_ids
-  log_retention_in_days           = var.log_retention_days
-  vpc_config                      = var.vpc_config
+  secrets_store_implementation       = var.secrets_store_implementation
+  path_to_instance_ssm_parameters    = var.path_to_instance_ssm_parameters
+  ssm_kms_key_ids                    = var.ssm_kms_key_ids
+  log_retention_in_days              = var.log_retention_days
+  vpc_config                         = var.vpc_config
 
   environment_variables = merge(
     var.environment_variables,

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -41,6 +41,7 @@ module "psoxy_lambda" {
   global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
   secrets_store_implementation       = var.secrets_store_implementation
   path_to_instance_ssm_parameters    = var.path_to_instance_ssm_parameters
+  path_to_shared_ssm_parameters      = var.path_to_shared_ssm_parameters
   ssm_kms_key_ids                    = var.ssm_kms_key_ids
   log_retention_in_days              = var.log_retention_days
   vpc_config                         = var.vpc_config

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -187,9 +187,9 @@ variable "global_parameter_arns" {
 }
 
 variable "global_secrets_manager_secret_arns" {
-  type        = list(string)
-  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
-  default     = []
+  type        = map(string)
+  description = "Secrets Manager Secrets ARNs to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = {}
 }
 
 variable "memory_size_mb" {

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -215,6 +215,12 @@ variable "vpc_config" {
   default     = null
 }
 
+variable "secrets_store_implementation" {
+  type        = string
+  description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"
+  default     = "aws_ssm_parameter_store"
+}
+
 variable "example_file" {
   type        = string
   description = "path to example file to use for testing, from psoxy_base_dir"

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -53,6 +53,12 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "path_to_shared_ssm_parameters" {
+  type        = string
+  description = "path to shared global config parameters in SSM Parameter Store"
+  default     = ""
+}
+
 variable "function_env_kms_key_arn" {
   type        = string
   description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -180,6 +180,12 @@ variable "global_parameter_arns" {
   default     = []
 }
 
+variable "global_secrets_manager_secret_arns" {
+  type        = list(string)
+  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = []
+}
+
 variable "memory_size_mb" {
   # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#memory_size
   type        = number

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -207,7 +207,7 @@ locals {
       "secretsmanager:DescribeSecret",
     ]
     Effect   = "Allow"
-    Resource = var.global_secrets_manager_secret_arns
+    Resource = values(var.global_secrets_manager_secret_arns)
   }]
 
   key_statements = length(local.kms_key_ids_to_allow) > 0 ? [{

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -180,7 +180,7 @@ locals {
     ]
   }]
 
-  local_secrets_manager_statements = var.secrets_store_implementation == "aws_secrets_manager" ? [ {
+  local_secrets_manager_statements = var.secrets_store_implementation == "aws_secrets_manager" ? [{
     Sid = "ReadWriteInstanceSecretsManagerSecrets"
     Action = [
       "secretsmanager:GetSecretValue",

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -78,8 +78,9 @@ resource "aws_lambda_function" "instance" {
       var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
       var.environment_variables,
       {
-        EXECUTION_ROLE  = aws_iam_role.iam_for_lambda.arn,
+        EXECUTION_ROLE  = aws_iam_role.iam_for_lambda.arn, # q: used for anything? doesn't seem accessed by Java code ...
         BUNDLE_FILENAME = local.bundle_filename
+        SECRETS_STORE   = upper(var.secrets_store_implementation)
       },
       # only set env vars for config paths if non-default values
       length(local.path_to_shared_config) > 1 ? { PATH_TO_SHARED_CONFIG = local.path_to_shared_config } : {},

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -180,8 +180,7 @@ locals {
     ]
   }]
 
-  # TODO: condition on whether secrets manager even being used
-  local_secrets_manager_statements = [{
+  local_secrets_manager_statements = var.secrets_store_implementation == "aws_secrets_manager" ? [ {
     Sid = "ReadWriteInstanceSecretsManagerSecrets"
     Action = [
       "secretsmanager:GetSecretValue",
@@ -193,8 +192,7 @@ locals {
     Resource = [
       "${local.secret_arn_prefix}*" # wildcard to match all secrets corresponding to this function
     ]
-  }]
-
+  }] : []
 
   global_ssm_param_statements = length(var.global_parameter_arns) == 0 ? [] : [{
     Sid = "ReadSharedSSMParameters"

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -136,9 +136,9 @@ variable "global_parameter_arns" {
 }
 
 variable "global_secrets_manager_secret_arns" {
-  type        = list(string)
-  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
-  default     = []
+  type        = map(string)
+  description = "Secrets Manager Secrets ARNs to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = {}
 }
 
 

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -157,3 +157,8 @@ variable "vpc_config" {
   default     = null
 }
 
+variable "secrets_store_implementation" {
+  type        = string
+  description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"
+  default     = "aws_ssm_parameter_store"
+}

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -125,7 +125,14 @@ variable "log_retention_in_days" {
 variable "global_parameter_arns" {
   # see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter#attributes-reference
   type        = list(string)
-  description = "System Manager Parameters ARNS to expose to psoxy instance, expected to contain global shared parameters, like salt or encryption keys"
+  description = "System Manager Parameters ARNS to expose to proxy instance, expected to contain global shared parameters, like salt or encryption keys"
+  default     = []
+}
+
+variable "global_secrets_manager_secret_arns" {
+  type        = list(string)
+  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = []
 }
 
 

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -68,6 +68,12 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "path_to_shared_ssm_parameters" {
+  type        = string
+  description = "path to shared global config parameters in SSM Parameter Store"
+  default     = ""
+}
+
 variable "reserved_concurrent_executions" {
   type        = number
   description = "Max number of concurrent instances for the function"

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -52,6 +52,7 @@ module "psoxy_lambda" {
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
   log_retention_in_days           = var.log_retention_days
   vpc_config                      = var.vpc_config
+  secrets_store_implementation    = var.secrets_store_implementation
 
   environment_variables = merge(
     var.environment_variables,

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -47,6 +47,7 @@ module "psoxy_lambda" {
   source_kind                        = var.source_kind
   function_parameters                = var.function_parameters
   path_to_instance_ssm_parameters    = var.path_to_instance_ssm_parameters
+  path_to_shared_ssm_parameters      = var.path_to_shared_ssm_parameters
   global_parameter_arns              = var.global_parameter_arns
   global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
   ssm_kms_key_ids                    = var.ssm_kms_key_ids

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -33,26 +33,26 @@ locals {
 module "psoxy_lambda" {
   source = "../aws-psoxy-lambda"
 
-  environment_name                = var.environment_name
-  instance_id                     = var.instance_id
-  handler_class                   = "co.worklytics.psoxy.Handler"
-  path_to_function_zip            = var.path_to_function_zip
-  function_zip_hash               = var.function_zip_hash
-  function_env_kms_key_arn        = var.function_env_kms_key_arn
-  logs_kms_key_arn                = var.logs_kms_key_arn
-  memory_size_mb                  = var.memory_size_mb
-  timeout_seconds                 = 55
-  reserved_concurrent_executions  = var.reserved_concurrent_executions
-  path_to_config                  = var.path_to_config
-  source_kind                     = var.source_kind
-  function_parameters             = var.function_parameters
-  path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
-  global_parameter_arns           = var.global_parameter_arns
+  environment_name                   = var.environment_name
+  instance_id                        = var.instance_id
+  handler_class                      = "co.worklytics.psoxy.Handler"
+  path_to_function_zip               = var.path_to_function_zip
+  function_zip_hash                  = var.function_zip_hash
+  function_env_kms_key_arn           = var.function_env_kms_key_arn
+  logs_kms_key_arn                   = var.logs_kms_key_arn
+  memory_size_mb                     = var.memory_size_mb
+  timeout_seconds                    = 55
+  reserved_concurrent_executions     = var.reserved_concurrent_executions
+  path_to_config                     = var.path_to_config
+  source_kind                        = var.source_kind
+  function_parameters                = var.function_parameters
+  path_to_instance_ssm_parameters    = var.path_to_instance_ssm_parameters
+  global_parameter_arns              = var.global_parameter_arns
   global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
-  ssm_kms_key_ids                 = var.ssm_kms_key_ids
-  log_retention_in_days           = var.log_retention_days
-  vpc_config                      = var.vpc_config
-  secrets_store_implementation    = var.secrets_store_implementation
+  ssm_kms_key_ids                    = var.ssm_kms_key_ids
+  log_retention_in_days              = var.log_retention_days
+  vpc_config                         = var.vpc_config
+  secrets_store_implementation       = var.secrets_store_implementation
 
   environment_variables = merge(
     var.environment_variables,

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -48,6 +48,7 @@ module "psoxy_lambda" {
   function_parameters             = var.function_parameters
   path_to_instance_ssm_parameters = var.path_to_instance_ssm_parameters
   global_parameter_arns           = var.global_parameter_arns
+  global_secrets_manager_secret_arns = var.global_secrets_manager_secret_arns
   ssm_kms_key_ids                 = var.ssm_kms_key_ids
   log_retention_in_days           = var.log_retention_days
   vpc_config                      = var.vpc_config

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -169,9 +169,9 @@ variable "global_parameter_arns" {
 }
 
 variable "global_secrets_manager_secret_arns" {
-  type        = list(string)
-  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
-  default     = []
+  type        = map(string)
+  description = "Secrets Manager Secrets ARNs to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = {}
 }
 
 # remove after v0.4.x

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -39,6 +39,12 @@ variable "path_to_instance_ssm_parameters" {
   default     = null
 }
 
+variable "path_to_shared_ssm_parameters" {
+  type        = string
+  description = "path to shared global config parameters in SSM Parameter Store"
+  default     = ""
+}
+
 variable "function_env_kms_key_arn" {
   type        = string
   description = "AWS KMS key ARN to use to encrypt lambda's environment. NOTE: Terraform must be authenticated as an AWS principal authorized to encrypt/decrypt with this key."

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -162,6 +162,12 @@ variable "global_parameter_arns" {
   default     = []
 }
 
+variable "global_secrets_manager_secret_arns" {
+  type        = list(string)
+  description = "Secrets Manager Secrets ARNS to expose to proxy instance, expected to contain global shared secrets, like salt or encryption keys"
+  default     = []
+}
+
 # remove after v0.4.x
 variable "function_parameters" {
   type = list(object({

--- a/infra/modules/aws-psoxy-rest/variables.tf
+++ b/infra/modules/aws-psoxy-rest/variables.tf
@@ -214,6 +214,11 @@ variable "http_methods" {
   default     = ["HEAD", "GET", "POST"]
 }
 
+variable "secrets_store_implementation" {
+  type        = string
+  description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"
+  default     = "aws_ssm_parameter_store"
+}
 
 variable "todo_step" {
   type        = number

--- a/infra/modules/aws-secretsmanager-secrets/main.tf
+++ b/infra/modules/aws-secretsmanager-secrets/main.tf
@@ -12,7 +12,7 @@ locals {
   PLACEHOLDER_VALUE        = "fill me"
 
   # externally_managed_secrets = { for k, spec in var.secrets : k => spec if !(spec.value_managed_by_tf) }
-  terraform_managed_secrets  = { for k, spec in var.secrets : k => spec if spec.value_managed_by_tf }
+  terraform_managed_secrets = { for k, spec in var.secrets : k => spec if spec.value_managed_by_tf }
 
   tf_management_description_appendix = "Value managed by a Terraform configuration; changes outside Terraform may be overwritten by subsequent 'terraform apply' runs"
 }

--- a/infra/modules/aws-secretsmanager-secrets/main.tf
+++ b/infra/modules/aws-secretsmanager-secrets/main.tf
@@ -1,4 +1,4 @@
-# stores secrets as AWS Secret Manager SEcrets
+# stores secrets as AWS Secret Manager Secrets
 # NOTE: value of this module is a consistent interface across potential Secret store implementations
 #   eg, GCP Secret Manager, AWS SSM Parameter Store, Hashicorp Vault, AWS Secrets Manager, etc.
 #  but is this good Terraform style? clearly in AWS case, this module doesn't do much ...

--- a/infra/modules/aws-secretsmanager-secrets/main.tf
+++ b/infra/modules/aws-secretsmanager-secrets/main.tf
@@ -23,7 +23,7 @@ resource "aws_secretsmanager_secret" "secret" {
 
   name        = "${local.path_prefix}${each.key}"
   description = "${each.value.description} ${each.value.value_managed_by_tf ? local.tf_management_description_appendix : ""}"
-  kms_key_id  = coalesce(var.kms_key_id, "aws/secretsmanager")
+  kms_key_id  = var.kms_key_id
 }
 
 resource "aws_secretsmanager_secret_version" "terraform_managed" {

--- a/infra/modules/aws-secretsmanager-secrets/main.tf
+++ b/infra/modules/aws-secretsmanager-secrets/main.tf
@@ -1,0 +1,43 @@
+# stores secrets as AWS Secret Manager SEcrets
+# NOTE: value of this module is a consistent interface across potential Secret store implementations
+#   eg, GCP Secret Manager, AWS SSM Parameter Store, Hashicorp Vault, AWS Secrets Manager, etc.
+#  but is this good Terraform style? clearly in AWS case, this module doesn't do much ...
+
+locals {
+  # AWS SSM param name must be fully qualified if contains `/`;
+  # so test for that case, and prefix with `/` if needed
+  non_empty_path           = length(var.path) > 0
+  non_fully_qualified_path = length(regexall("/", var.path)) > 0 && !startswith(var.path, "/")
+  path_prefix              = local.non_empty_path && local.non_fully_qualified_path ? "/${var.path}" : var.path
+  PLACEHOLDER_VALUE        = "fill me"
+
+  # externally_managed_secrets = { for k, spec in var.secrets : k => spec if !(spec.value_managed_by_tf) }
+  terraform_managed_secrets  = { for k, spec in var.secrets : k => spec if spec.value_managed_by_tf }
+
+  tf_management_description_appendix = "Value managed by a Terraform configuration; changes outside Terraform may be overwritten by subsequent 'terraform apply' runs"
+}
+
+# see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
+resource "aws_secretsmanager_secret" "secret" {
+  for_each = var.secrets
+
+  name        = "${local.path_prefix}${each.key}"
+  description = "${each.value.description} ${each.value.value_managed_by_tf ? local.tf_management_description_appendix : ""}"
+  kms_key_id  = coalesce(var.kms_key_id, "aws/secretsmanager")
+}
+
+resource "aws_secretsmanager_secret_version" "terraform_managed" {
+  for_each = local.terraform_managed_secrets
+
+  secret_id     = aws_secretsmanager_secret.secret[each.key].id
+  secret_string = each.value.value
+}
+
+output "secret_ids" {
+  value = { for k, v in aws_secretsmanager_secret.secret : k => aws_secretsmanager_secret.secret[k].id }
+}
+
+# actually the same as id
+output "secret_arns" {
+  value = { for k, v in aws_secretsmanager_secret.secret : k => aws_secretsmanager_secret.secret[k].arn }
+}

--- a/infra/modules/aws-secretsmanager-secrets/variables.tf
+++ b/infra/modules/aws-secretsmanager-secrets/variables.tf
@@ -1,0 +1,22 @@
+variable "secrets" {
+  type = map(
+    object({
+      value               = string
+      description         = optional(string, "")
+      value_managed_by_tf = optional(bool, true) # if value will be managed by Terraform, or some outside process
+      sensitive           = optional(bool, true) # if value is to be handled as sensitive
+    })
+  )
+}
+
+variable "path" {
+  type        = string
+  description = "secrets will be created under this path (prefix); be sure to include trailing `/` if needed."
+  default     = ""
+}
+
+variable "kms_key_id" {
+  type        = string
+  description = "KMS key ID or ARN to use for encrypting secrets. If not provided, secrets will be encrypted by SSM with its keys (controlled by AWS)."
+  default     = null
+}

--- a/infra/modules/aws-ssm-secrets/main.tf
+++ b/infra/modules/aws-ssm-secrets/main.tf
@@ -22,6 +22,8 @@ resource "aws_ssm_parameter" "secret" {
   for_each = local.terraform_managed_secrets
 
   name        = "${local.path_prefix}${each.key}"
+  # Due https://github.com/hashicorp/terraform-provider-aws/issues/31267
+  # all are added as secureString
   type        = "SecureString"
   description = each.value.description
   value       = sensitive(coalesce(each.value.value, local.PLACEHOLDER_VALUE))

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -4,7 +4,7 @@ locals {
   # see: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#aws-managed-policies
   required_aws_roles_to_provision_host = {
     "arn:aws:iam::aws:policy/IAMFullAccess"        = "IAMFullAccess"
-    "arn:aws:iam::aws:policy/AmazonS3FullAccess"   = "AmazonS3FullAccess"
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess"   = "AmazonS3FullAccess" # only if using bulk sources, although 95% do
     "arn:aws:iam::aws:policy/CloudWatchFullAccess" = "CloudWatchFullAccess"
     "arn:aws:iam::aws:policy/AmazonSSMFullAccess"  = "AmazonSSMFullAccess"
     "arn:aws:iam::aws:policy/AWSLambda_FullAccess" = "AWSLambda_FullAccess"
@@ -14,6 +14,27 @@ locals {
   required_aws_managed_policies_to_consume_msft_365_source = {
     "arn:aws:iam::aws:policy/AmazonCognitoPowerUser" = "AmazonCognitoPowerUser"
   }
+
+  # subset of https://docs.aws.amazon.com/aws-managed-policy/latest/reference/SecretsManagerReadWrite.html
+  # as that seems like overkill
+  #  - if you're going to use KMS to encrypt the secrets, then you'll need to add the KMS permissions
+  #    on the key you intend to use.
+  #  - you can/should modify the Resource part of this to limit to a subset of secrets, if this
+  #    is being deployed to an AWS account that's used for purposes beyond this proxy deployment
+  required_aws_policy_to_use_secrets_manager = {
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "secretsmanager:*",
+          "tag:GetResources"
+        ],
+        "Resource" : "*"
+      }
+  ]
+
+
 
   # TODO: create IAM policy document, which installer could use to create their own policy as
   # alternative to using AWS Managed policies

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -32,8 +32,8 @@ locals {
         ],
         "Resource" : "*"
       }
-  ]
-
+    ]
+  }
 
 
   # TODO: create IAM policy document, which installer could use to create their own policy as

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -1108,14 +1108,14 @@ EOT
         {
           name : "OAUTH_REFRESH_TOKEN"
           writable : true
-          lockable : true
-          sensitive : true
+          lockable : true # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
+          sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
           value_managed_by_tf : false
         },
         {
           name : "CLIENT_ID"
           writable : false
-          sensitive : false
+          sensitive : true # not really, but simpler this way; and some may want it treated as sensitive, since would be req'd to brute-force app tokens or something
           value_managed_by_tf : false
         },
         {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ConfigService.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ConfigService.java
@@ -21,9 +21,8 @@ public interface ConfigService {
         // shared? (across multiple instances?)
         // local? (per-instance secrets)
 
-        //sensitive? (eg, value should not be exposed to 3rd parties)
-
-        //secret? (eg, value should be handled as a secret; obscured/acl even internally; avoid in logs, etc)
+        // sensitive? (eg, value should not be exposed to 3rd parties)
+        // secret? (eg, value should be handled as a secret; obscured/acl even internally; avoid in logs, etc)
 
         /**
          * @return whether cached value for property must be revalidated with origin before re-use

--- a/java/impl/aws/pom.xml
+++ b/java/impl/aws/pom.xml
@@ -133,11 +133,13 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cognitoidentity</artifactId>
         </dependency>
-
-
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
         </dependency>
 
         <!-- support Hashicorp Vault as a secret store-->

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsEnvironment.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsEnvironment.java
@@ -1,5 +1,6 @@
 package co.worklytics.psoxy.aws;
 
+import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.HostEnvironment;
 
 
@@ -20,6 +21,20 @@ public class AwsEnvironment implements HostEnvironment {
 
     public String getRegion() {
         return System.getenv(RuntimeEnvironmentVariables.AWS_REGION.name());
+    }
+
+
+    enum AwsConfigProperty implements ConfigService.ConfigProperty {
+        SECRETS_STORE,
+        ;
+    }
+
+
+    enum SecretStoreImplementations {
+        AWS_SSM_PARAMETER_STORE,
+        AWS_SECRETS_MANAGER,
+        HASHICORP_VAULT,
+        ;
     }
 
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsModule.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsModule.java
@@ -100,6 +100,7 @@ public interface AwsModule {
                 parameterStoreConfigServiceFactory.create(pathToSharedConfig);
 
         AwsEnvironment.SecretStoreImplementations secretStoreImpl = envVarsConfigService.getConfigPropertyAsOptional(AwsEnvironment.AwsConfigProperty.SECRETS_STORE)
+            .map(String::toUpperCase) //case-insensitive, so accept 'aws_ssm_parameter_store'
             .map(AwsEnvironment.SecretStoreImplementations::valueOf)
             .orElse(AwsEnvironment.SecretStoreImplementations.AWS_SSM_PARAMETER_STORE);
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsModule.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsModule.java
@@ -67,8 +67,14 @@ public interface AwsModule {
                 .build();
     }
 
-    //NOTE: also used in SecretsManager case for simplicity
-    static String asParameterStoreNamespace(String functionName) {
+    /**
+     * used to prefix function's "local" config in a way that is compliant with AWS roles for
+     * SSM parameter paths and Secrets Manager secret names
+     *
+     * @param functionName
+     * @return function name formated for use as AWS ssm parameter path or secrets manager secret prefix
+     */
+    static String asAwsCompliantNamespace(String functionName) {
         return functionName.toUpperCase().replace("-", "_");
     }
 
@@ -148,7 +154,7 @@ public interface AwsModule {
 
         String pathToInstanceConfig =
             envVarsConfigService.getConfigPropertyAsOptional(ProxyConfigProperty.PATH_TO_INSTANCE_CONFIG)
-                .orElseGet(() -> asParameterStoreNamespace(hostEnvironment.getInstanceId()) + "_");
+                .orElseGet(() -> asAwsCompliantNamespace(hostEnvironment.getInstanceId()) + "_");
 
         return parameterStoreConfigServiceFactory.create(pathToInstanceConfig);
     }
@@ -161,7 +167,7 @@ public interface AwsModule {
 
         String pathToInstanceConfig =
             envVarsConfigService.getConfigPropertyAsOptional(ProxyConfigProperty.PATH_TO_INSTANCE_CONFIG)
-                .orElseGet(() -> asParameterStoreNamespace(hostEnvironment.getInstanceId()) + "_");
+                .orElseGet(() -> asAwsCompliantNamespace(hostEnvironment.getInstanceId()) + "_");
 
         return secretsManagerConfigServiceFactory.create(pathToInstanceConfig);
     }

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -93,6 +93,7 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
             log.info(String.format("Property: %s, stored version %d", key, parameterResponse.version()));
         } catch (SsmException e) {
             log.log(Level.SEVERE, "Could not store property " + key, e);
+            //q: should we be re-throwing here? caller will be unaware of failure
         }
     }
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -93,7 +93,7 @@ public class ParameterStoreConfigService implements ConfigService, LockService {
             log.info(String.format("Property: %s, stored version %d", key, parameterResponse.version()));
         } catch (SsmException e) {
             log.log(Level.SEVERE, "Could not store property " + key, e);
-            //q: should we be re-throwing here? caller will be unaware of failure
+            throw e;
         }
     }
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigService.java
@@ -64,7 +64,7 @@ public class SecretsManagerConfigService implements ConfigService {
             log.info(String.format("Property: %s, stored version %d", id, response.versionId()));
         } catch (SecretsManagerException e) {
             log.log(Level.SEVERE, "failed to write secret", e);
-            //q: re-throw??
+            throw e;
         }
     }
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigService.java
@@ -1,0 +1,120 @@
+package co.worklytics.psoxy.aws;
+
+import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
+import com.google.common.annotations.VisibleForTesting;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedInject;
+import lombok.Getter;
+import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.*;
+
+import javax.inject.Inject;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.logging.Level;
+
+/**
+ * implementation of ConfigService backed by AWS Secrets Manager
+ *
+ * @see co.worklytics.psoxy.aws.ParameterStoreConfigService - model for this
+ *
+ */
+@Log
+public class SecretsManagerConfigService implements ConfigService {
+
+    @Getter(onMethod_ = @VisibleForTesting)
+    final String namespace;
+
+    @Inject
+    SecretsManagerClient client;
+
+    @Inject
+    EnvVarsConfigService envVarsConfig;
+
+    @AssistedInject
+    SecretsManagerConfigService(@Assisted String namespace) {
+        //SSM parameter stores must be "fully qualified" if contain a "/"
+        //q: is this true for Secrets Manager paths?
+        if (StringUtils.isNotBlank(namespace) && namespace.contains("/") && !namespace.startsWith("/")) {
+            namespace = "/" + namespace;
+        }
+        this.namespace = namespace;
+    }
+
+    @Override
+    public boolean supportsWriting() {
+        return true;
+    }
+
+    @Override
+    public void putConfigProperty(ConfigProperty property, String value) {
+        String id = secretId(property);
+        try {
+            PutSecretValueRequest request = PutSecretValueRequest.builder()
+                .secretId(id)
+                .secretString(value)
+                .build();
+            PutSecretValueResponse response = client.putSecretValue(request);
+
+            log.info(String.format("Property: %s, stored version %d", id, response.versionId()));
+        } catch (SecretsManagerException e) {
+            log.log(Level.SEVERE, "failed to write secret", e);
+            //q: re-throw??
+        }
+    }
+
+    String secretId(ConfigProperty property) {
+        if (StringUtils.isBlank(namespace)) {
+            return property.name();
+        } else {
+            return namespace + property.name();
+        }
+    }
+
+    @Override
+    public String getConfigPropertyOrError(ConfigProperty property) {
+        return getConfigPropertyAsOptional(property)
+            .orElseThrow(() -> new NoSuchElementException("Proxy misconfigured; no value for " + property));
+    }
+
+    @Override
+    public Optional<String> getConfigPropertyAsOptional(ConfigProperty property) {
+        return getConfigPropertyAsOptional(property, r -> r.secretString());
+    }
+
+    <T> Optional<T> getConfigPropertyAsOptional(ConfigProperty property, Function<GetSecretValueResponse, T> mapping) {
+
+        String id = secretId(property);
+        try {
+            GetSecretValueRequest request = GetSecretValueRequest.builder()
+                .secretId(id)
+                //specify version?
+                .build();
+
+            GetSecretValueResponse response = client.getSecretValue(request);
+            return Optional.ofNullable(mapping.apply(response));
+        } catch (DecryptionFailureException e ) {
+            log.log(Level.SEVERE, "failed to read secret due to decryption error; check lambda's exec role perms for secret " + id, e);
+            return Optional.empty();
+        } catch (ResourceNotFoundException e) {
+            // does not exist, that could be OK depending on case.
+            if (envVarsConfig.isDevelopment()) {
+                log.log(Level.INFO, "secret not found; may be expected; if not, check lambda's exec role perms for secret " + id, e);
+            }
+            return Optional.empty();
+        } catch (SecretsManagerException e) {
+            log.log(Level.SEVERE, "failed to read secret: " + id, e);
+            return Optional.empty();
+        } catch (AwsServiceException e) {
+            if (e.isThrottlingException()) {
+                log.log(Level.SEVERE, String.format("Throttling issues for Secrets Manager Secret %s, rate limit reached most likely despite retries", id), e);
+            }
+            throw new IllegalStateException(String.format("failed to get config value: %s", id), e);
+        }
+    }
+}

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigService.java
@@ -99,12 +99,12 @@ public class SecretsManagerConfigService implements ConfigService {
             GetSecretValueResponse response = client.getSecretValue(request);
             return Optional.ofNullable(mapping.apply(response));
         } catch (DecryptionFailureException e ) {
-            log.log(Level.SEVERE, "failed to read secret due to decryption error; check lambda's exec role perms for secret " + id, e);
+            log.log(Level.SEVERE, "failed to read secret due to decryption error; check lambda's exec role perms for secret " + id);
             return Optional.empty();
         } catch (ResourceNotFoundException e) {
             // does not exist, that could be OK depending on case.
             if (envVarsConfig.isDevelopment()) {
-                log.log(Level.INFO, "secret not found; may be expected; if not, check lambda's exec role perms for secret " + id, e);
+                log.log(Level.INFO, "secret not found; may be expected; if not, check lambda's exec role perms for secret " + id);
             }
             return Optional.empty();
         } catch (SecretsManagerException e) {
@@ -114,7 +114,7 @@ public class SecretsManagerConfigService implements ConfigService {
             if (e.isThrottlingException()) {
                 log.log(Level.SEVERE, String.format("Throttling issues for Secrets Manager Secret %s, rate limit reached most likely despite retries", id), e);
             }
-            throw new IllegalStateException(String.format("failed to get config value: %s", id), e);
+            throw new IllegalStateException(String.format("failed to get config value: %s", id));
         }
     }
 }

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigServiceFactory.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerConfigServiceFactory.java
@@ -1,0 +1,9 @@
+package co.worklytics.psoxy.aws;
+
+import dagger.assisted.AssistedFactory;
+
+@AssistedFactory
+interface SecretsManagerConfigServiceFactory {
+
+    SecretsManagerConfigService create(String namespace);
+}

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/AwsModuleTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/AwsModuleTest.java
@@ -4,20 +4,16 @@ import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.ssm.SsmClient;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class AwsModuleTest {
 
     @Test
     void asParameterStoreNamespace() {
-        assertEquals("PSOXY_GDIRECTORY", AwsModule.asParameterStoreNamespace("psoxy-gdirectory"));
+        assertEquals("PSOXY_GDIRECTORY", AwsModule.asAwsCompliantNamespace("psoxy-gdirectory"));
     }
 
     //TODO: tests of `nativeConfigService` method

--- a/tools/jira-cloud-auth.sh
+++ b/tools/jira-cloud-auth.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# a script to simplify the process of creating oauth app in Jira Cloud, authorizing it for the
+# the required scopes, and obtaining authentication credentials that can be used by the proxy
+# connector
+
+# Prefer printf over echo for compatibility and formatting
+# Use colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PREFIX="${1:-PSOXY_}"
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null
+then
+    printf "${RED}jq is not installed.${NC}\n"
+    printf "Please install jq to proceed. For example:\n"
+    printf "macOS: ${YELLOW}brew install jq${NC}\n"
+    printf "Linux: ${YELLOW}sudo apt-get install jq${NC} or ${YELLOW}sudo yum install jq${NC}\n"
+    exit 1
+fi
+
+printf "${GREEN}This script will guide you through the process of creating an OAuth app in Jira Cloud, authorizing it for the required scopes, and obtaining authentication credentials that can be used by the proxy connector.${NC}\n"
+
+printf "1. Go to https://developer.atlassian.com/console/myapps/ and click on \"Create\" and choose \"OAuth 2.0 Integration\"\n"
+printf "2. Then click \"Authorization\" and \"Add\" on \`OAuth 2.0 (3L0)\`, adding \`http://localhost\` as callback URI. It can be any URL     that matches the URL format and it is required to be populated, but the proxy instance workflow will not use it.\n"
+printf "3. Now navigate to \"Permissions\" and click on \"Add\" for \`Jira API\`. Once added, click on \"Configure\".
+  Add following scopes as part of \"Classic Scopes\", first clicking on \`Edit Scopes\` and then selecting them:
+    - \`read:jira-user\`
+    - \`read:jira-work\`
+  And these from \"Granular Scopes\":
+    - \`read:group:jira\`
+    - \`read:avatar:jira\`
+    - \`read:user:jira\`
+  Then go back to \"Permissions\" and click on \"Add\" for \`User Identity API\`, only selecting following scopes:
+    - \`read:account\`
+\n"
+
+printf "4. Once Configured, go to \"Settings\" and copy the \"Client Id\" and \"Secret\". You will use these to
+  obtain an OAuth \`refresh_token\`.\n"
+
+# Prompt for Jira client ID and secret
+printf "Enter your Jira Client ID: "
+read -r CLIENT_ID
+printf "Enter your Jira Client Secret: "
+read -r CLIENT_SECRET
+
+# Open authorization URL in user's browser
+AUTH_URL="https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=${CLIENT_ID}&scope=offline_access%20read:group:jira%20read:avatar:jira%20read:user:jira%20read:account%20read:jira-user%20read:jira-work&redirect_uri=http://localhost&state=YOUR_USER_BOUND_VALUE&response_type=code&prompt=consent"
+printf "${GREEN}Opening the following URL in your default browser:${NC}\n"
+echo $AUTH_URL
+open "${AUTH_URL}" || xdg-open "${AUTH_URL}"
+
+# Prompt for authorization code
+printf "After accepting access on the Jira site, paste the authorization code from the URL here: "
+read -r AUTH_CODE
+
+# Use the authorization code to request access and refresh tokens
+DATA="{\"grant_type\": \"authorization_code\",\"client_id\": \"${CLIENT_ID}\",\"client_secret\": \"${CLIENT_SECRET}\", \"code\": \"${AUTH_CODE}\", \"redirect_uri\": \"http://localhost\"}"
+echo $DATA
+#exit 1
+RESPONSE=$(echo $DATA | curl --silent -X POST --data-binary @- https://auth.atlassian.com/oauth/token -H 'Content-Type: application/json')
+# Parse access token and refresh token
+echo $RESPONSE
+ACCESS_TOKEN=$(echo "${RESPONSE}" | jq -r '.access_token')
+REFRESH_TOKEN=$(echo "${RESPONSE}" | jq -r '.refresh_token')
+
+# Use access token to get cloud ID
+CLOUD_ID_RESPONSE=$(curl --silent --header "Authorization: Bearer ${ACCESS_TOKEN}" --url 'https://api.atlassian.com/oauth/token/accessible-resources')
+CLOUD_ID=$(echo "${CLOUD_ID_RESPONSE}" | jq -r '.[0].id')
+
+# Instructions for user
+printf "${GREEN}Use the following values in the secret manager choosen for your host platform:${NC}\n"
+
+printf "${YELLOW}${PREFIX}JIRA_CLOUD_ACCESS_TOKEN${NC}: ${ACCESS_TOKEN}\n"
+printf "${YELLOW}${PREFIX}JIRA_CLOUD_REFRESH_TOKEN${NC}: ${REFRESH_TOKEN}\n"
+printf "${YELLOW}${PREFIX}JIRA_CLOUD_CLIENT_ID${NC}: ${CLIENT_ID}\n"
+printf "${YELLOW}${PREFIX}JIRA_CLOUD_CLIENT_SECRET${NC}: ${CLIENT_SECRET}\n"
+
+printf "And set the cloud ID (${YELLOW}${CLOUD_ID}${NC}) as the value of ${YELLOW}jira_cloud_id${NC} in your ${YELLOW}terraform.tfvars${NC} file.\n"
+


### PR DESCRIPTION
### Features
 - alpha support for AWS Secrets Manager as secrets store implementation
 - bash script to help Jira token exchange

### Change implications

 - dependencies added/changed? **yes, if used requires' AWS secret manager client lib, infra created; perms to use it**
 - something important to note in future release notes? **some moves**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206145456646562