### PR TITLE
fixes to legacy existing-bucket transform module

### DIFF
--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -13,7 +13,7 @@ module "psoxy_lambda" {
   path_to_function_zip                 = var.path_to_function_zip
   function_zip_hash                    = var.function_zip_hash
   global_parameter_arns                = var.global_parameter_arns
-  global_secrets_manager_secrets_arns  = var.global_secrets_manager_secrets_arns
+  global_secrets_manager_secrets_arns  = var.global_secrets_manager_secret_arns
   path_to_instance_ssm_parameters      = var.path_to_instance_ssm_parameters
   path_to_shared_ssm_parameters        = var.path_to_shared_ssm_parameters
   function_env_kms_key_arn             = var.function_env_kms_key_arn

--- a/infra/modules/aws-psoxy-bulk-existing/main.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/main.tf
@@ -27,7 +27,7 @@ module "psoxy_lambda" {
     var.environment_variables,
     {
       INPUT_BUCKET  = var.input_bucket
-      OUTPUT_BUCKET = aws_s3_bucket.output.bucket,
+      OUTPUT_BUCKET = module.sanitized_output_bucket.output_bucket
     }
   )
 }


### PR DESCRIPTION
### Fixes
 - typo in variable used in bucket
 - bad ref creating lookup table

Believe neither of these are problems in practice, as this module with the bugs was only used in some old workflows; eg, it's doing a lambda to pick up from an existing bucket and write to a new output. Our current approach just uses one lambda to do write to two outputs. 

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
