### PR TITLE
S171 : email canonicalization control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Changes to be including in future/planned release notes will be added here.
         then wildcard policy to read shared also grants read of secrets across all connectors)
   - keys/salts per value kind (PII, item id, etc)
 
+## [0.4.52](https://github.com/Worklytics/psoxy/release/tag/v0.4.52)
+  - BREAKING: default behavior for sub-addressing aka "plus addressing" of emails has changed; the
+    proxy previously considered these canonically distinct. Now, the proxy will consider these
+    canonically equivalent. As we don't expect plus addressing to be used hris or directory data,
+    this should have little impact.  Changes will most likely be in a few edge cases, such as
+    emails or calendar invites sent to a sub-address - sender unlikely to be a subaddress, but
+    recipient could be.  In such cases, behavior prior to 0.4.52 would cause recipient to appear
+    as a distinct mailbox; from 0.4.52 onward, they will be considered the same mailbox; we expect
+    this to be behavior that is more in line with user expectations, so although technically
+    breaking, we're introducing it without a major version bump.
+  - there new option to enable less strict email canonicalization; we strongly recommend new
+    customers to enable it, although it is not enabled by default to avoid a breaking change. Set
+    `email_canonicalization` to `IGNORE_DOTS` to enable this feature.
+
 ## [0.4.51](https://github.com/Worklytics/psoxy/release/tag/v0.4.51)
  - GCP: non-breaking, but noticeable in Terraform plan: `title` attribute of GCP Custom Project
    roles created by our modules are changing to more closely follow conventions GCP uses for its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Changes to be including in future/planned release notes will be added here.
   - there new option to enable less strict email canonicalization; we strongly recommend new
     customers to enable it, although it is not enabled by default to avoid a breaking change. Set
     `email_canonicalization` to `IGNORE_DOTS` to enable this feature.
+  - BREAKING for examples: default value fore `email_canonicalization` in our example repos has been
+    set to `IGNORE_DOTS`; if you've previously forked an example, this is not a breaking change. but
+    if you fork an example > 0.4.52 and are attempting to migrate a proxy deployment initially built
+    with modules or examples from < 0.4.52, you should explicitly add `email_canonicalization = "STRICT"`
+    in your `terraform.tfvars`
 
 ## [0.4.51](https://github.com/Worklytics/psoxy/release/tag/v0.4.51)
  - GCP: non-breaking, but noticeable in Terraform plan: `title` attribute of GCP Custom Project

--- a/docs/guides/deployment-migration.md
+++ b/docs/guides/deployment-migration.md
@@ -45,6 +45,10 @@ What you MUST **copy**:
 - **value for `PSEUDONYMIZE_APP_IDS`.** This value, if set to `true` will have the proxy use a rule
   set that pseudonymizes identifiers issued by source applications themselves in some cases where
   these identifiers aren't inherently PII - but the association could be considered discoverable.
