### PR TITLE
S175 : tooling fixes

### DIFF
--- a/tools/release/example-create-release-pr.sh
+++ b/tools/release/example-create-release-pr.sh
@@ -170,7 +170,19 @@ if command -v gh &> /dev/null; then
   PR_URL=$(gh pr create --title "update to \`${RELEASE_TAG}\`" --body "update to proxy release https://github.com/Worklytics/psoxy/releases/tag/${RELEASE_TAG}" --assignee "@me")
   printf "created PR ${BLUE}${PR_URL}${NC}\n"
   PR_NUMBER=$(gh pr view $PR_URL --json number | jq -r ".number")
-  gh pr comment $PR_NUMBER --body "when ready, from your Psoxy checkout, run \`./tools/release/example-publish-release-pr.sh $EXAMPLE_TEMPLATE_REPO $PR_NUMBER\`"
+  # Generate a random file name for the comment body file
+  COMMENT_BODY_FILE="/tmp/comment-body-file-$(uuidgen).md"
+
+  # Create and write to the comment body file
+  {
+    echo "🛑 Stop! Do not merge manually.🛑"
+    echo "Tooling will merge it for you. When ready, from your Psoxy checkout, run:"
+    echo "\`./tools/release/example-publish-release-pr.sh $EXAMPLE_TEMPLATE_REPO $PR_NUMBER\`"
+  } >> "$COMMENT_BODY_FILE"
+
+  # Add the comment to the PR
+  gh pr comment "$PR_NUMBER" --body-file "$COMMENT_BODY_FILE"
+  rm "$COMMENT_BODY_FILE"
   gh pr view $PR_URL --web
 fi
 

--- a/tools/release/example-publish-release-pr.sh
+++ b/tools/release/example-publish-release-pr.sh
@@ -127,8 +127,11 @@ git tag $RELEASE_NUMBER
 git push origin $RELEASE_NUMBER
 
 printf "Creating release ${BLUE}${RELEASE_NUMBER}${NC} in GitHub ...\n"
-PSOXY_RELEASE_URL=$(gh release view v${RELEASE_NUMBER} --repo ${REMOTE_MAIN_REPO_NAME} --json url | jq -r ".url")
-gh release create $RELEASE_NUMBER --title $RELEASE_NUMBER --notes "Update example to psoxy release ${RELEASE_NUMBER}\nSee: ${PSOXY_RELEASE_URL}"
+PSOXY_RELEASE_URL=$(gh release view ${RELEASE_NUMBER} --repo ${REMOTE_MAIN_REPO_NAME} --json url | jq -r ".url")
+touch /tmp/release-notes.md
+printf "Update example to psoxy release ${RELEASE_NUMBER}\nSee: ${PSOXY_RELEASE_URL}" >> /tmp/release-notes.md
+gh release create $RELEASE_NUMBER --title $RELEASE_NUMBER --notes-file /tmp/release-notes.md
+rm /tmp/release-notes.md
 
 
 

--- a/tools/release/example-publish-release-pr.sh
+++ b/tools/release/example-publish-release-pr.sh
@@ -83,32 +83,32 @@ fi
 # check status of PR
 PR_STATUS=$(gh pr view $PR_NUMBER --json state | jq -r '.state')
 if [ "$PR_STATUS" != "OPEN" ]; then
-  printf "PR ${BLUE}${PR_NUMBER}${NC} is not open. Exiting.\n"
-  exit 1
+  printf "PR ${BLUE}${PR_NUMBER}${NC} is not open. Continuing with cutting release from ${BLUE}main${NC}, presuming it's already merged.\n"
+else
+  # check if PR is mergeable
+  PR_MERGEABLE=$(gh pr view $PR_NUMBER --json mergeable | jq -r '.mergeable')
+  if [ "$PR_MERGEABLE" != "MERGEABLE" ]; then
+    printf "${RED}PR ${PR_NUMBER} is not mergeable. Exiting.${NC}\n"
+    exit 1
+  fi
+
+  # confirm all status checks succeeded
+  PR_CHECKS_PASSED=$(gh pr view $PR_NUMBER --json statusCheckRollup | jq 'all(.statusCheckRollup[]; .conclusion == "SUCCESS")')
+  if [ "$PR_CHECKS_PASSED" != "true" ]; then
+    printf "${RED}PR ${PR_NUMBER} does not have all status checks passing. Exiting.${NC}\n"
+    printf "Here are the status checks that failed:\n"
+    gh pr view $PR_NUMBER --json statusCheckRollup | jq '.statusCheckRollup[] | select(.conclusion == "FAILURE")'
+    exit 1
+  fi
+
+  # merge the PR to main
+  printf "Merging PR ${BLUE}${PR_NUMBER}${NC} to main ...\n"
+  gh pr merge $PR_NUMBER --delete-branch --squash
 fi
 
-# check if PR is mergeable
-PR_MERGEABLE=$(gh pr view $PR_NUMBER --json mergeable | jq -r '.mergeable')
-if [ "$PR_MERGEABLE" != "MERGEABLE" ]; then
-  printf "${RED}PR ${PR_NUMBER} is not mergeable. Exiting.${NC}\n"
-  exit 1
-fi
-
-# confirm all status checks succeeded
-PR_CHECKS_PASSED=$(gh pr view $PR_NUMBER --json statusCheckRollup | jq 'all(.statusCheckRollup[]; .conclusion == "SUCCESS")')
-if [ "$PR_CHECKS_PASSED" != "true" ]; then
-  printf "${RED}PR ${PR_NUMBER} does not have all status checks passing. Exiting.${NC}\n"
-  printf "Here are the status checks that failed:\n"
-  gh pr view $PR_NUMBER --json statusCheckRollup | jq '.statusCheckRollup[] | select(.conclusion == "FAILURE")'
-  exit 1
-fi
-
-# merge the PR to main
-printf "Merging PR ${BLUE}${PR_NUMBER}${NC} to main ...\n"
-gh pr merge $PR_NUMBER --delete-branch --squash
 
 # ensure `main` up-to-date with origin
-printf "Ensuring local main branch is up-to-date with origin ...\n"
+printf "Ensuring local ${BLUE}main${NC} branch is up-to-date with origin ...\n"
 if git fetch origin main --dry-run | grep -q 'up to date'; then
       echo "The local main branch is up to date with origin/main."
   else


### PR DESCRIPTION
### Fixes
 - release notes for examples poorly formatted, missing link

### Features
 - example release tooling works even if PR already merged
 - clearer auto-comments on PRs, to inform user they don't need to merge

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? **no**
