### PR TITLE
Jira cloud drop cloudid from deep linking

### DIFF
--- a/docs/sources/atlassian/jira/README.md
+++ b/docs/sources/atlassian/jira/README.md
@@ -135,7 +135,7 @@ And its response will be something like:
 
 Add the `id` value from that JSON response as the value of the `jira_cloud_id` variable in the
 `terraform.tfvars` file of your Terraform configuration. This will generate all the test URLs with a
-proper value and it will populate the right value for setting up the configuration.
+proper value for targeting a valid Jira Cloud instance.
 
 NOTE: A "token family" includes the initial access/refresh tokens generated above as well as all
 subsequent access/refresh tokens that Jira returns to any future token refresh requests. By default,

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -166,7 +166,7 @@ locals {
   k => merge(v, { example_calls : v.example_api_calls }) }
 
 
-  jira_cloud_id                    = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
+  jira_example_cloud_id                    = coalesce(var.jira_cloud_id, "YOUR_JIRA_CLOUD_ID")
   jira_example_issue_id            = coalesce(var.jira_example_issue_id, var.example_jira_issue_id, "YOUR_JIRA_EXAMPLE_ISSUE_ID")
   github_installation_id           = coalesce(var.github_installation_id, "YOUR_GITHUB_INSTALLATION_ID")
   github_enterprise_server_host    = coalesce(var.github_api_host, var.github_enterprise_server_host, "YOUR_GITHUB_ENTERPRISE_SERVER_HOST")
@@ -1146,26 +1146,25 @@ EOT
         USE_SHARED_TOKEN : "TRUE"
       }
       settings_to_provide = {
-        "Jira Cloud Id" = local.jira_cloud_id
       }
       reserved_concurrent_executions : null
       example_api_calls_user_to_impersonate : null
       example_api_calls : [
         "/oauth/token/accessible-resources", # obtain Jira Cloud ID from here
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/users",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/users",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/group/bulk",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/search?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/changelog?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/comment?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/users",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/group/bulk",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/search?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/changelog?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/comment?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
-        "/ex/jira/${local.jira_cloud_id}/rest/api/3/project/search?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/users",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/users",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/group/bulk",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/search?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/changelog?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/comment?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/2/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/users",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/group/bulk",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/search?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/changelog?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/comment?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/issue/${local.jira_example_issue_id}/worklog?maxResults=25",
+        "/ex/jira/${local.jira_example_cloud_id}/rest/api/3/project/search?maxResults=25",
       ],
       external_token_todo : <<EOT
 ## Prerequisites

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -1265,7 +1265,7 @@ And following granular scopes:
 
   Add the `id` value from that JSON response as the value of the `jira_cloud_id` variable in the
   `terraform.tfvars` file of your Terraform configuration. This will generate all the test URLs with
-  a proper value and it will populate the right value for setting up the configuration.
+  proper value for targeting a valid Jira Cloud instance.
 EOT
     }
   }

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -72,7 +72,7 @@ variable "jira_server_url" {
 variable "jira_cloud_id" {
   type        = string
   default     = null
-  description = "(Only required if using Jira Cloud connector) Cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
+  description = "(Only required if using Jira Cloud connector) Example of cloud id of the Jira Cloud to connect to (ex: 1324a887-45db-1bf4-1e99-ef0ff456d421)."
 }
 
 #DEPRECATED


### PR DESCRIPTION
~~**NOTE** Mark as draft, as until https://github.com/Worklytics/evalengin/pull/6537 is released this cannot be integrated in psoxy.~~

- Drop `jira_cloud_id` parameter from deep linking
- Minor update on instructions


### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Update Jira Proxy doc and remove parameter from deep linking](https://app.asana.com/0/0/1206475184639833)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
