### PR TITLE
AWS provider, terraform version constraints

### DIFF
--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.12, < 5.0"
+    }
+  }
+}
+
 # NOTE: region used to be passed in as a variable; put it MUST match the region in which the lambda
 # is provisioned, and that's implicit in the provider - so we should just infer from the provider
 data "aws_region" "current" {}

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.3, < 1.6"
   required_providers {
     aws = {
       version = ">= 4.12, < 5.0"

--- a/infra/modules/aws-host/output.tf
+++ b/infra/modules/aws-host/output.tf
@@ -53,6 +53,7 @@ output "todos" {
 output "next_todo_step" {
   value = max(concat(
     values(module.api_connector)[*].next_todo_step,
-    values(module.bulk_connector)[*].next_todo_step
+    values(module.bulk_connector)[*].next_todo_step,
+    [1]
   )...)
 }

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.12"
+      version = ">= 4.12, < 5.0"
     }
   }
 }

--- a/infra/modules/aws-psoxy-rest/main.tf
+++ b/infra/modules/aws-psoxy-rest/main.tf
@@ -3,10 +3,11 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.12"
+      version = ">= 4.12, < 5.0"
     }
   }
 }
+
 
 # NOTE: region used to be passed in as a variable; put it MUST match the region in which the lambda
 # is provisioned, and that's implicit in the provider - so we should just infer from the provider

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.12"
+      version = ">= 4.12, < 5.0"
     }
   }
 }

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.3, < 1.6"
+}
+
 locals {
   default_config_parameter_prefix       = length(var.environment_name) == 0 ? "psoxy_" : "${var.environment_name}_"
   config_parameter_prefix               = var.config_parameter_prefix == "" ? local.default_config_parameter_prefix : var.config_parameter_prefix

--- a/infra/modules/worklytics-connectors-google-workspace/main.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/main.tf
@@ -1,4 +1,8 @@
 terraform {
+  required_version = ">= 1.3, < 1.6"
+}
+
+terraform {
   required_providers {
     # for the API connections to Google Workspace
     google = {

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.3, < 1.6"
+}
+
 locals {
   environment_id_prefix                 = "${var.environment_id}${length(var.environment_id) > 0 ? "-" : ""}"
   environment_id_display_name_qualifier = length(var.environment_id) > 0 ? " ${var.environment_id} " : ""

--- a/infra/modules/worklytics-connectors/main.tf
+++ b/infra/modules/worklytics-connectors/main.tf
@@ -1,3 +1,6 @@
+terraform {
+  required_version = ">= 1.3, < 1.6"
+}
 
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"


### PR DESCRIPTION
### Fixes
 - aws provider constraints in our modules don't follow best practice
 - constrain terraform version explicitly (docs constrain it, but not our modules)
 - `max()` expression fails when no connectors (a destroy use-case)


### Change implications

 - dependencies added/changed? **yes - terraform version constraints enforced**
 - something important to note in future release notes? **terraform version constraint explicitly enforced**