### PR TITLE
qualify GCP custom role titles with environment ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Changes to be including in future/planned release notes will be added here.
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.51](https://github.com/Worklytics/psoxy/release/tag/v0.4.51)
+ - GCP: non-breaking, but noticeable in Terraform plan: `title` attribute of GCP Custom Project
+   roles created by our modules are changing to more closely follow conventions GCP uses for its
+   built-in roles; as well as prefixing them with your environment ID to group them together
+   alphabetically and differentiate in shared project.
+
+
 ## [0.4.50](https://github.com/Worklytics/psoxy/release/tag/v0.4.50)
   - `todos_as_local_files` properly respected now; if you had it as `false`, you may see some local
     files deleted on your next `terraform apply`.

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -232,7 +232,7 @@ resource "google_project_iam_custom_role" "bucket_write" {
 resource "google_project_iam_custom_role" "psoxy_instance_secret_role" {
   project     = var.project_id
   role_id     = "${local.environment_id_role_prefix}PsoxyInstanceSecretHandler"
-  title       = "Access for updating and reading secrets"
+  title       = "${var.environment_id_prefix} Instance Secret Handler"
   description = "Role to grant on secret that is to be managed by a Psoxy instance (cloud function); subset of roles/secretmanager.admin, to support reading/updating the secret and managing their versions"
 
   permissions = [

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -1,7 +1,10 @@
 
 locals {
   # a prefix legal for GCP Roles
-  environment_id_role_prefix = replace(var.environment_id_prefix, "-", "_")
+  environment_id_role_prefix   = replace(var.environment_id_prefix, "-", "_")
+
+  # version of environment_id_prefix with trailing space, presuming it's a hyphen or a underscore
+  environment_id_prefix_display = length(var.environment_id_prefix) > 0 ? "${substr(var.environment_id_prefix, 0, length(var.environment_id_prefix) - 1)} " : ""
 }
 
 
@@ -219,7 +222,7 @@ module "test_tool" {
 resource "google_project_iam_custom_role" "bucket_write" {
   project     = var.project_id
   role_id     = "${local.environment_id_role_prefix}writeAccess"
-  title       = "Access for writing and update objects in bucket"
+  title       = "${local.environment_id_prefix_display}Bucket Object Write/Update"
   description = "Write and update support, because storage.objectCreator role only support creation - not update"
 
   permissions = [
@@ -232,7 +235,7 @@ resource "google_project_iam_custom_role" "bucket_write" {
 resource "google_project_iam_custom_role" "psoxy_instance_secret_role" {
   project     = var.project_id
   role_id     = "${local.environment_id_role_prefix}PsoxyInstanceSecretHandler"
-  title       = "${var.environment_id_prefix} Instance Secret Handler"
+  title       = "${local.environment_id_prefix_display}Instance Secret Handler"
   description = "Role to grant on secret that is to be managed by a Psoxy instance (cloud function); subset of roles/secretmanager.admin, to support reading/updating the secret and managing their versions"
 
   permissions = [


### PR DESCRIPTION
### Features
 - qualify GCP custom role titles with environment ID;
     - Why? 1) differentiating in shared GCP project, 2) group the psoxy roles alphabetically. 3) match title usage by the built-in roles
  
![SCR-20240325-lydf](https://github.com/Worklytics/psoxy/assets/102831/49700522-8d6d-48d5-8e5b-f40950258784)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes; GCP, will see changes to titles of custom roles**