+- **value for `EMAIL_CANONICALIZATION`.** prior to v0.4.52, this default was in effect `STRICT`; so
+  if your original deployment was built on a version prior to this, you should explicitly set this
+  value to `STRICT` in your new configuration (likely `email_canonicalization` variable in terraform
+  modules)
 - any **custom sanitization rules** that you've set, either in your Terraform configuration or
   directly as the value of a `RULES` environment variable, SSM Parameter, or GCP Secret.
 - historical **sanitized files** for any bulk connectors, if you wish to continue to have this data

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -115,6 +115,8 @@ module "psoxy" {
   non_production_connectors            = var.non_production_connectors
   custom_api_connector_rules           = var.custom_api_connector_rules
   lookup_table_builders                = var.lookup_table_builders
+  pseudonymize_app_ids                 = var.pseudonymize_app_ids
+  email_canonicalization               = var.email_canonicalization
   general_environment_variables        = var.general_environment_variables
   function_env_kms_key_arn             = var.project_aws_kms_key_arn
   logs_kms_key_arn                     = var.project_aws_kms_key_arn

--- a/infra/examples-dev/aws-all/variables.tf
+++ b/infra/examples-dev/aws-all/variables.tf
@@ -181,6 +181,12 @@ variable "pseudonymize_app_ids" {
   default     = true
 }
 
+variable "email_canonicalization" {
+  type        = string
+  description = "defines how email address are processed prior to hashing, hence which are considered 'canonically equivalent'; one of 'STRICT' (default and most standard compliant) or 'IGNORE_DOTS' (probably most in line with user expectations)"
+  default     = "IGNORE_DOTS"
+}
+
 variable "enabled_connectors" {
   type        = list(string)
   description = "list of ids of connectors to enabled; see modules/worklytics-connector-specs"

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -101,6 +101,7 @@ module "psoxy" {
   custom_api_connector_rules        = var.custom_api_connector_rules
   general_environment_variables     = var.general_environment_variables
   pseudonymize_app_ids              = var.pseudonymize_app_ids
+  email_canonicalization            = var.email_canonicalization
   bulk_input_expiration_days        = var.bulk_input_expiration_days
   bulk_sanitized_expiration_days    = var.bulk_sanitized_expiration_days
   custom_bulk_connector_rules       = var.custom_bulk_connector_rules

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -118,6 +118,12 @@ variable "pseudonymize_app_ids" {
   default     = true
 }
 
+variable "email_canonicalization" {
+  type        = string
+  description = "defines how email address are processed prior to hashing, hence which are considered 'canonically equivalent'; one of 'STRICT' (default and most standard compliant) or 'IGNORE_DOTS' (probably most in line with user expectations)"
+  default     = "IGNORE_DOTS"
+}
+
 variable "gcp_region" {
   type        = string
   description = "Region in which to provision GCP resources, if applicable"

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -145,9 +145,10 @@ module "api_connector" {
     var.general_environment_variables,
     try(each.value.environment_variables, {}),
     {
-      PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
-      CUSTOM_RULES_SHA     = try(var.custom_api_connector_rules[each.key], null) != null ? filesha1(var.custom_api_connector_rules[each.key]) : null
-      IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
+      PSEUDONYMIZE_APP_IDS   = tostring(var.pseudonymize_app_ids)
+      EMAIL_CANONICALIZATION = var.email_canonicalization
+      CUSTOM_RULES_SHA       = try(var.custom_api_connector_rules[each.key], null) != null ? filesha1(var.custom_api_connector_rules[each.key]) : null
+      IS_DEVELOPMENT_MODE    = contains(var.non_production_connectors, each.key)
     }
   )
 }
@@ -205,7 +206,8 @@ module "bulk_connector" {
     var.general_environment_variables,
     try(each.value.environment_variables, {}),
     {
-      IS_DEVELOPMENT_MODE = contains(var.non_production_connectors, each.key)
+      IS_DEVELOPMENT_MODE    = contains(var.non_production_connectors, each.key)
+      EMAIL_CANONICALIZATION = var.email_canonicalization
     },
   )
 }

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -153,6 +153,12 @@ variable "pseudonymize_app_ids" {
   default     = true
 }
 
+variable "email_canonicalization" {
+  type        = string
+  description = "defines how email address are processed prior to hashing, hence which are considered 'canonically equivalent'; one of 'STRICT' (default and most standard compliant) or 'IGNORE_DOTS' (probably most in line with user expectations)"
+  default     = "STRICT"
+}
+
 variable "general_environment_variables" {
   type        = map(string)
   description = "environment variables to add for all connectors"

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -165,10 +165,11 @@ module "api_connector" {
     var.general_environment_variables,
     try(each.value.environment_variables, {}),
     {
-      BUNDLE_FILENAME      = module.psoxy.filename
-      IS_DEVELOPMENT_MODE  = contains(var.non_production_connectors, each.key)
-      PSEUDONYMIZE_APP_IDS = tostring(var.pseudonymize_app_ids)
-      CUSTOM_RULES_SHA     = try(var.custom_api_connector_rules[each.key], null) != null ? filesha1(var.custom_api_connector_rules[each.key]) : null
+      BUNDLE_FILENAME        = module.psoxy.filename
+      IS_DEVELOPMENT_MODE    = contains(var.non_production_connectors, each.key)
+      PSEUDONYMIZE_APP_IDS   = tostring(var.pseudonymize_app_ids)
+      CUSTOM_RULES_SHA       = try(var.custom_api_connector_rules[each.key], null) != null ? filesha1(var.custom_api_connector_rules[each.key]) : null
+      EMAIL_CANONICALIZATION = var.email_canonicalization
     }
   )
 
@@ -224,10 +225,11 @@ module "bulk_connector" {
     var.general_environment_variables,
     try(each.value.environment_variables, {}),
     {
-      SOURCE              = each.value.source_kind
-      RULES               = each.value.rules_file == null ? yamlencode(try(var.custom_bulk_connector_rules[each.key], each.value.rules)) : file(each.value.rules_file)
-      BUNDLE_FILENAME     = module.psoxy.filename
-      IS_DEVELOPMENT_MODE = contains(var.non_production_connectors, each.key)
+      SOURCE                 = each.value.source_kind
+      RULES                  = each.value.rules_file == null ? yamlencode(try(var.custom_bulk_connector_rules[each.key], each.value.rules)) : file(each.value.rules_file)
+      BUNDLE_FILENAME        = module.psoxy.filename
+      IS_DEVELOPMENT_MODE    = contains(var.non_production_connectors, each.key)
+      EMAIL_CANONICALIZATION = var.email_canonicalization
     }
   )
 }

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -88,6 +88,12 @@ variable "pseudonymize_app_ids" {
   default     = true
 }
 
+variable "email_canonicalization" {
+  type        = string
+  description = "defines how email address are processed prior to hashing, hence which are considered 'canonically equivalent'; one of 'STRICT' (default and most standard compliant) or 'IGNORE_DOTS' (probably most in line with user expectations)"
+  default     = "STRICT"
+}
+
 variable "gcp_region" {
   type        = string
   description = "Region in which to provision GCP resources, if applicable"

--- a/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
@@ -1,0 +1,41 @@
+package co.worklytics.psoxy;
+
+/**
+ * possibly methods for canonicalizing email addresses prior to pseudonymization.
+ *
+ * general idea is that email address strings that would be routed to the same mailbox would be
+ * considered canonically equivalent. However, there is some discrepancy between major email
+ * providers, so we offer several options.
+ *
+ */
+public enum EmailCanonicalization {
+
+    /**
+     * aligned with the strictest of the major email providers (eg, Microsoft, Yahoo, Apple); in
+     * particular where dots (`.`) in local portion of address (prior to `@`) are respected.
+     * eg `roger.rabbit@acme.com` != `rogerrabbit@acme.com`
+     *
+     * default as of 0.4, bc it's the most conservative/standard compliant approach. If a Microsoft
+     * customer wants to have behavior where `.` is ignored, this can always be acheived by explicitly
+     * adding those variants as aliases in their directory - and this should pose no problem to
+     * proxy operation.
+     */
+    STRICT,
+
+    /**
+     * canonicalization that ignores dots (`.`) in local portion of address (prior to `@`), aligned
+     * to convention followed by Google (GMail) and some others.
+     *
+     * `roger.rabbit@acme.com` == `rogerrabbit@acme.com`
+     *
+     * Likely to become the default in future versions, because very weird that someone would
+     * intentionally issue email addresses that differ only in dots.
+     *
+     */
+    IGNORE_DOTS,
+    ;
+
+    public static EmailCanonicalization parseConfigPropertyValue(String s) {
+        return EmailCanonicalization.valueOf(s.toUpperCase());
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
@@ -15,6 +15,11 @@ public enum EmailCanonicalization {
      * particular where dots (`.`) in local portion of address (prior to `@`) are respected.
      * eg `roger.rabbit@acme.com` != `rogerrabbit@acme.com`
      *
+     * As these support sub-addressing, a `+` in the local portion and anything after that will
+     * be trimmed off. (As of May 2022, this is the default for Microsoft)
+     *
+     * see: https://learn.microsoft.com/en-us/exchange/recipients-in-exchange-online/plus-addressing-in-exchange-online
+     *
      * default as of 0.4, bc it's the most conservative/standard compliant approach. If a Microsoft
      * customer wants to have behavior where `.` is ignored, this can always be acheived by explicitly
      * adding those variants as aliases in their directory - and this should pose no problem to

--- a/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
@@ -15,8 +15,12 @@ public enum EmailCanonicalization {
      * particular where dots (`.`) in local portion of address (prior to `@`) are respected.
      * eg `roger.rabbit@acme.com` != `rogerrabbit@acme.com`
      *
-     * As these support sub-addressing, a `+` in the local portion and anything after that will
-     * be trimmed off. (As of May 2022, this is the default for Microsoft)
+     * this is still NOT RFC compliant. For several reasons:
+     *   - RFC 5321 specifies that the local part of an email address is case-sensitive; this method
+     *    considers email mailbox names to be case-insensitive
+     *   - No RFC explicitly defines rules for sub-addressing "plus addressing", but this method
+     *    treats sub-addressed (mailbox suffix of `+` in the local portion and anything after) that
+     *    as canonically equivalent. (As of May 2022, this is the default for Microsoft; see below)
      *
      * see: https://learn.microsoft.com/en-us/exchange/recipients-in-exchange-online/plus-addressing-in-exchange-online
      *

--- a/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/EmailCanonicalization.java
@@ -36,6 +36,8 @@ public enum EmailCanonicalization {
      * Likely to become the default in future versions, because very weird that someone would
      * intentionally issue email addresses that differ only in dots.
      *
+     * q: better name? non-obvious to someone seeing the env var or anywhere else absent this
+     * documentation that 'IGNORE_DOTS' is really the recommended value here
      */
     IGNORE_DOTS,
     ;

--- a/java/core/src/main/java/co/worklytics/psoxy/Pseudonymizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/Pseudonymizer.java
@@ -34,6 +34,9 @@ public interface Pseudonymizer {
         @Builder.Default
         PseudonymImplementation pseudonymImplementation = PseudonymImplementation.DEFAULT;
 
+        @Builder.Default
+        EmailCanonicalization emailCanonicalization = EmailCanonicalization.STRICT;
+
     }
 
     /**

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
@@ -56,8 +56,15 @@ public class PseudonymizerImpl implements Pseudonymizer {
         String domain = EmailAddressParser.getDomain(original, EmailAddressCriteria.RECOMMENDED, true);
 
         //NOTE: lower-case here is NOT stipulated by RFC
-        return  EmailAddressParser.getLocalPart(original, EmailAddressCriteria.RECOMMENDED, true)
-            .toLowerCase()
+        String mailboxLowercase = EmailAddressParser.getLocalPart(original, EmailAddressCriteria.RECOMMENDED, true)
+            .toLowerCase();
+
+        //trim off any + and anything after it (sub-address)
+        if (mailboxLowercase.contains("+")) {
+            mailboxLowercase = mailboxLowercase.substring(0, mailboxLowercase.indexOf("+"));
+        }
+
+        return mailboxLowercase
             + "@"
             + domain.toLowerCase();
 

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
@@ -64,6 +64,10 @@ public class PseudonymizerImpl implements Pseudonymizer {
             mailboxLowercase = mailboxLowercase.substring(0, mailboxLowercase.indexOf("+"));
         }
 
+        if (getOptions().getEmailCanonicalization() == EmailCanonicalization.IGNORE_DOTS) {
+            mailboxLowercase = mailboxLowercase.replace(".", "");
+        }
+
         return mailboxLowercase
             + "@"
             + domain.toLowerCase();

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImplFactory.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImplFactory.java
@@ -24,6 +24,10 @@ public interface PseudonymizerImplFactory {
             .map(PseudonymImplementation::parseConfigPropertyValue)
             .ifPresent(builder::pseudonymImplementation);
 
+        config.getConfigPropertyAsOptional(ProxyConfigProperty.EMAIL_CANONICALIZATION)
+            .map(EmailCanonicalization::parseConfigPropertyValue)
+            .ifPresent(builder::emailCanonicalization);
+
 
         return builder.build();
     }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
@@ -17,6 +17,13 @@ public enum ProxyConfigProperty implements ConfigService.ConfigProperty {
     CUSTOM_RULES_SHA,
 
     /**
+     * 'STRICT', 'IGNORE_DOTS', ...
+     *
+     * OPTIONAL; default to 'STRICT'; possibly will change in next proxy version.
+     */
+    EMAIL_CANONICALIZATION,
+
+    /**
      * where to find configuration parameters that are shared across connectors
      * OPTIONAL; default to ""
      */

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
@@ -79,7 +79,7 @@ class PseudonymizerImplTest {
         "\"Alice Different Last name\" <alice@worklytics.co>",
         "Alice@worklytics.co",
         "AlIcE@worklytics.co",
-        //"alice+test@worklytics.co", // + suffix should be ignored
+        "alice+test@worklytics.co", // + suffix should be ignored
     })
     @ParameterizedTest
     void emailCanonicalEquivalents(String mailHeaderValue) {
@@ -94,8 +94,9 @@ class PseudonymizerImplTest {
         "\"Alice Different Last name\" <alice@worklytics.co>",
         "Alice@worklytics.co",
         "AlIcE@worklytics.co",
-        //"alice+test@worklytics.co", // + suffix should be ignored
+        "alice+test@worklytics.co", // + suffix should be ignored
         "al.ice@worklytics.co",
+        "\"Alice Different Last name\" <alice+t@worklytics.co>",
     })
     @ParameterizedTest
     void emailCanonicalEquivalents_IgnoreDots(String mailHeaderValue) {

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
@@ -79,9 +79,33 @@ class PseudonymizerImplTest {
         "\"Alice Different Last name\" <alice@worklytics.co>",
         "Alice@worklytics.co",
         "AlIcE@worklytics.co",
+        //"alice+test@worklytics.co", // + suffix should be ignored
     })
     @ParameterizedTest
     void emailCanonicalEquivalents(String mailHeaderValue) {
+        PseudonymizedIdentity canonicalExample = pseudonymizer.pseudonymize(ALICE_CANONICAL);
+
+        assertEquals(canonicalExample.getHash(),
+            pseudonymizer.pseudonymize(mailHeaderValue).getHash());
+    }
+    @ValueSource(strings = {
+        ALICE_CANONICAL,
+        "Alice Example <alice@worklytics.co>",
+        "\"Alice Different Last name\" <alice@worklytics.co>",
+        "Alice@worklytics.co",
+        "AlIcE@worklytics.co",
+        //"alice+test@worklytics.co", // + suffix should be ignored
+        "al.ice@worklytics.co",
+    })
+    @ParameterizedTest
+    void emailCanonicalEquivalents_IgnoreDots(String mailHeaderValue) {
+         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
+            .pseudonymizationSalt("an irrelevant per org secret")
+            .defaultScopeId("scope")
+            .pseudonymImplementation(PseudonymImplementation.DEFAULT)
+            .emailCanonicalization(EmailCanonicalization.IGNORE_DOTS)
+            .build());
+
         PseudonymizedIdentity canonicalExample = pseudonymizer.pseudonymize(ALICE_CANONICAL);
 
         assertEquals(canonicalExample.getHash(),


### PR DESCRIPTION
### Fixes
  - alter email canonicalization in proxy to respect subaddress/"plus addressing" convention; 
    eg `alice+test@acme.com` equivalent to `alice@acme.com`

### Features
  - make email canonicalization behavior configurable
  - introduce different email canonicalization behavior that ignores dot in local portion of mailbox, such that `alice.test@acme.com` and `alicetest@acme.com` considered equivalent; this aligns to behavior of Google mail systems, but deviates from standard, as well as Microsoft/Apple/Yahoo in practice. That said, really strange if some actually intends to issue these variants to distinct humans - so this strategy (`IGNORE_DOTS`) is what should become the new default

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **yes**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **yes, but arguably strict improvement in behavior towards people's expections, so 
     while technically breaking going to treat as not**
