### PR TITLE
source availability concept in connector specs

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -1156,12 +1156,12 @@ EOT
     },
     jira-server = {
       source_kind : "jira-server"
-      availability : "deprecated",
+      availability : "ga",
       enable_by_default : false
       worklytics_connector_id : "jira-server-psoxy"
       target_host : var.jira_server_url
       source_auth_strategy : "oauth2_access_token"
-      display_name : "Jira Server REST API"
+      display_name : "Jira Data Center"
       identifier_scope_id : "jira"
       worklytics_connector_name : "Jira Server REST API via Psoxy"
       secured_variables : [

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -27,6 +27,7 @@ locals {
     # to the Google Workspace, so may be directly connected in such scenarios.
     "gdirectory" : {
       source_kind : "gdirectory",
+      availability : "ga",
       worklytics_connector_id : "gdirectory-psoxy",
       display_name : "Google Directory"
       identifier_scope_id : "gapps"
@@ -57,6 +58,7 @@ locals {
     },
     "gcal" : {
       source_kind : "gcal",
+      availability : "ga",
       worklytics_connector_id : "gcal-psoxy",
       display_name : "Google Calendar"
       identifier_scope_id : "gapps"
@@ -80,6 +82,7 @@ locals {
     },
     "gmail" : {
       source_kind : "gmail",
+      availability : "ga",
       worklytics_connector_id : "gmail-meta-psoxy",
       display_name : "GMail"
       identifier_scope_id : "gapps"
@@ -100,6 +103,7 @@ locals {
     },
     "google-chat" : {
       source_kind : "google-chat",
+      availability : "ga",
       worklytics_connector_id : "google-chat-psoxy",
       display_name : "Google Chat"
       identifier_scope_id : "gapps"
@@ -119,6 +123,7 @@ locals {
     },
     "google-meet" : {
       source_kind : "google-meet"
+      availability : "ga",
       worklytics_connector_id : "google-meet-psoxy"
       display_name : "Google Meet"
       identifier_scope_id : "gapps"
@@ -138,6 +143,7 @@ locals {
     },
     "gdrive" : {
       source_kind : "gdrive",
+      availability : "ga",
       worklytics_connector_id : "gdrive-psoxy",
       display_name : "Google Drive"
       identifier_scope_id : "gapps"
@@ -181,6 +187,7 @@ locals {
   msft_365_connectors = {
     "azure-ad" : {
       worklytics_connector_id : "azure-ad-psoxy",
+      availability : "deprecated",
       source_kind : "azure-ad",
       display_name : "(Deprecated, use MSFT Entra Id instead) Azure Directory"
       identifier_scope_id : "azure-ad"
@@ -207,6 +214,7 @@ locals {
     },
     "msft-entra-id" : {
       worklytics_connector_id : "azure-ad-psoxy",
+      availability : "ga",
       source_kind : "azure-ad",
       display_name : "Microsoft Entra ID (former Azure AD)"
       identifier_scope_id : "azure-ad"
@@ -233,6 +241,7 @@ locals {
     },
     "outlook-cal" : {
       source_kind : "outlook-cal",
+      availability : "ga",
       worklytics_connector_id : "outlook-cal-psoxy",
       display_name : "Outlook Calendar"
       identifier_scope_id : "azure-ad"
@@ -263,6 +272,7 @@ locals {
     },
     "outlook-mail" : {
       source_kind : "outlook-mail"
+      availability : "ga",
       worklytics_connector_id : "outlook-mail-psoxy",
       display_name : "Outlook Mail"
       identifier_scope_id : "azure-ad"
@@ -291,6 +301,7 @@ locals {
     },
     "msft-teams" : {
       source_kind : "msft-teams"
+      availability : "ga",
       worklytics_connector_id : "msft-teams-psoxy",
       display_name : "Microsoft Teams"
       identifier_scope_id : "azure-ad"
@@ -373,6 +384,7 @@ EOT
   oauth_long_access_connectors = {
     asana = {
       source_kind : "asana",
+      availability : "ga",
       worklytics_connector_id : "asana-psoxy"
       display_name : "Asana"
       identifier_scope_id : "asana"
@@ -409,6 +421,7 @@ EOT
     }
     github = {
       source_kind : "github",
+      availability : "ga",
       worklytics_connector_id : "github-enterprise-psoxy"
       display_name : "Github Enterprise"
       identifier_scope_id : "github"
@@ -516,6 +529,7 @@ EOT
     }
     github-enterprise-server = {
       source_kind : "github-enterprise-server",
+      availability : "ga",
       worklytics_connector_id : "github-enterprise-server-psoxy"
       display_name : "Github Enterprise Server"
       identifier_scope_id : "github"
@@ -638,6 +652,7 @@ EOT
     }
     github-non-enterprise = {
       source_kind : "github",
+      availability : "ga",
       worklytics_connector_id : "github-free-team-psoxy"
       display_name : "Github"
       identifier_scope_id : "github"
@@ -742,6 +757,7 @@ EOT
     }
     salesforce = {
       source_kind : "salesforce",
+      availability : "ga",
       worklytics_connector_id : "salesforce-psoxy"
       display_name : "Salesforce"
       identifier_scope_id : "salesforce"
@@ -843,6 +859,7 @@ EOT
     }
     slack-discovery-api = {
       source_kind : "slack"
+      availability : "ga",
       identifier_scope_id : "slack"
       worklytics_connector_id : "slack-discovery-api-psoxy",
       worklytics_connector_name : "Slack via Psoxy",
@@ -913,6 +930,7 @@ EOT
     }
     zoom = {
       source_kind : "zoom"
+      availability : "ga",
       worklytics_connector_id : "zoom-psoxy"
       display_name : "Zoom"
       worklytics_connector_name : "Zoom via Psoxy"
@@ -1031,6 +1049,7 @@ EOT
     },
     dropbox-business = {
       source_kind : "dropbox-business"
+      availability : "deprecated",
       worklytics_connector_id : "dropbox-business-log-psoxy"
       target_host : "api.dropboxapi.com"
       source_auth_strategy : "oauth2_refresh_token"
@@ -1118,6 +1137,7 @@ EOT
     },
     jira-server = {
       source_kind : "jira-server"
+      availability : "deprecated",
       worklytics_connector_id : "jira-server-psoxy"
       target_host : var.jira_server_url
       source_auth_strategy : "oauth2_access_token"
@@ -1159,6 +1179,7 @@ EOT
     }
     jira-cloud = {
       source_kind : "jira-cloud"
+      availability : "ga"
       worklytics_connector_id : "jira-cloud-psoxy"
       target_host : "api.atlassian.com"
       source_auth_strategy : "oauth2_refresh_token"
@@ -1332,6 +1353,7 @@ EOT
   bulk_connectors = {
     "badge" = {
       source_kind               = "badge"
+      availability              = "ga"
       worklytics_connector_id   = "bulk-import-psoxy",
       worklytics_connector_name = "Bulk Data Import via Psoxy"
       rules = {
@@ -1348,6 +1370,7 @@ EOT
     }
     "hris" = {
       source_kind               = "hris"
+      availability              = "ga"
       worklytics_connector_id   = "hris-import-psoxy"
       worklytics_connector_name = "HRIS Data Import via Psoxy"
       rules = {
@@ -1366,6 +1389,7 @@ EOT
     }
     "survey" = {
       worklytics_connector_id   = "survey-import-psoxy"
+      availability              = "ga"
       source_kind               = "survey"
       worklytics_connector_name = "Survey Data Import via Psoxy"
       rules = {
@@ -1379,6 +1403,7 @@ EOT
     }
     "qualtrics" = {
       source_kind               = "qualtrics"
+      availability              = "beta"
       worklytics_connector_id   = "survey-import-psoxy"
       worklytics_connector_name = "Survey Data Import via Psoxy"
       rules = {
@@ -1396,14 +1421,21 @@ EOT
   k => merge(v, { example_calls : v.example_api_calls }) }
 
 
-  # to expose via console
-  # eg, `echo "local.available_connector_ids" | terraform console` will print this
-  available_connector_ids = keys(merge(
+  all_connectors =  merge(
     local.google_workspace_sources,
     local.msft_365_connectors,
     local.oauth_long_access_connectors,
     local.bulk_connectors,
-  ))
+  )
+
+  ga_connectors = {
+    for k, v in local.all_connectors : k => v if v.availability == "ga"
+  }
+
+  # to expose via console
+  # eg, `echo "local.available_connector_ids" | terraform console` will print this
+  # used via `tools/init-tfvars.sh` script, as default values for `enabled_connectors` variable
+  available_connector_ids = keys(local.ga_connectors)
 
 }
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -28,6 +28,7 @@ locals {
     "gdirectory" : {
       source_kind : "gdirectory",
       availability : "ga",
+      enable_by_default : true
       worklytics_connector_id : "gdirectory-psoxy",
       display_name : "Google Directory"
       identifier_scope_id : "gapps"
@@ -59,6 +60,7 @@ locals {
     "gcal" : {
       source_kind : "gcal",
       availability : "ga",
+      enable_by_default : true
       worklytics_connector_id : "gcal-psoxy",
       display_name : "Google Calendar"
       identifier_scope_id : "gapps"
@@ -83,6 +85,7 @@ locals {
     "gmail" : {
       source_kind : "gmail",
       availability : "ga",
+      enable_by_default : true
       worklytics_connector_id : "gmail-meta-psoxy",
       display_name : "GMail"
       identifier_scope_id : "gapps"
@@ -104,6 +107,7 @@ locals {
     "google-chat" : {
       source_kind : "google-chat",
       availability : "ga",
+      enable_by_default : false
       worklytics_connector_id : "google-chat-psoxy",
       display_name : "Google Chat"
       identifier_scope_id : "gapps"
@@ -124,6 +128,7 @@ locals {
     "google-meet" : {
       source_kind : "google-meet"
       availability : "ga",
+      enable_by_default : false
       worklytics_connector_id : "google-meet-psoxy"
       display_name : "Google Meet"
       identifier_scope_id : "gapps"
@@ -144,6 +149,7 @@ locals {
     "gdrive" : {
       source_kind : "gdrive",
       availability : "ga",
+      enable_by_default : false
       worklytics_connector_id : "gdrive-psoxy",
       display_name : "Google Drive"
       identifier_scope_id : "gapps"
@@ -188,6 +194,7 @@ locals {
     "azure-ad" : {
       worklytics_connector_id : "azure-ad-psoxy",
       availability : "deprecated",
+      enable_by_default : false,
       source_kind : "azure-ad",
       display_name : "(Deprecated, use MSFT Entra Id instead) Azure Directory"
       identifier_scope_id : "azure-ad"
@@ -215,6 +222,7 @@ locals {
     "msft-entra-id" : {
       worklytics_connector_id : "azure-ad-psoxy",
       availability : "ga",
+      enable_by_default : true,
       source_kind : "azure-ad",
       display_name : "Microsoft Entra ID (former Azure AD)"
       identifier_scope_id : "azure-ad"
@@ -242,6 +250,7 @@ locals {
     "outlook-cal" : {
       source_kind : "outlook-cal",
       availability : "ga",
+      enable_by_default : true,
       worklytics_connector_id : "outlook-cal-psoxy",
       display_name : "Outlook Calendar"
       identifier_scope_id : "azure-ad"
@@ -273,6 +282,7 @@ locals {
     "outlook-mail" : {
       source_kind : "outlook-mail"
       availability : "ga",
+      enable_by_default : true,
       worklytics_connector_id : "outlook-mail-psoxy",
       display_name : "Outlook Mail"
       identifier_scope_id : "azure-ad"
@@ -302,6 +312,7 @@ locals {
     "msft-teams" : {
       source_kind : "msft-teams"
       availability : "ga",
+      enable_by_default : false,
       worklytics_connector_id : "msft-teams-psoxy",
       display_name : "Microsoft Teams"
       identifier_scope_id : "azure-ad"
@@ -385,6 +396,7 @@ EOT
     asana = {
       source_kind : "asana",
       availability : "ga",
+      enable_by_default : false,
       worklytics_connector_id : "asana-psoxy"
       display_name : "Asana"
       identifier_scope_id : "asana"
@@ -422,6 +434,7 @@ EOT
     github = {
       source_kind : "github",
       availability : "ga",
+      enable_by_default : true,
       worklytics_connector_id : "github-enterprise-psoxy"
       display_name : "Github Enterprise"
       identifier_scope_id : "github"
@@ -530,6 +543,7 @@ EOT
     github-enterprise-server = {
       source_kind : "github-enterprise-server",
       availability : "ga",
+      enable_by_default : false
       worklytics_connector_id : "github-enterprise-server-psoxy"
       display_name : "Github Enterprise Server"
       identifier_scope_id : "github"
@@ -653,6 +667,7 @@ EOT
     github-non-enterprise = {
       source_kind : "github",
       availability : "ga",
+      enable_by_default : false
       worklytics_connector_id : "github-free-team-psoxy"
       display_name : "Github"
       identifier_scope_id : "github"
@@ -758,6 +773,7 @@ EOT
     salesforce = {
       source_kind : "salesforce",
       availability : "ga",
+      enable_by_default : false
       worklytics_connector_id : "salesforce-psoxy"
       display_name : "Salesforce"
       identifier_scope_id : "salesforce"
@@ -860,6 +876,7 @@ EOT
     slack-discovery-api = {
       source_kind : "slack"
       availability : "ga",
+      enable_by_default : true
       identifier_scope_id : "slack"
       worklytics_connector_id : "slack-discovery-api-psoxy",
       worklytics_connector_name : "Slack via Psoxy",
@@ -931,6 +948,7 @@ EOT
     zoom = {
       source_kind : "zoom"
       availability : "ga",
+      enable_by_default : true
       worklytics_connector_id : "zoom-psoxy"
       display_name : "Zoom"
       worklytics_connector_name : "Zoom via Psoxy"
@@ -1050,6 +1068,7 @@ EOT
     dropbox-business = {
       source_kind : "dropbox-business"
       availability : "deprecated",
+      enable_by_default : false
       worklytics_connector_id : "dropbox-business-log-psoxy"
       target_host : "api.dropboxapi.com"
       source_auth_strategy : "oauth2_refresh_token"
@@ -1138,6 +1157,7 @@ EOT
     jira-server = {
       source_kind : "jira-server"
       availability : "deprecated",
+      enable_by_default : false
       worklytics_connector_id : "jira-server-psoxy"
       target_host : var.jira_server_url
       source_auth_strategy : "oauth2_access_token"
@@ -1180,6 +1200,7 @@ EOT
     jira-cloud = {
       source_kind : "jira-cloud"
       availability : "ga"
+      enable_by_default : true
       worklytics_connector_id : "jira-cloud-psoxy"
       target_host : "api.atlassian.com"
       source_auth_strategy : "oauth2_refresh_token"
@@ -1354,6 +1375,7 @@ EOT
     "badge" = {
       source_kind               = "badge"
       availability              = "ga"
+      enable_by_default         = true
       worklytics_connector_id   = "bulk-import-psoxy",
       worklytics_connector_name = "Bulk Data Import via Psoxy"
       rules = {
@@ -1371,6 +1393,7 @@ EOT
     "hris" = {
       source_kind               = "hris"
       availability              = "ga"
+      enable_by_default         = true
       worklytics_connector_id   = "hris-import-psoxy"
       worklytics_connector_name = "HRIS Data Import via Psoxy"
       rules = {
@@ -1390,6 +1413,7 @@ EOT
     "survey" = {
       worklytics_connector_id   = "survey-import-psoxy"
       availability              = "ga"
+      enable_by_default         = true
       source_kind               = "survey"
       worklytics_connector_name = "Survey Data Import via Psoxy"
       rules = {
@@ -1404,6 +1428,7 @@ EOT
     "qualtrics" = {
       source_kind               = "qualtrics"
       availability              = "beta"
+      enable_by_default         = false
       worklytics_connector_id   = "survey-import-psoxy"
       worklytics_connector_name = "Survey Data Import via Psoxy"
       rules = {
@@ -1421,22 +1446,28 @@ EOT
   k => merge(v, { example_calls : v.example_api_calls }) }
 
 
-  all_connectors =  merge(
+  all_default_connectors =  merge(
     local.google_workspace_sources,
     local.msft_365_connectors,
     local.oauth_long_access_connectors,
     local.bulk_connectors,
   )
 
-  ga_connectors = {
-    for k, v in local.all_connectors : k => v if v.availability == "ga"
+  default_ga_connectors = {
+    for k, v in local.all_default_connectors : k => v if (
+      v.availability == "ga"
+      && v.enable_by_default
+      # either GWS included, or NOT a gws-connector
+      && (var.include_google_workspace || !contains(keys(local.google_workspace_sources), k))
+      # either MSFT include or NOT a msft-connector
+      && (var.include_msft || !contains(keys(local.msft_365_connectors), k))
+    )
   }
 
   # to expose via console
   # eg, `echo "local.available_connector_ids" | terraform console` will print this
   # used via `tools/init-tfvars.sh` script, as default values for `enabled_connectors` variable
-  available_connector_ids = keys(local.ga_connectors)
-
+  default_enabled_connector_ids = keys(local.default_ga_connectors)
 }
 
 # computed values filtered by enabled connectors

--- a/infra/modules/worklytics-connector-specs/outputs.tf
+++ b/infra/modules/worklytics-connector-specs/outputs.tf
@@ -36,9 +36,15 @@ output "enabled_bulk_connectors" {
   value       = local.enabled_bulk_connectors
 }
 
+# deprecated; remove in 0.5
 output "available_connector_ids" {
+  description = "List of available connector IDs (deprecated since 0.4.54)"
+  value       = local.default_enabled_connector_ids
+}
+
+output "default_enabled_connector_ids" {
   description = "List of available connector IDs"
-  value       = local.available_connector_ids
+  value       = local.default_enabled_connector_ids
 }
 
 output "available_google_workspace_connectors" {

--- a/infra/modules/worklytics-connector-specs/variables.tf
+++ b/infra/modules/worklytics-connector-specs/variables.tf
@@ -15,6 +15,18 @@ variable "google_workspace_example_admin" {
   default     = null # will failover to user
 }
 
+variable "include_msft" {
+  type        = bool
+  description = "whether to include Microsoft 365 connectors by default"
+  default     = true
+}
+
+variable "include_google_workspace" {
+  type        = bool
+  description = "whether to include Google Workspace connectors by default"
+  default     = true
+}
+
 variable "msft_tenant_id" {
   type        = string
   description = "ID of Microsoft tenant to connect to (req'd only if config includes MSFT connectors)"

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -169,7 +169,7 @@ remove_google_workspace() {
   sed -i '' '/^[[:space:]]*module\.worklytics_connectors_google_workspace\.next_todo_step,[[:space:]]*$/d' main.tf
 }
 
-
+INCLUDE_GWS="false"
 GOOGLE_PROVIDER_COUNT=$(terraform providers | grep "${TOP_LEVEL_PROVIDER_PATTERN}/google" | wc -l)
 if test $GOOGLE_PROVIDER_COUNT -ne 0; then
   if gcloud --version &> /dev/null ; then
@@ -201,6 +201,7 @@ if test $GOOGLE_PROVIDER_COUNT -ne 0; then
     prompt_user_Yn "Do you want to use ${BLUE}Google Workspace${NC} as a data source? (requires ${BLUE}gcloud${NC} to be installed and authenticated in the environment from which this terraform configuration will be applied) "
 
     if [[ $? -eq 1 ]]; then
+      INCLUDE_GWS="true"
       # init google workspace variables if file exists OR the variables are in the main variables.tf file
       # (google_workspace_gcp_project_id not in all legacy examples)
       [[ -f google-workspace-variables.tf ]] || grep -q '^variable "google_workspace_gcp_project_id"' variables.tf
@@ -260,6 +261,7 @@ remove_msft() {
 
 # Microsoft 365
 AZUREAD_PROVIDER_COUNT=$(terraform providers | grep "${TOP_LEVEL_PROVIDER_PATTERN}/azuread" | wc -l)
+INCLUDE_MSFT="false"
 if test $AZUREAD_PROVIDER_COUNT -ne 0; then
   printf "AzureAD provider in Terraform configuration.\n"
   MSFT_VARIABLES_DEFINED=$( [[ -f msft-365-variables.tf ]] || grep -q '^variable "msft_tenant_id"' variables.tf)
@@ -283,6 +285,7 @@ if test $AZUREAD_PROVIDER_COUNT -ne 0; then
         printf "#  - if you're not connecting to Microsoft 365 data sources, you can omit this value\n" >> $TFVARS_FILE
         printf "msft_owners_email=[\n  \"${MSFT_USER_EMAIL}\"\n]\n\n" >> $TFVARS_FILE
         printf "\tmsft_owners_email=${BLUE}[ \"${MSFT_USER_EMAIL}\" ]${NC}\n"
+        INCLUDE_MSFT="true"
       else
         printf "${RED}az not available${NC}. Microsoft 365 variables cannot be initialized.\n"
       fi
@@ -304,7 +307,8 @@ fi
 # init worklytics-connector-specs module as if it's a terraform config, so subsequent 'console' call
 # will work
 terraform -chdir="${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs" init >> /dev/null
-AVAILABLE_CONNECTORS=$(echo "local.available_connector_ids" | terraform -chdir="${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs" console)
+CLI_VARS="-var=include_msft=${INCLUDE_MSFT} -var=include_google_workspace=${INCLUDE_GWS}"
+AVAILABLE_CONNECTORS=$(echo "local.default_enabled_connector_ids" | terraform -chdir="${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs" console $CLI_VARS)
 
 # clean up what the init did above
 rm -rf "${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs/.terraform" 2> /dev/null

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -310,7 +310,7 @@ AVAILABLE_CONNECTORS=$(echo "local.available_connector_ids" | terraform -chdir="
 rm -rf "${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs/.terraform" 2> /dev/null
 rm "${PSOXY_BASE_DIR}infra/modules/worklytics-connector-specs/.terraform.lock.hcl" 2> /dev/null
 
-if [ -z $AVAILABLE_CONNECTORS ]; then
+if [ -z "$AVAILABLE_CONNECTORS" ]; then
   printf "${RED}Failed to generate list of enabled_connectors${NC}; you will need to add an variable assigned for ${BLUE}enabled_connectors${NC} to your ${BLUE}terraform.tfvars${NC} as a list of connector ID strings. Contact support for assistance.\n"
 else
   printf "# review following list of connectors to enable, and comment out what you don't want\n" >> $TFVARS_FILE


### PR DESCRIPTION
why? have deprecated `azure-ad`; so won't customers to get `entra-id` version by default and don't see the deprecated one.

### Features
  - `availability` flag on connector specs
  - `enable_by_default` flag on connector specs, which flags whether connector is included in default list to enable (provision) after running `./init`
  - improve `./init`; if customer opts out of GWS/MSFT connectors, don't include in enabled list by default

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207403269492780