### PR TITLE
make creation of AWS S3 public access blocks conditional

### DIFF
--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -124,6 +124,7 @@ module "psoxy" {
   bulk_input_expiration_days           = var.bulk_input_expiration_days
   api_connectors                       = local.api_connectors
   bulk_connectors                      = local.bulk_connectors
+  provision_bucket_public_access_block = var.provision_bucket_public_access_block
   custom_bulk_connector_rules          = var.custom_bulk_connector_rules
   custom_bulk_connector_arguments      = var.custom_bulk_connector_arguments
   todo_step                            = local.max_auth_todo_step

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -216,6 +216,12 @@ variable "use_api_gateway_v2" {
   default     = false
 }
 
+variable "provision_bucket_public_access_block" {
+  type        = bool
+  description = "Whether to provision public_access_block resources on all buckets; defaults to 'true', but can be 'false' if you have organizational control policies that do this at a higher level."
+  default     = true
+}
+
 variable "custom_bulk_connectors" {
   type = map(object({
     source_kind               = string

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -194,6 +194,7 @@ module "bulk_connector" {
   example_file                         = each.value.example_file
   vpc_config                           = var.vpc_config
   aws_lambda_execution_role_policy_arn = var.aws_lambda_execution_role_policy_arn
+  provision_bucket_public_access_block = var.provision_bucket_public_access_block
   todos_as_local_files                 = var.todos_as_local_files
 
 

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -317,6 +317,12 @@ variable "secrets_store_implementation" {
   default     = "aws_ssm_parameter_store"
 }
 
+variable "provision_bucket_public_access_block" {
+  type        = bool
+  description = "Whether to provision public_access_block resources on all buckets; defaults to 'true', but can be 'false' if you have organizational control policies that do this at a higher level."
+  default     = true
+}
+
 variable "todos_as_local_files" {
   type        = bool
   description = "whether to render TODOs as flat files"

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -88,27 +88,6 @@ resource "aws_iam_role_policy_attachment" "read_policy_for_import_bucket" {
   policy_arn = aws_iam_policy.input_bucket_getObject_policy.arn
 }
 
-
-moved {
-  from = aws_iam_policy.sanitized_bucket_write_policy
-  to   = module.sanitized_output_bucket.aws_iam_policy.sanitized_bucket_write_policy
-}
-
-moved {
-  from = aws_iam_role_policy_attachment.write_policy_for_sanitized_bucket
-  to   = module.sanitized_output_bucket.aws_iam_role_policy_attachment.write_policy_for_sanitized_bucket
-}
-
-moved {
-  from = aws_iam_policy.sanitized_bucket_read
-  to   = module.sanitized_output_bucket.aws_iam_policy.sanitized_bucket_read
-}
-
-moved {
-  from = aws_iam_role_policy_attachment.reader_policy_to_accessor_role
-  to   = module.sanitized_output_bucket.aws_iam_role_policy_attachment.reader_policy_to_accessor_role
-}
-
 module "sanitized_output_bucket" {
   source = "../aws-psoxy-output-bucket"
 

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -27,7 +27,7 @@ module "psoxy_lambda" {
     var.environment_variables,
     {
       INPUT_BUCKET  = var.input_bucket
-      OUTPUT_BUCKET = aws_s3_bucket.output.bucket,
+      OUTPUT_BUCKET = module.sanitized_output_bucket.output_bucket
     }
   )
 }
@@ -91,9 +91,10 @@ resource "aws_iam_role_policy_attachment" "read_policy_for_import_bucket" {
 module "sanitized_output_bucket" {
   source = "../aws-psoxy-output-bucket"
 
-  instance_id                   = var.instance_id
-  iam_role_for_lambda_name      = module.psoxy_lambda.iam_role_for_lambda_name
-  sanitized_accessor_role_names = var.sanitized_accessor_role_names
+  instance_id                          = var.instance_id
+  iam_role_for_lambda_name             = module.psoxy_lambda.iam_role_for_lambda_name
+  sanitized_accessor_role_names        = var.sanitized_accessor_role_names
+  provision_bucket_public_access_block = var.provision_bucket_public_access_block
 }
 
 

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -32,21 +32,6 @@ module "psoxy_lambda" {
   )
 }
 
-moved {
-  from = aws_s3_bucket.output
-  to   = module.sanitized_output_bucket.output
-}
-
-moved {
-  from = aws_s3_bucket_server_side_encryption_configuration.sanitized
-  to   = module.sanitized_output_bucket.aws_s3_bucket_server_side_encryption_configuration.sanitized
-}
-
-moved {
-  from = aws_s3_bucket_public_access_block.sanitized
-  to   = module.sanitized_output_bucket.aws_s3_bucket_public_access_block.sanitized
-}
-
 data "aws_s3_bucket" "input" {
   bucket = var.input_bucket
 }

--- a/infra/modules/aws-psoxy-bulk-existing/migration_legacy.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/migration_legacy.tf
@@ -1,0 +1,35 @@
+
+moved {
+  from = aws_s3_bucket.output
+  to   = module.sanitized_output_bucket.output
+}
+
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.sanitized
+  to   = module.sanitized_output_bucket.aws_s3_bucket_server_side_encryption_configuration.sanitized
+}
+
+moved {
+  from = aws_s3_bucket_public_access_block.sanitized
+  to   = module.sanitized_output_bucket.aws_s3_bucket_public_access_block.sanitized
+}
+
+moved {
+  from = aws_iam_policy.sanitized_bucket_write_policy
+  to   = module.sanitized_output_bucket.aws_iam_policy.sanitized_bucket_write_policy
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.write_policy_for_sanitized_bucket
+  to   = module.sanitized_output_bucket.aws_iam_role_policy_attachment.write_policy_for_sanitized_bucket
+}
+
+moved {
+  from = aws_iam_policy.sanitized_bucket_read
+  to   = module.sanitized_output_bucket.aws_iam_policy.sanitized_bucket_read
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.reader_policy_to_accessor_role
+  to   = module.sanitized_output_bucket.aws_iam_role_policy_attachment.reader_policy_to_accessor_role
+}

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -168,6 +168,12 @@ variable "secrets_store_implementation" {
   default     = "aws_ssm_parameter_store"
 }
 
+variable "provision_bucket_public_access_block" {
+  type        = bool
+  description = "Whether to provision public_access_block resources on all buckets; defaults to 'true', but can be 'false' if you have organizational control policies that do this at a higher level."
+  default     = true
+}
+
 variable "todo_step" {
   type        = number
   description = "of all todos, where does this one logically fall in sequence"

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -68,6 +68,8 @@ resource "aws_s3_bucket" "input" {
 
 
 resource "aws_s3_bucket_public_access_block" "input-block-public-access" {
+  count = var.provision_bucket_public_access_block ? 1 : 0
+
   bucket = aws_s3_bucket.input.bucket
 
   block_public_acls       = true
@@ -101,6 +103,8 @@ resource "aws_s3_bucket" "sanitized" {
 }
 
 resource "aws_s3_bucket_public_access_block" "sanitized" {
+  count = var.provision_bucket_public_access_block ? 1 : 0
+
   bucket = aws_s3_bucket.sanitized.bucket
 
   block_public_acls       = true

--- a/infra/modules/aws-psoxy-bulk/migration_0_4_51.tf
+++ b/infra/modules/aws-psoxy-bulk/migration_0_4_51.tf
@@ -1,0 +1,9 @@
+moved {
+  from = aws_s3_bucket_public_access_block.sanitized
+  to   = aws_s3_bucket_public_access_block.sanitized[0]
+}
+
+moved {
+  from = aws_s3_bucket_public_access_block.input-block-public-access
+  to   = aws_s3_bucket_public_access_block.input-block-public-access[0]
+}

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -239,6 +239,12 @@ variable "example_file" {
   default     = null
 }
 
+variable "provision_bucket_public_access_block" {
+  type        = bool
+  description = "Whether to provision public_access_block resources on all buckets; defaults to 'true', but can be 'false' if you have organizational control policies that do this at a higher level."
+  default     = true
+}
+
 variable "todos_as_local_files" {
   type        = bool
   description = "whether to render TODOs as flat files"

--- a/infra/modules/aws-psoxy-output-bucket/main.tf
+++ b/infra/modules/aws-psoxy-output-bucket/main.tf
@@ -19,6 +19,8 @@ resource "aws_s3_bucket" "output" {
 }
 
 resource "aws_s3_bucket_public_access_block" "sanitized" {
+  count = var.provision_bucket_public_access_block ? 1 : 0
+
   bucket = aws_s3_bucket.output.bucket
 
   block_public_acls       = true

--- a/infra/modules/aws-psoxy-output-bucket/migration_0_4_51.tf
+++ b/infra/modules/aws-psoxy-output-bucket/migration_0_4_51.tf
@@ -1,0 +1,5 @@
+
+moved {
+  from = aws_s3_bucket_public_access_block.sanitized
+  to   = aws_s3_bucket_public_access_block.sanitized[0]
+}

--- a/infra/modules/aws-psoxy-output-bucket/variables.tf
+++ b/infra/modules/aws-psoxy-output-bucket/variables.tf
@@ -39,3 +39,9 @@ variable "expiration_days" {
   description = "**alpha** Number of days after which objects in the bucket will expire"
   default     = 720
 }
+
+variable "provision_bucket_public_access_block" {
+  type        = bool
+  description = "Whether to provision public_access_block resources on all buckets; defaults to 'true', but can be 'false' if you have organizational control policies that do this at a higher level."
+  default     = true
+}


### PR DESCRIPTION
### Features
  - **make creation of AWS S3 public access blocks conditional** - public access isn't enable by default, although unless you explicitly block it, AWS UX shows an alarming "public access blocked = false" in red. So we were creating these, but have encountered a customer whose org controls don't allow changes to block policies, even setting to `true` - which is what we do. So need to make it conditional to support working around this.


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **customers will see moves**