### PR TITLE
auth config fallback to config, if not in secrets

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/CertificateGrantTokenRequestBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/CertificateGrantTokenRequestBuilder.java
@@ -54,7 +54,9 @@ public class CertificateGrantTokenRequestBuilder
     @Override
     public void addHeaders(HttpHeaders httpHeaders) {
         String oauthClientId =
-            secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID);
+            config.getConfigPropertyAsOptional(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID)
+                .orElseGet(() -> secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
+
         String tokenEndpoint =
             config.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.REFRESH_ENDPOINT);
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/ClientCredentialsGrantTokenRequestBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/ClientCredentialsGrantTokenRequestBuilder.java
@@ -180,20 +180,23 @@ public class ClientCredentialsGrantTokenRequestBuilder
         Map<String, String> data = new HashMap<>();
 
         data.put("grant_type", getGrantType());
-        data.put("client_id",
-            secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
+        data.put("client_id", getClientId());
         data.put("client_secret",
             secretStore.getConfigPropertyOrError(ConfigProperty.CLIENT_SECRET));
 
         return data;
     }
 
+    private String getClientId() {
+        return config.getConfigPropertyAsOptional(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID)
+            .orElseGet(() -> secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
+    }
+
     private Map<String, String> buildJWTPayload() {
         //implementation of:
         // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token
 
-        String oauthClientId =
-            secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID);
+        String oauthClientId = getClientId();
         String tokenEndpoint =
             config.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.REFRESH_ENDPOINT);
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/ClientCredentialsGrantTokenRequestBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/ClientCredentialsGrantTokenRequestBuilder.java
@@ -187,11 +187,6 @@ public class ClientCredentialsGrantTokenRequestBuilder
         return data;
     }
 
-    private String getClientId() {
-        return config.getConfigPropertyAsOptional(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID)
-            .orElseGet(() -> secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
-    }
-
     private Map<String, String> buildJWTPayload() {
         //implementation of:
         // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token
@@ -279,5 +274,10 @@ public class ClientCredentialsGrantTokenRequestBuilder
                 });
 
         return result.get();
+    }
+
+    private String getClientId() {
+        return config.getConfigPropertyAsOptional(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID)
+            .orElseGet(() -> secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/RefreshTokenTokenRequestBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/RefreshTokenTokenRequestBuilder.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -49,10 +48,16 @@ public class RefreshTokenTokenRequestBuilder
 
         data.put("grant_type", getGrantType());
         data.put("refresh_token", secretStore.getConfigPropertyOrError(ConfigProperty.REFRESH_TOKEN));
-        data.put("client_id", secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
+        data.put("client_id", getClientId());
         data.put("client_secret", secretStore.getConfigPropertyOrError(ConfigProperty.CLIENT_SECRET));
 
         return new UrlEncodedContent(data);
+
+    }
+
+    private String getClientId() {
+        return config.getConfigPropertyAsOptional(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID)
+                .orElseGet(() -> secretStore.getConfigPropertyOrError(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.CLIENT_ID));
 
     }
 


### PR DESCRIPTION

### Features
 - various auth properties (client id, account id) aren't in and of themselves *secret*; so allow to get them from Config if not found in `SecretStore`; we have customers who think of them as secret, but others who prob don't want to pay overhead of handling them as secrets

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **should be backwards compatible**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207091086964724