### PR TITLE
aws secret manager secret prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Changes to be including in future/planned release notes will be added here.
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.50](https://github.com/Worklytics/psoxy/release/tag/v0.4.50)
+  - BREAKING - for AWS Secrets Manager (released in 0.4.47 as 'alpha' feature), these will now
+    be prefixed by default with the environment ID, unless a `aws_secrets_manager_path` is set.
+
 ## [0.4.48](https://github.com/Worklytics/psoxy/release/tag/v0.4.48)
   - BREAKING - GitHub Enterprise Server: authentication strategy has changed; you will see creation
     and destruction of some secrets that are used for authentication; you MUST generate new auth

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -102,6 +102,7 @@ module "psoxy" {
   environment_name                = var.environment_name
   aws_account_id                  = var.aws_account_id
   aws_ssm_param_root_path         = var.aws_ssm_param_root_path
+  aws_secrets_manager_path        = var.aws_secrets_manager_path
   psoxy_base_dir                  = var.psoxy_base_dir
   deployment_bundle               = var.deployment_bundle
   install_test_tool               = var.install_test_tool

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -44,7 +44,7 @@ variable "default_tags" {
 
 variable "aws_ssm_param_root_path" {
   type        = string
-  description = "root to path under which SSM parameters created by this module will be created; NOTE: shouldn't be necessary to use this is you're following recommended approach of using dedicated AWS account for deployment"
+  description = "path under which SSM parameters created by this module will be created; NOTE: shouldn't be necessary to use this is you're following recommended approach of using dedicated AWS account for deployment"
   default     = ""
 
   validation {
@@ -55,7 +55,7 @@ variable "aws_ssm_param_root_path" {
 
 variable "aws_secrets_manager_path" {
   type        = string
-  description = "root to path under which Secrets Manager secrets created by this module will be created"
+  description = "**beta** path under which Secrets Manager secrets will be created"
   default     = ""
 
   validation {

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -53,6 +53,18 @@ variable "aws_ssm_param_root_path" {
   }
 }
 
+variable "aws_secrets_manager_path" {
+  type        = string
+  description = "root to path under which Secrets Manager secrets created by this module will be created"
+  default     = ""
+
+  validation {
+    condition     = length(var.aws_secrets_manager_path) == 0 || length(regexall("/", var.aws_secrets_manager_path)) == 0 || startswith(var.aws_secrets_manager_path, "/")
+    error_message = "The `aws_secrets_manager_path` value must be fully qualified (begin with `/`) if it contains any `/` characters."
+  }
+}
+
+
 variable "secrets_store_implementation" {
   type        = string
   description = "one of 'aws_ssm_parameter_store' (default) or 'aws_secrets_manager'"

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -61,7 +61,7 @@ module "global_secrets_secrets_manager" {
 
   source = "../../modules/aws-secretsmanager-secrets"
 
-  path       = var.aws_ssm_param_root_path
+  path       = coalesce(var.aws_secrets_manager_path, module.env_id.id)
   kms_key_id = var.aws_ssm_key_id
   secrets    = module.psoxy.secrets
 }

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -9,7 +9,7 @@ variable "aws_account_id" {
 
 variable "aws_ssm_param_root_path" {
   type        = string
-  description = "root to path under which SSM parameters created by this module will be created"
+  description = "path under which SSM parameters created by this module will be created"
   default     = ""
 
   validation {
@@ -17,6 +17,18 @@ variable "aws_ssm_param_root_path" {
     error_message = "The aws_ssm_param_root_path value must be fully qualified (begin with `/`) if it contains any `/` characters."
   }
 }
+
+variable "aws_secrets_manager_path" {
+  type        = string
+  description = "root to path under which Secrets Manager secrets created by this module will be created"
+  default     = null
+
+  validation {
+    condition     = var.aws_secrets_manager_path == null || length(var.aws_secrets_manager_path) == 0 || length(regexall("/", var.aws_secrets_manager_path)) == 0 || startswith(var.aws_secrets_manager_path, "/")
+    error_message = "The `aws_secrets_manager_path` value must be fully qualified (begin with `/`) if it contains any `/` characters."
+  }
+}
+
 
 # TODO: generalize to 'secrets', regardless of store (AWS SSM, AWS Secrets Manager, etc)
 variable "aws_ssm_key_id" {

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -20,7 +20,7 @@ variable "aws_ssm_param_root_path" {
 
 variable "aws_secrets_manager_path" {
   type        = string
-  description = "root to path under which Secrets Manager secrets created by this module will be created"
+  description = "**beta** path under which Secrets Manager secrets created by this module will be created"
   default     = null
 
   validation {


### PR DESCRIPTION
### Features
 - support arbitrary path in front of AWS Secret Manager secrets: use cases are supporting organizing infra by name (common prefix) and multiple deployments into same AWS account (not recommended, but eases testing)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes**
