### PR TITLE
GH Enterprise Server with OAUTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ Changes to be including in future/planned release notes will be added here.
   - keys/salts per value kind (PII, item id, etc)
 
 ## [0.4.48](https://github.com/Worklytics/psoxy/release/tag/v0.4.48)
-  - GitHub Enterprise Server: since this version is using `refresh_token` oauth flow and the connector 
-    should be reinstalled in order to create the new variables, permissions and the new documentation
-    that will help you to configure the right values for the variables.
+  - BREAKING - GitHub Enterprise Server: authentication strategy has changed; you will see creation
+    and destruction of some secrets that are used for authentication; you MUST generate new auth
+    credentials for your proxy instance. see [`docs/sources/github/README.md`](docs/sources/github/README.md)
+    or contact support for assistance.
 
 ## [0.4.47](https://github.com/Worklytics/psoxy/release/tag/v0.4.47)
   - AWS: some moved resources due to refactoring to accommodate option to use AWS Secrets Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Changes to be including in future/planned release notes will be added here.
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.48](https://github.com/Worklytics/psoxy/release/tag/v0.4.48)
+  - GitHub Enterprise Server: since this version is using `refresh_token` oauth flow and the connector 
+    should be reinstalled in order to create the new variables, permissions and the new documentation
+    that will help you to configure the right values for the variables.
+
 ## [0.4.47](https://github.com/Worklytics/psoxy/release/tag/v0.4.47)
   - AWS: some moved resources due to refactoring to accommodate option to use AWS Secrets Manager
 

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -142,7 +142,7 @@ curl --location --request POST 'https://your-github-host/login/oauth/access_toke
 The response will be something like:
 
 ```
-access_token=ghu_jTL7Utf7hZUnGxsVmuItnyGFU2gBfB1JzEXS&expires_in=28800&refresh_token=ghr_6Qof66CCCZyMX4O5c5Jf1Ri02uBwI06zg1MV0yTFziM8xJowaarYRtnDoyoRng2da743oO3WEhXZ&refresh_token_expires_in=15724800&scope=&token_type=bearer
+access_token=...&expires_in=28800&refresh_token=...&refresh_token_expires_in=15724800&scope=&token_type=bearer
 ```
 You will need to copy the value of the `refresh_token`.
 

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -4,17 +4,17 @@ Availability: **BETA**
 
 There are several connectors available for GitHub:
 
-- [Github Free/Pro/Teams] - for non-Enterprise GitHub organization hosted in github.com.
-- [Github Enterprise Cloud] - GitHub Enterprise instances hosted by github.com on behalf of your
+- [GitHub Free/Pro/Teams] - for non-Enterprise GitHub organization hosted in github.com.
+- [GitHub Enterprise Cloud] - GitHub Enterprise instances hosted by github.com on behalf of your
   organization.
-- [Github Enterprise Server] - similar to 'Cloud', but you must customize rules and API host;
+- [GitHub Enterprise Server] - similar to 'Cloud', but you must customize rules and API host;
   contact Worklytics for assistance.
 
 ## Authentication workflow
 
-The connector uses a GitHub App to authenticate and access the data. 
-- For Enterprise Server, it uses App with a user token generation [based on the application](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#generating-a-user-access-token-when-a-user-installs-your-app).
-- For non enterprise, it uses [installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) for authentication.
+The connector uses a GitHub App to authenticate and access the data.
+- For Enterprise Server, you must generate a [user access token](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#generating-a-user-access-token-when-a-user-installs-your-app).
+- For Cloud, including Free/Pro/Teams/Enterprise, you must provide an [installation token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) for authentication.
 
 ## Examples
 
@@ -22,7 +22,7 @@ The connector uses a GitHub App to authenticate and access the data.
 - Example Data : [original](example-api-responses/original) |
   [sanitized](example-api-responses/sanitized)
 
-## Github Cloud instances (Free, Teams, Professional, Enterprise): Steps to Connect
+## GitHub Cloud (Free, Teams, Professional, Enterprise): Steps to Connect
 
 Both share the same configuration and setup instructions except Administration permission for Audit
 Log events.
@@ -105,27 +105,30 @@ Terraform. You will need to redeploy the proxy again if that value was not popul
 
 ## GitHub Enteprise Server: Steps to connect
 
-You can use a [guided script](../../../tools/github-enterprise-server-auth.sh) to setup the connector. In any case, you can follow here the manual steps that needs to be done.
+We provide a [helper script](../../../tools/github-enterprise-server-auth.sh) to set up the connector, which will guide you through the steps
+below and automate some of them. Alternatively, you can follow the steps below directly:
 
 1. You have to populate:
-    - `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
-      This host should be accessible from the psoxy function, as the connector will need to reach it.
-    - `github_organization` variable in Terraform with the name of your organization in Github Enterprise Server. You can put more than one, just split them in commas (example: `org1,org2`).
+    - `github_enterprise_server_host` variable in Terraform with the hostname of your GitHub
+      Enterprise Server (example: `github.your-company.com`). This host should be accessible from
+      the proxy instance function, as the connector will need to reach it.
+    - `github_organization` variable in Terraform with the name of your organization in GitHub
+      Enterprise Server. You can put more than one, just split them in commas (example: `org1,org2`).
 2. From your organization, register a [GitHub App](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
    with following permissions with **Read Only**:
-   - Repository:
-    - Contents: for reading commits and comments
-    - Issues: for listing issues, comments, assignees, etc.
-    - Metadata: for listing repositories and branches
-    - Pull requests: for listing pull requests, reviews, comments and commits
-      - Organization
-    - Administration: for listing events from audit log
-    - Members: for listing teams and their members
+    - Repository:
+      - Contents: for reading commits and comments
+      - Issues: for listing issues, comments, assignees, etc.
+      - Metadata: for listing repositories and branches
+      - Pull requests: for listing pull requests, reviews, comments and commits
+    - Organization
+      - Administration: for listing events from audit log
+      - Members: for listing teams and their members
 
 NOTES:
 - We assume that ALL the repositories are going to be listed **should be owned by the organization, not the users**.
 
-Apart from Github instructions please review the following:
+Apart from GitHub instructions please review the following:
 - "Homepage URL" can be anything, not required in this flow but required by GitHub.
 - "Callback URL" can be anything, but we recommend something like `http://localhost` as we will need it for the redirect as part of the authentication.
 - Webhooks check can be disabled as this connector is not using them

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -105,6 +105,8 @@ Terraform. You will need to redeploy the proxy again if that value was not popul
 
 ## GitHub Enteprise Server: Steps to connect
 
+You can use a [guided script](../../../tools/github-enterprise-server-auth.sh) to setup the connector. In any case, you can follow here the manual steps that needs to be done.
+
 1. You have to populate:
     - `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
       This host should be accessible from the psoxy function, as the connector will need to reach it.

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -139,12 +139,19 @@ https://your-github-host/login/oauth/authorize?client_id={YOUR CLIENT ID}
    The URL should look like this: `https://localhost/?code=69d0f5bd0d82282b9a11`.
 6. Copy the value of `code` and run the following URL replacing in the placeholders the values of `Client ID` and `Client Secret`:
 ```
-curl --location --request POST 'https://your-github-host/login/oauth/access_token?client_id={YOUR CLIENT ID}&client_secret={YOUR CLIENT SECRET}&code={YOUR CODE}'
+curl --location --request POST 'https://your-github-host/login/oauth/access_token?client_id={YOUR CLIENT ID}&client_secret={YOUR CLIENT SECRET}&code={YOUR CODE}' --header 'Content-Type: application/json' --header 'Accept: application/json'
 ```
 The response will be something like:
 
-```
-access_token=...&expires_in=28800&refresh_token=...&refresh_token_expires_in=15724800&scope=&token_type=bearer
+```json
+{
+  "access_token":"ghu_...",
+  "expires_in":28800,
+  "refresh_token":"ghr_...",
+  "refresh_token_expires_in":15724800,
+  "token_type":"bearer",
+  "scope":""
+}
 ```
 You will need to copy the value of the `refresh_token`.
 

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -10,13 +10,19 @@ There are several connectors available for GitHub:
 - [Github Enterprise Server] - similar to 'Cloud', but you must customize rules and API host;
   contact Worklytics for assistance.
 
+## Authentication workflow
+
+The connector uses a GitHub App to authenticate and access the data. 
+- For Enterprise Server, it uses App with a user token generation [based on the application](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#generating-a-user-access-token-when-a-user-installs-your-app).
+- For non enterprise, it uses [installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) for authentication.
+
 ## Examples
 
 - [Example Rules](github.yaml)
 - Example Data : [original](example-api-responses/original) |
   [sanitized](example-api-responses/sanitized)
 
-## Steps to Connect
+## Github Cloud instances (Free, Teams, Professional, Enterprise): Steps to Connect
 
 Both share the same configuration and setup instructions except Administration permission for Audit
 Log events.
@@ -24,14 +30,8 @@ Log events.
 Follow the following steps:
 
 1. Populate `github_organization` variable in Terraform with the name of your GitHub organization.
-2. (Only if you are going to use GitHub Enterprise Server):
 
-- You have to populate `github_enterprise_server_host` variable in Terraform with the hostname of
-  your Github Enterprise Server (example: `github.your-company.com`).
-- variable `github_organization` can be a list of organizations split by commas (ex:
-  Worklytics,Worklytics2)
-
-3. From your organization, register a
+2. From your organization, register a
    [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
    with following permissions with **Read Only**:
    - Repository:
@@ -54,9 +54,9 @@ Apart from GitHub instructions please review the following:
 - Webhooks check can be disabled as this connector is not using them
 - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
 
-4. Once is created please generate a new `Private Key`.
+3. Once is created please generate a new `Private Key`.
 
-5. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step
+4. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step
    to PKCS#8. Please run following command:
 
 ```shell
@@ -70,11 +70,11 @@ openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE F
 - Command proposed has been successfully tested on Ubuntu; it may differ for other operating
   systems.
 
-6. Install the application in your organization. Go to your organization settings and then in
+5. Install the application in your organization. Go to your organization settings and then in
    "Developer Settings". Then, click on "Edit" for your "Github App" and once you are in the app
    settings, click on "Install App" and click on the "Install" button. Accept the permissions to
    install it in your whole organization.
-7. Once installed, the `installationId` is required as it needs to be provided in the proxy as
+6. Once installed, the `installationId` is required as it needs to be provided in the proxy as
    parameter for the connector in your Terraform module. You can go to your organization settings
    and click on `Third Party Access`. Click on `Configure` the application you have installed in
    previous step and you will find the `installationId` at the URL of the browser:
@@ -102,6 +102,57 @@ Terraform. You will need to redeploy the proxy again if that value was not popul
      this variable.
 9. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and
    `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+
+## GitHub Enteprise Server: Steps to connect
+
+1. You have to populate:
+    - `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
+      This host should be accessible from the psoxy function, as the connector will need to reach it.
+    - `github_organization` variable in Terraform with the name of your organization in Github Enterprise Server. You can put more than one, just split them in commas (example: `org1,org2`).
+2. From your organization, register a [GitHub App](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
+   with following permissions with **Read Only**:
+   - Repository:
+    - Contents: for reading commits and comments
+    - Issues: for listing issues, comments, assignees, etc.
+    - Metadata: for listing repositories and branches
+    - Pull requests: for listing pull requests, reviews, comments and commits
+      - Organization
+    - Administration: for listing events from audit log
+    - Members: for listing teams and their members
+
+NOTES:
+- We assume that ALL the repositories are going to be listed **should be owned by the organization, not the users**.
+
+Apart from Github instructions please review the following:
+- "Homepage URL" can be anything, not required in this flow but required by GitHub.
+- "Callback URL" can be anything, but we recommend something like `http://localhost` as we will need it for the redirect as part of the authentication.
+- Webhooks check can be disabled as this connector is not using them
+- Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
+3. Once is created please generate a new `Client Secret`.
+4. Copy the `Client ID` and copy in your browser following URL, replacing the `CLIENT_ID` with the value you have just copied:
+```
+https://your-github-host/login/oauth/authorize?client_id={YOUR CLIENT ID}
+```
+5. The browser will ask you to accept permissions and then it will redirect you with to the previous `Callback URL` set as part of the application.
+   The URL should look like this: `https://localhost/?code=69d0f5bd0d82282b9a11`.
+6. Copy the value of `code` and run the following URL replacing in the placeholders the values of `Client ID` and `Client Secret`:
+```
+curl --location --request POST 'https://your-github-host/login/oauth/access_token?client_id={YOUR CLIENT ID}&client_secret={YOUR CLIENT SECRET}&code={YOUR CODE}'
+```
+The response will be something like:
+
+```
+access_token=ghu_jTL7Utf7hZUnGxsVmuItnyGFU2gBfB1JzEXS&expires_in=28800&refresh_token=ghr_6Qof66CCCZyMX4O5c5Jf1Ri02uBwI06zg1MV0yTFziM8xJowaarYRtnDoyoRng2da743oO3WEhXZ&refresh_token_expires_in=15724800&scope=&token_type=bearer
+```
+You will need to copy the value of the `refresh_token`.
+
+**NOTES**:
+- `Code` can be used once, so if you need to repeat the process you will need to generate a new one.
+
+7. Update the variables with values obtained in previous step:
+    - `psoxy_GITHUB_ENTERPRISE_SERVER_CLIENT_ID` with `Client Id` value.
+    - `psoxy_GITHUB_ENTERPRISE_SERVER_CLIENT_SECRET` with `Client Secret` value.
+    - `psoxy_GITHUB_ENTERPRISE_SERVER_REFRESH_TOKEN` with the `refresh_token`.
 
 ## Reference
 

--- a/docs/sources/github/README.md
+++ b/docs/sources/github/README.md
@@ -13,7 +13,7 @@ There are several connectors available for GitHub:
 ## Authentication workflow
 
 The connector uses a GitHub App to authenticate and access the data. 
-- For Enterprise Server, it uses App with a user token generation [based on the application](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#generating-a-user-access-token-when-a-user-installs-your-app).
+- For Enterprise Server, it uses App with a user token generation [based on the application](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#generating-a-user-access-token-when-a-user-installs-your-app).
 - For non enterprise, it uses [installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) for authentication.
 
 ## Examples

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -531,7 +531,8 @@ EOT
       ],
       environment_variables : {
         GRANT_TYPE : "refresh_token"
-        REFRESH_ENDPOINT : "https://github.com/login/oauth/access_token"
+        TOKEN_RESPONSE_TYPE : "GITHUB_ACCESS_TOKEN"
+        REFRESH_ENDPOINT : "https://${local.github_enterprise_server_host}/login/oauth/access_token"
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -531,7 +531,7 @@ EOT
       ],
       environment_variables : {
         GRANT_TYPE : "refresh_token"
-        REFRESH_ENDPOINT : "http://${local.github_enterprise_server_host}/login/oauth/access_token"
+        REFRESH_ENDPOINT : "https://${local.github_enterprise_server_host}/login/oauth/access_token"
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -552,6 +552,7 @@ EOT
       external_token_todo : <<EOT
   1. You have to populate:
      - `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
+This host should be accessible from the psoxy function, as the connector will need to reach it.
      - `github_organization` variable in Terraform with the name of your organization in Github Enterprise Server. You can put more than one, just split them in commas (example: `org1,org2`).
   2. From your organization, register a [GitHub App](https://docs.github.com/en/enterprise-server@3.11/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app)
     with following permissions with **Read Only**:
@@ -566,39 +567,37 @@ EOT
 
   NOTES:
     - We assume that ALL the repositories are going to be listed **should be owned by the organization, not the users**.
-    - Enterprise Cloud is required for this connector.
 
   Apart from Github instructions please review the following:
   - "Homepage URL" can be anything, not required in this flow but required by GitHub.
+  - "Callback URL" can be anything, but we recommend something like `http://localhost` as we will need it for the redirect as part of the authentication.
   - Webhooks check can be disabled as this connector is not using them
   - Keep `Expire user authorization tokens` enabled, as GitHub documentation recommends
-  3. Once is created please generate a new `Private Key`.
-  4. It is required to convert the format of the certificate downloaded from PKCS#1 in previous step to PKCS#8. Please run following command:
-```shell
-openssl pkcs8 -topk8 -inform PEM -outform PEM -in {YOUR DOWNLOADED CERTIFICATE FILE} -out gh_pk_pkcs8.pem -nocrypt
+  3. Once is created please generate a new `Client Secret`.
+  4. Copy the `Client ID` and copy in your browser following URL, replacing the `CLIENT_ID` with the value you have just copied:
 ```
+https://${local.github_enterprise_server_host}/login/oauth/authorize?client_id={YOUR CLIENT ID}
+```
+  5. The browser will ask you to accept permissions and then it will redirect you with to the previous `Callback URL` set as part of the application.
+The URL should look like this: `https://localhost/?code=69d0f5bd0d82282b9a11`.
+  6. Copy the value of `code` and run the following URL replacing in the placeholders the values of `Client ID` and `Client Secret`:
+```
+curl --location --request POST 'https://${local.github_enterprise_server_host}/login/oauth/access_token?client_id={YOUR CLIENT ID}&client_secret={YOUR CLIENT SECRET}&code={YOUR CODE}'
+```
+The response will be something like:
+
+```
+access_token=ghu_jTL7Utf7hZUnGxsVmuItnyGFU2gBfB1JzEXS&expires_in=28800&refresh_token=ghr_6Qof66CCCZyMX4O5c5Jf1Ri02uBwI06zg1MV0yTFziM8xJowaarYRtnDoyoRng2da743oO3WEhXZ&refresh_token_expires_in=15724800&scope=&token_type=bearer
+```
+You will need to copy the value of the `refresh_token`.
 
 **NOTES**:
- - If the certificate is not converted to PKCS#8 connector will NOT work. You might see in logs a Java error `Invalid PKCS8 data.` if the format is not correct.
- - Command proposed has been successfully tested on Ubuntu; it may differ for other operating systems.
+ - `Code` can be used once, so if you need to repeat the process you will need to generate a new one.
 
-  5. Install the application in your organization.
-     Go to your organization settings and then in "Developer Settings". Then, click on "Edit" for your "Github App" and once you are in the app settings, click on "Install App" and click on the "Install" button. Accept the permissions to install it in your whole organization.
-  6. Once installed, the `installationId` is required as it needs to be provided in the proxy as parameter for the connector in your Terraform module. You can go to your organization settings and
-click on `Third Party Access`. Click on `Configure` the application you have installed in previous step and you will find the `installationId` at the URL of the browser:
-```
-https://{YOUR GITHUB HOST}/organizations/{YOUR ORG}/settings/installations/{INSTALLATION_ID}
-```
-  Copy the value of `installationId` and assign it to the `github_installation_id` variable in Terraform. You will need to redeploy the proxy again if that value was not populated before.
-
-**NOTE**:
- - If `github_installation_id` is not set, authentication URL will not be properly formatted and you will see *401: Unauthorized* when trying to get an access token.
- - If you see *404: Not found* in logs please review the *IP restriction policies* that your organization might have; that could cause connections from psoxy AWS Lambda/GCP Cloud Functions be rejected.
-
-  6. Update the variables with values obtained in previous step:
-     - `PSOXY_GITHUB_CLIENT_ID` with `App ID` value. **NOTE**: It should be `App Id` value as we are going to use authentication through the App and **not** *client_id*.
-     - `PSOXY_GITHUB_PRIVATE_KEY` with content of the `gh_pk_pkcs8.pem` from previous step. You could open the certificate with VS Code or any other editor and copy all the content *as-is* into this variable.
-  7. Once the certificate has been uploaded, please remove {YOUR DOWNLOADED CERTIFICATE FILE} and `gh_pk_pkcs8.pem` from your computer or store it in a safe place.
+  7. Update the variables with values obtained in previous step:
+     - `psoxy_GITHUB_ENTERPRISE_SERVER_CLIENT_ID` with `Client Id` value.
+     - `psoxy_GITHUB_ENTERPRISE_SERVER_CLIENT_SECRET` with `Client Secret` value.
+     - `psoxy_GITHUB_ENTERPRISE_SERVER_REFRESH_TOKEN` with the `refresh_token`.
 
 EOT
     }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -504,29 +504,34 @@ EOT
           value_managed_by_tf : false
         },
         {
-          name : "PRIVATE_KEY"
-          writable : false
-          sensitive : true
-          value_managed_by_tf : false
-        },
-        {
-          name : "CLIENT_ID"
-          writable : false
+          name : "REFRESH_TOKEN"
+          writable : true
           sensitive : true
           value_managed_by_tf : false
         },
         {
           name : "OAUTH_REFRESH_TOKEN"
           writable : true
-          lockable : true
+          lockable : true   # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
+          sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
+          value_managed_by_tf : false
+        },
+        {
+          name : "CLIENT_ID"
+          writable : false
+          sensitive : true # not really, but simpler this way; and some may want it treated as sensitive, since would be req'd to brute-force app tokens or something
+          value_managed_by_tf : false
+        },
+        {
+          name : "CLIENT_SECRET"
+          writable : false
           sensitive : true
           value_managed_by_tf : false
-        }
+        },
       ],
       environment_variables : {
-        GRANT_TYPE : "certificate_credentials"
-        TOKEN_RESPONSE_TYPE : "GITHUB_ACCESS_TOKEN"
-        REFRESH_ENDPOINT : "https://${local.github_enterprise_server_host}/api/${local.github_enterprise_server_version}/app/installations/${local.github_installation_id}/access_tokens"
+        GRANT_TYPE : "refresh_token"
+        REFRESH_ENDPOINT : "https://github.com/login/oauth/access_token"
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -584,12 +584,19 @@ https://${local.github_enterprise_server_host}/login/oauth/authorize?client_id={
 The URL should look like this: `https://localhost/?code=69d0f5bd0d82282b9a11`.
   6. Copy the value of `code` and run the following URL replacing in the placeholders the values of `Client ID` and `Client Secret`:
 ```
-curl --location --request POST 'https://${local.github_enterprise_server_host}/login/oauth/access_token?client_id={YOUR CLIENT ID}&client_secret={YOUR CLIENT SECRET}&code={YOUR CODE}'
+curl --location --request POST 'https://${local.github_enterprise_server_host}/login/oauth/access_token?client_id={YOUR CLIENT ID}&client_secret={YOUR CLIENT SECRET}&code={YOUR CODE}' --header 'Content-Type: application/json' --header 'Accept: application/json'
 ```
 The response will be something like:
 
-```
-access_token=...&expires_in=28800&refresh_token=...&refresh_token_expires_in=15724800&scope=&token_type=bearer
+```json
+{
+  "access_token":"ghu_...",
+  "expires_in":28800,
+  "refresh_token":"ghr_...",
+  "refresh_token_expires_in":15724800,
+  "token_type":"bearer",
+  "scope":""
+}
 ```
 You will need to copy the value of the `refresh_token`.
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -550,6 +550,8 @@ EOT
         "/api/${local.github_enterprise_server_version}/repos/${local.github_first_organization}/${local.github_example_repository}/pulls",
       ]
       external_token_todo : <<EOT
+You can use a [guided script](../../../tools/github-enterprise-server-auth.sh) to setup the connector. In any case, you can follow here the manual steps that needs to be done.
+
   1. You have to populate:
      - `github_enterprise_server_host` variable in Terraform with the hostname of your Github Enterprise Server (example: `github.your-company.com`).
 This host should be accessible from the psoxy function, as the connector will need to reach it.

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -531,8 +531,7 @@ EOT
       ],
       environment_variables : {
         GRANT_TYPE : "refresh_token"
-        TOKEN_RESPONSE_TYPE : "GITHUB_ACCESS_TOKEN"
-        REFRESH_ENDPOINT : "https://${local.github_enterprise_server_host}/login/oauth/access_token"
+        REFRESH_ENDPOINT : "http://${local.github_enterprise_server_host}/login/oauth/access_token"
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -587,7 +587,7 @@ curl --location --request POST 'https://${local.github_enterprise_server_host}/l
 The response will be something like:
 
 ```
-access_token=ghu_jTL7Utf7hZUnGxsVmuItnyGFU2gBfB1JzEXS&expires_in=28800&refresh_token=ghr_6Qof66CCCZyMX4O5c5Jf1Ri02uBwI06zg1MV0yTFziM8xJowaarYRtnDoyoRng2da743oO3WEhXZ&refresh_token_expires_in=15724800&scope=&token_type=bearer
+access_token=...&expires_in=28800&refresh_token=...&refresh_token_expires_in=15724800&scope=&token_type=bearer
 ```
 You will need to copy the value of the `refresh_token`.
 

--- a/tools/github-enterprise-server-auth.sh
+++ b/tools/github-enterprise-server-auth.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# a script to simplify the process of creating GitHub app in GitHub Enterprise Server, authorizing it for the
+# the required scopes, and obtaining authentication credentials that can be used by the proxy
+# connector
+
+# Prefer printf over echo for compatibility and formatting
+# Use colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PREFIX="${1:-PSOXY_}"
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null
+then
+    printf "${RED}jq is not installed.${NC}\n"
+    printf "Please install jq to proceed. For example:\n"
+    printf "macOS: ${YELLOW}brew install jq${NC}\n"
+    printf "Linux: ${YELLOW}sudo apt-get install jq${NC} or ${YELLOW}sudo yum install jq${NC}\n"
+    exit 1
+fi
+
+printf "${GREEN}This script will guide you through the process of creating an GitHub app in GitHub Enterprise Server, authorizing it for the required permissions, and obtaining authentication credentials that can be used by the proxy connector.${NC}\n"
+
+printf "Enter the host where your GitHub Enteprise Server is: "
+read -r GITHUB_ENTERPRISE_SERVER_HOST
+
+printf "1. Go to https://${GITHUB_ENTERPRISE_SERVER_HOST}/settings/apps and click on \"New GitHub app\"\n"
+printf "2. Put a name for your app and then put \`http://localhost\` as \"HomePage URL\" and for \"Callback URL\"\n"
+printf "3. Ensure that \"Expire user authorization tokens\" is marked and Webhooks are disabled\n"
+printf "4. Set following with following permissions with **Read Only**:
+    - Repository:
+      - Contents: for reading commits and comments
+      - Issues: for listing issues, comments, assignees, etc.
+      - Metadata: for listing repositories and branches
+      - Pull requests: for listing pull requests, reviews, comments and commits
+    - Organization
+      - Administration: for listing events from audit log
+      - Members: for listing teams and their members
+\n"
+printf "5. Once created, go to the app settings and copy the \"Client ID\"\n"
+printf "Enter your Client ID: "
+read -r CLIENT_ID
+
+printf "6. And now generate a new \"Client Secret\":\n"
+printf "Enter your Client Secret: "
+read -r CLIENT_SECRET
+
+# Open authorization URL in user's browser
+AUTH_URL="https://${GITHUB_ENTERPRISE_SERVER_HOST}/login/oauth/authorize?client_id=${CLIENT_ID}"
+printf "${GREEN}Opening the following URL in your default browser:${NC}\n"
+echo $AUTH_URL
+open "${AUTH_URL}" || xdg-open "${AUTH_URL}"
+
+# Prompt for authorization code
+printf "After accepting access on the GitHub application, paste the authorization code from the URL here: "
+read -r AUTH_CODE
+
+# Use the authorization code to request access and refresh tokens
+#exit 1
+RESPONSE=$(curl --silent --location --request POST "https://${GITHUB_ENTERPRISE_SERVER_HOST}/login/oauth/access_token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&code=${AUTH_CODE}" --header 'Content-Type: application/json' --header 'Accept: application/json')
+# Parse access token and refresh token
+echo $RESPONSE
+ACCESS_TOKEN=$(echo "${RESPONSE}" | jq -r '.access_token')
+REFRESH_TOKEN=$(echo "${RESPONSE}" | jq -r '.refresh_token')
+
+printf "${YELLOW}${PREFIX}GITHUB_ENTERPRISE_SERVER_REFRESH_TOKEN${NC}: ${REFRESH_TOKEN}\n"
+printf "${YELLOW}${PREFIX}GITHUB_ENTERPRISE_SERVER_CLIENT_ID${NC}: ${CLIENT_ID}\n"
+printf "${YELLOW}${PREFIX}GITHUB_ENTERPRISE_SERVER_CLIENT_SECRET${NC}: ${CLIENT_SECRET}\n"


### PR DESCRIPTION
Updating GH Enterprise Server connector with OAUTH support with GH Apps for supporting multipe orgs under the same token generation.

### Features
[Support oauth for GH in Enterprise Server](https://app.asana.com/0/1206513197716007/1206593321815075)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
