### PR TITLE
fix aws provider min version

### DIFF
--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -3,7 +3,7 @@ terraform {
     # for the infra that will host Psoxy instances
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.12"
+      version = "~> 4.22"
     }
   }
 

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3, < 1.6"
   required_providers {
     aws = {
-      version = ">= 4.12, < 5.0"
+      version = ">= 4.22, < 5.0"
     }
   }
 }


### PR DESCRIPTION

### Fixes
 - [fix aws min version](https://app.asana.com/0/1206743342799949/1206761866963809)

### Change implications

 - dependencies added/changed? **yes** - aws 4.22 min, if using our aws-host-based examples (these were released LONG after 4.22, so should be OK for everyone**
 - something important to note in future release notes? **the aws provider version change, although shouldn't impact anyone who hasn't pinned something old**
