### PR TITLE
GH: Fix double transform when pseudonymizing commits from timeline/single/pull commits

### DIFF
--- a/docs/sources/github/example-api-responses/original/issue_timeline.json
+++ b/docs/sources/github/example-api-responses/original/issue_timeline.json
@@ -5,8 +5,8 @@
     "url": "https://api.github.com/repos/khnum-heket/test2/git/commits/66249c83914e7ad8e9976eededda069b936ee426",
     "html_url": "https://github.com/khnum-heket/test2/commit/66249c83914e7ad8e9976eededda069b936ee426",
     "author": {
-      "name": "Octocat",
-      "email": "octocat@some-domain.com",
+      "name": "AuthorUser",
+      "email": "authorUser@some-domain.com",
       "date": "2023-09-18T10:46:54Z"
     },
     "committer": {

--- a/docs/sources/github/example-api-responses/original/issue_timeline.json
+++ b/docs/sources/github/example-api-responses/original/issue_timeline.json
@@ -1,5 +1,40 @@
 [
   {
+    "sha": "66249c83914e7ad8e9976eededda069b936ee426",
+    "node_id": "C_kwDOKU_SqtoAKDY2MjQ5YzgzOTE0ZTdhZDhlOTk3NmVlZGVkZGEwNjliOTM2ZWU0MjY",
+    "url": "https://api.github.com/repos/khnum-heket/test2/git/commits/66249c83914e7ad8e9976eededda069b936ee426",
+    "html_url": "https://github.com/khnum-heket/test2/commit/66249c83914e7ad8e9976eededda069b936ee426",
+    "author": {
+      "name": "Octocat",
+      "email": "octocat@some-domain.com",
+      "date": "2023-09-18T10:46:54Z"
+    },
+    "committer": {
+      "name": "GitHub",
+      "email": "noreply@github.com",
+      "date": "2023-09-18T10:46:54Z"
+    },
+    "tree": {
+      "sha": "03de69fb35a9fc98e66a8dc3b5a835022ac90df1",
+      "url": "https://api.github.com/repos/github/roadmap/git/trees/03de69fb35a9fc98e66a8dc3b5a835022ac90df1"
+    },
+    "message": "Update README.md",
+    "parents": [
+      {
+        "sha": "5fece56c5bbe94b8e119c511c8da505fc6fccb8d",
+        "url": "https://api.github.com/repos/github/roadmap/git/commits/5fece56c5bbe94b8e119c511c8da505fc6fccb8d",
+        "html_url": "https://github.com/github/roadmap/commit/5fece56c5bbe94b8e119c511c8da505fc6fccb8d"
+      }
+    ],
+    "verification": {
+      "verified": true,
+      "reason": "valid",
+      "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJlCCqeCRBK7hj4Ov3rIwAA6SEIAFhYvvBk3SmdImeJSASmpc+I\nsKznegm4vG0ajQEqt6KhEAhCNOG5zG3+te1S+MMCQ6dSKzBAgPlgMd4h+MleWlH1\n/HgMc4iEb/g0efaFOqQv7EzWiKPGwgxM691DDCOF23aGvZ3uDifuGeDzphJozWg0\n78rOvcz/lCF5jkbgzHIUQZxXvYB7tkTOijdM5MF7OehN389DriMW9nrE3McWOImU\nmQMJKnI6H+6Sr3xpIF/hRKzIZCmUwhPSlwzbJ4CKRHVk5YFibDF+tB9rKwxQ2hXd\n+dgOjQf8drha9lEs1KGTG9tfeBTWefXYoo/RWT/n4GrGuQ61miR1ZRX33OrfuNU=\n=m7/G\n-----END PGP SIGNATURE-----\n",
+      "payload": "tree 03de69fb35a9fc98e66a8dc3b5a835022ac90df1\nparent 5fece56c5bbe94b8e119c511c8da505fc6fccb8d\nauthor Andrés Pérez <isisosirishorus@hotmail.com> 1695034014 +0200\ncommitter GitHub <noreply@github.com> 1695034014 +0200\n\nUpdate README.md"
+    },
+    "event": "committed"
+  },
+  {
     "id": 6430295168,
     "node_id": "LOE_lADODwFebM5HwC0kzwAAAAF_RoSA",
     "url": "https://api.github.com/repos/github/roadmap/issues/events/6430295168",

--- a/docs/sources/github/example-api-responses/sanitized/commit.json
+++ b/docs/sources/github/example-api-responses/sanitized/commit.json
@@ -7,11 +7,11 @@
   "commit":{
     "url":"https://api.github.com/repos/org/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
     "author":{
-      "email":"{\"scope\":\"github\",\"hash\":\"T-sBXXi6k0bWw-zNtcdQenxAuqN5C51_ehZ5lJDWeqw\"}",
+      "email":"{\"scope\":\"email\",\"domain\":\"github.com\",\"hash\":\"39uRnKxs0PYIueRoGGc7fyyp-hSTtamEhvB6YywFNVM\"}",
       "date":"2011-04-14T16:00:49Z"
     },
     "committer":{
-      "email":"{\"scope\":\"github\",\"hash\":\"T-sBXXi6k0bWw-zNtcdQenxAuqN5C51_ehZ5lJDWeqw\"}",
+      "email":"{\"scope\":\"email\",\"domain\":\"github.com\",\"hash\":\"39uRnKxs0PYIueRoGGc7fyyp-hSTtamEhvB6YywFNVM\"}",
       "date":"2011-04-14T16:00:49Z"
     },
     "tree":{

--- a/docs/sources/github/example-api-responses/sanitized/issue_timeline.json
+++ b/docs/sources/github/example-api-responses/sanitized/issue_timeline.json
@@ -1,5 +1,32 @@
 [
   {
+    "sha":"66249c83914e7ad8e9976eededda069b936ee426",
+    "node_id":"C_kwDOKU_SqtoAKDY2MjQ5YzgzOTE0ZTdhZDhlOTk3NmVlZGVkZGEwNjliOTM2ZWU0MjY",
+    "html_url":"https://github.com/khnum-heket/test2/commit/66249c83914e7ad8e9976eededda069b936ee426",
+    "author":{
+      "email":"{\"scope\":\"email\",\"domain\":\"some-domain.com\",\"hash\":\"h6PdMetXUw2gjVVsnjSgAXCBCSbTAHOAwIlrzYyylKo\"}",
+      "date":"2023-09-18T10:46:54Z"
+    },
+    "committer":{
+      "email":"{\"scope\":\"email\",\"domain\":\"github.com\",\"hash\":\"MIHgBni75cZjiHCpj2v957zYWWKML5xc_Zu-0HvVQ2w\"}",
+      "date":"2023-09-18T10:46:54Z"
+    },
+    "tree":{
+      "sha":"03de69fb35a9fc98e66a8dc3b5a835022ac90df1"
+    },
+    "parents":[
+      {
+        "sha":"5fece56c5bbe94b8e119c511c8da505fc6fccb8d",
+        "html_url":"https://github.com/github/roadmap/commit/5fece56c5bbe94b8e119c511c8da505fc6fccb8d"
+      }
+    ],
+    "verification":{
+      "verified":true,
+      "reason":"valid"
+    },
+    "event":"committed"
+  },
+  {
     "id":6430295168,
     "node_id":"LOE_lADODwFebM5HwC0kzwAAAAF_RoSA",
     "actor":{

--- a/docs/sources/github/github-enterprise-server.yaml
+++ b/docs/sources/github/github-enterprise-server.yaml
@@ -781,10 +781,6 @@ endpoints:
           - "$..files"
           - "$..signature"
           - "$..payload"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$.commit..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github-enterprise-server.yaml
+++ b/docs/sources/github/github-enterprise-server.yaml
@@ -610,10 +610,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github-enterprise-server.yaml
+++ b/docs/sources/github/github-enterprise-server.yaml
@@ -329,10 +329,6 @@ endpoints:
           - "$..files"
           - "$..signature"
           - "$..payload"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$.commit..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"
@@ -357,10 +353,6 @@ endpoints:
           - "$..files"
           - "$..signature"
           - "$..payload"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$.commit..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github-enterprise-server.yaml
+++ b/docs/sources/github/github-enterprise-server.yaml
@@ -577,10 +577,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github.yaml
+++ b/docs/sources/github/github.yaml
@@ -781,10 +781,6 @@ endpoints:
           - "$..files"
           - "$..signature"
           - "$..payload"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$.commit..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github.yaml
+++ b/docs/sources/github/github.yaml
@@ -610,10 +610,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github.yaml
+++ b/docs/sources/github/github.yaml
@@ -329,10 +329,6 @@ endpoints:
           - "$..files"
           - "$..signature"
           - "$..payload"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$.commit..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"
@@ -357,10 +353,6 @@ endpoints:
           - "$..files"
           - "$..signature"
           - "$..payload"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$.commit..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github.yaml
+++ b/docs/sources/github/github.yaml
@@ -577,10 +577,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..email"
-        encoding: "JSON"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -282,9 +282,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..payload")
                     .jsonPath("$..dismissalMessage")
                     .build())
-            .transform(Transform.Pseudonymize.builder()
-                    .jsonPath("$..email")
-                    .build())
             .transforms(generateUserTransformations("..", Arrays.asList(
                     // Owner can be a user or an organization user
                     "owner",

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -457,9 +457,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..signature")
                     .jsonPath("$..payload")
                     .build())
-            .transform(Transform.Pseudonymize.builder()
-                    .jsonPath("$.commit..email")
-                    .build())
             .transforms(generateUserTransformations("..", Arrays.asList("author", "committer")))
             .build();
 

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -249,9 +249,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..payload")
                     .jsonPath("$..dismissalMessage")
                     .build())
-            .transform(Transform.Pseudonymize.builder()
-                    .jsonPath("$..email")
-                    .build())
             .transforms(generateUserTransformations("..", Arrays.asList(
                     // Owner can be a user or an organization user
                     "owner",

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -184,9 +184,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..signature")
                     .jsonPath("$..payload")
                     .build())
-            .transform(Transform.Pseudonymize.builder()
-                    .jsonPath("$.commit..email")
-                    .build())
             .transforms(generateUserTransformations("..", Arrays.asList("author", "committer")))
             .build();
 
@@ -441,9 +438,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..files")
                     .jsonPath("$..signature")
                     .jsonPath("$..payload")
-                    .build())
-            .transform(Transform.Pseudonymize.builder()
-                    .jsonPath("$.commit..email")
                     .build())
             .transforms(generateUserTransformations("..", Arrays.asList("author", "committer")))
             .build();

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubEnterpriseServerTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubEnterpriseServerTests.java
@@ -364,7 +364,6 @@ public class GitHubEnterpriseServerTests extends JavaRulesTestBaseCase {
 
         Collection<String> PII = Arrays.asList(
                 "9919",
-                "octocat",
                 "67656570",
                 "94867353"
         );
@@ -374,6 +373,7 @@ public class GitHubEnterpriseServerTests extends JavaRulesTestBaseCase {
         String sanitized = this.sanitize(endpoint, jsonString);
 
         assertPseudonymized(sanitized, "octocat");
+        assertPseudonymized(sanitized, "octocat@some-domain.com");
         assertPseudonymized(sanitized, "9919");
         assertPseudonymized(sanitized, "67656570");
         assertPseudonymized(sanitized, "94867353");

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubEnterpriseServerTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubEnterpriseServerTests.java
@@ -365,7 +365,10 @@ public class GitHubEnterpriseServerTests extends JavaRulesTestBaseCase {
         Collection<String> PII = Arrays.asList(
                 "9919",
                 "67656570",
-                "94867353"
+                "94867353",
+                "octocat",
+                "authorUser@some-domain.com",
+                "noreply@github.com"
         );
 
         assertNotSanitized(jsonString, PII);
@@ -373,7 +376,8 @@ public class GitHubEnterpriseServerTests extends JavaRulesTestBaseCase {
         String sanitized = this.sanitize(endpoint, jsonString);
 
         assertPseudonymized(sanitized, "octocat");
-        assertPseudonymized(sanitized, "octocat@some-domain.com");
+        assertPseudonymized(sanitized, "authorUser@some-domain.com");
+        assertPseudonymized(sanitized, "noreply@github.com");
         assertPseudonymized(sanitized, "9919");
         assertPseudonymized(sanitized, "67656570");
         assertPseudonymized(sanitized, "94867353");

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
@@ -363,7 +363,10 @@ public class GitHubTests extends JavaRulesTestBaseCase {
         Collection<String> PII = Arrays.asList(
                 "9919",
                 "67656570",
-                "94867353"
+                "94867353",
+                "octocat",
+                "authorUser@some-domain.com",
+                "noreply@github.com"
         );
 
         assertNotSanitized(jsonString, PII);
@@ -371,7 +374,8 @@ public class GitHubTests extends JavaRulesTestBaseCase {
         String sanitized = this.sanitize(endpoint, jsonString);
 
         assertPseudonymized(sanitized, "octocat");
-        assertPseudonymized(sanitized, "octocat@some-domain.com");
+        assertPseudonymized(sanitized, "authorUser@some-domain.com");
+        assertPseudonymized(sanitized, "noreply@github.com");
         assertPseudonymized(sanitized, "9919");
         assertPseudonymized(sanitized, "67656570");
         assertPseudonymized(sanitized, "94867353");

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
@@ -362,7 +362,6 @@ public class GitHubTests extends JavaRulesTestBaseCase {
 
         Collection<String> PII = Arrays.asList(
                 "9919",
-                "octocat",
                 "67656570",
                 "94867353"
         );
@@ -372,6 +371,7 @@ public class GitHubTests extends JavaRulesTestBaseCase {
         String sanitized = this.sanitize(endpoint, jsonString);
 
         assertPseudonymized(sanitized, "octocat");
+        assertPseudonymized(sanitized, "octocat@some-domain.com");
         assertPseudonymized(sanitized, "9919");
         assertPseudonymized(sanitized, "67656570");
         assertPseudonymized(sanitized, "94867353");


### PR DESCRIPTION
When reading timeline, single and pull commit, there was a rule for pseudonymizing emails and then the *user* rule was being applied, so the identities were pseudonymized twice.

### Fixes
[Fix Commit identities for GH](https://app.asana.com/0/1206513197716007/1206557848212702)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
