### PR TITLE
misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You will need all the following in your deployment environment (eg, your laptop)
 | [git](https://git-scm.com/)                     | 2.17+                  | `git --version`           |
 | [Maven](https://maven.apache.org/)              | 3.6+                   | `mvn -v`                 |
 | [Java JDK 11+](https://openjdk.org/install/) | 11, 17, 21 (see notes) | `mvn -v &#124; grep Java` |
-| [Terraform](https://www.terraform.io/)          | 1.3.x, <= 1.5          | `terraform version`       |
+| [Terraform](https://www.terraform.io/)          | 1.3.x, <= 1.6          | `terraform version`       |
 
 NOTE: we will support Java versions for duration of official support windows, in particular the
 LTS versions. As of Nov 2023, we  still support java 11 but may end this at any time. Minor

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3, < 1.6"
+  required_version = ">= 1.3, < 1.7"
   required_providers {
     aws = {
       version = ">= 4.22, < 5.0"

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -21,7 +21,7 @@ variable "aws_ssm_param_root_path" {
 variable "aws_secrets_manager_path" {
   type        = string
   description = "**beta** path under which Secrets Manager secrets created by this module will be created"
-  default     = null
+  default     = ""
 
   validation {
     condition     = var.aws_secrets_manager_path == null || length(var.aws_secrets_manager_path) == 0 || length(regexall("/", var.aws_secrets_manager_path)) == 0 || startswith(var.aws_secrets_manager_path, "/")

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3, < 1.6"
+  required_version = ">= 1.3, < 1.7"
 }
 
 locals {


### PR DESCRIPTION
### Fixes
  - missing default for ssm param root path

### Features
  - allow Terraform 1.6.x; opentofu docs suggest that it has parity with opentofu 1.6 - https://opentofu.org/docs/intro/migration/ 

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**