### PR TITLE
Bulk sanitization empty values handling

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -317,15 +317,19 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
 
                         Pair<String, List<Function<String, Optional<String>>>> transforms = columnTransforms.getOrDefault(h, null);
                         if (transforms == null) {
-                            newRecord.put(h, "");
+                            newRecord.put(h, null);
                         } else {
                             // apply all transformations in insertion order
                             // key holds the original column
                             String v = record.get(transforms.getKey());
-                            for (Function<String, Optional<String>> transform : transforms.getValue()) {
-                                v = transform.apply(v).orElse(v);
+                            if (StringUtils.isNotBlank(v)) {
+                                for (Function<String, Optional<String>> transform : transforms.getValue()) {
+                                    v = transform.apply(v).orElse(null);
+                                }
+                                newRecord.put(h, v);
+                            } else {
+                                newRecord.put(h, null);
                             }
-                            newRecord.put(h, v);
                         }
 
                     });


### PR DESCRIPTION
### Fixes
Follow up of https://github.com/Worklytics/psoxy/pull/660 handling better null / empty values case

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
