### PR TITLE
Set container repo as default

### DIFF
--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -175,7 +175,7 @@ resource "google_cloudfunctions_function" "function" {
   service_account_email = google_service_account.service_account.email
   timeout               = 540 # 9 minutes, which is gen1 max allowed
   labels                = var.default_labels
-  docker_registry = "CONTAINER_REGISTRY"
+  docker_registry       = "CONTAINER_REGISTRY"
 
   environment_variables = merge(tomap({
     INPUT_BUCKET  = google_storage_bucket.input_bucket.name,

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -175,6 +175,7 @@ resource "google_cloudfunctions_function" "function" {
   service_account_email = google_service_account.service_account.email
   timeout               = 540 # 9 minutes, which is gen1 max allowed
   labels                = var.default_labels
+  docker_registry = "CONTAINER_REGISTRY"
 
   environment_variables = merge(tomap({
     INPUT_BUCKET  = google_storage_bucket.input_bucket.name,

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -70,6 +70,7 @@ resource "google_cloudfunctions_function" "function" {
   entry_point                  = "co.worklytics.psoxy.Route"
   service_account_email        = var.service_account_email
   labels                       = var.default_labels
+  docker_registry = "CONTAINER_REGISTRY"
 
   environment_variables = merge(
     local.required_env_vars,

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -70,7 +70,7 @@ resource "google_cloudfunctions_function" "function" {
   entry_point                  = "co.worklytics.psoxy.Route"
   service_account_email        = var.service_account_email
   labels                       = var.default_labels
-  docker_registry = "CONTAINER_REGISTRY"
+  docker_registry              = "CONTAINER_REGISTRY"
 
   environment_variables = merge(
     local.required_env_vars,


### PR DESCRIPTION
Set `CONTAINER_REGISTRY` to default container for cloud functions, meanwhile #656 feedback is applied and we decide how we do the transtition.

Without specifying the kind of repository used, any new GCP cloud function will throw a 403 error:

```bash
Error: googleapi: Error 403: With the general transition from Container Registry to Artifact Registry (https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr), Cloud Functions now uses Artifact Registry by default. This API is not enabled in your project. To enable Artifact Registry, visit ...
```

As that it what we had before, it is going to be transparent for existing deployments.

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Forcing container repo as default meanwhile](https://app.asana.com/0/0/1206713397426884)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
