### PR TITLE
S177 optimize S3 handler for bulk processing

### DIFF
--- a/docs/configuration/bulk-file-sanitization.md
+++ b/docs/configuration/bulk-file-sanitization.md
@@ -264,3 +264,27 @@ Alternatively, you can remove the environment variable from your instance, and i
 
 This approach is useful for testing, but note that if you later run `terraform apply` again, any
 changes you make to the environment variable may be overwritten by Terraform.
+
+
+### Troubleshooting
+
+If you encounter issues processing your files, check the logs of the Psoxy instance. The logs will
+give some indication of what went wrong, and may help you identify the issue.
+
+#### Error: java.lang.IllegalArgumentException: Mapping for employee_id not found
+
+**Causes**: The column specified in `columnsToPseudonymize` is not present in the input data or contains
+empty values. Any column specified in `columnsToPseudonymize` must be present in the input data.
+
+**Solution**: Regenerate your input file removing empty values for mandatory columns.
+
+#### Error: java.lang.OutOfMemoryError
+
+**Causes**: The file size is too large for the Psoxy instance to process, likely in AWS Lambda in proxy
+versions prior to v0.4.54.
+
+**Solutions:**
+1. Use compression in the file (see [Compression](#compression)); if already compressed, then:
+2. Split the file into smaller files and process them separately
+3. (AWS only) Update the proxy version to v0.4.55 or later
+4. (AWS only) If in v0.4.55 or later, process the files one by one or increase the ephemeral storage allocated to the Lambda function (see https://aws.amazon.com/blogs/aws/aws-lambda-now-supports-up-to-10-gb-ephemeral-storage/)

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -325,7 +325,7 @@ public class StorageHandler {
     }
 
 
-    private int getBufferSize() {
+    public int getBufferSize() {
         return config.getConfigPropertyAsOptional(BulkModeConfigProperty.BUFFER_SIZE).map(Integer::parseInt).orElse(DEFAULT_BUFFER_SIZE);
     }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -331,11 +331,11 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
                 });
 
                 if (buffer.addAndAttemptFlush(ProcessedRecord.of(Lists.newArrayList(newRecord.values())))) {
-                    log.info(String.format("Processed records: %.2f%%", (double) records.getRecordNumber()*100/buffer.getProcessed()));
+                    log.info(String.format("Processed records: %d", buffer.getProcessed()));
                 };
             }
             if (buffer.flush()) {
-                log.info(String.format("Processed records: %.2f%%", (double) records.getRecordNumber()*100/buffer.getProcessed()));
+                log.info(String.format("Processed records: %d", buffer.getProcessed()));
             }
         }
     }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/ProcessingBuffer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/ProcessingBuffer.java
@@ -1,0 +1,55 @@
+package co.worklytics.psoxy.utils;
+
+import co.worklytics.psoxy.storage.impl.ColumnarBulkDataSanitizerImpl;
+import com.google.api.client.util.Lists;
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class ProcessingBuffer<T> {
+
+    @Getter
+    final int capacity;
+    final Consumer<Collection<T>> consumer;
+
+    // making it synchronized so can be used in parallel streams if wanted, but usually won't
+    private final List<T> buffer = Collections.synchronizedList(Lists.newArrayList());
+    @Getter
+    private int flushes = 0;
+
+    public ProcessingBuffer(int capacity, Consumer<Collection<T>> consumer) {
+        Preconditions.checkArgument(capacity > 0);
+        this.capacity = capacity;
+        this.consumer = consumer;
+    }
+
+
+    public void addAndAttemptFlush(T t) {
+        this.buffer.add(t);
+        this.flushIfFull();
+    }
+
+    /**
+     * Flushes if buffer has anything
+     */
+    public void flush() {
+        if (!this.buffer.isEmpty()) {
+            consumer.accept(this.buffer);
+            flushes++;
+            this.buffer.clear();
+        }
+    }
+
+    /**
+     * Flushes if buffer is full
+     */
+    private void flushIfFull() {
+        if (this.buffer.size() >= capacity) {
+            this.flush();
+        }
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/ProcessingBuffer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/ProcessingBuffer.java
@@ -19,7 +19,7 @@ public class ProcessingBuffer<T> {
     // making it synchronized so can be used in parallel streams if wanted, but usually won't
     private final List<T> buffer = Collections.synchronizedList(Lists.newArrayList());
     @Getter
-    private int flushes = 0;
+    private long processed = 0;
 
     public ProcessingBuffer(int capacity, Consumer<Collection<T>> consumer) {
         Preconditions.checkArgument(capacity > 0);
@@ -28,28 +28,31 @@ public class ProcessingBuffer<T> {
     }
 
 
-    public void addAndAttemptFlush(T t) {
+    public boolean addAndAttemptFlush(T t) {
         this.buffer.add(t);
-        this.flushIfFull();
+        return this.flushIfFull();
     }
 
     /**
      * Flushes if buffer has anything
      */
-    public void flush() {
+    public boolean flush() {
         if (!this.buffer.isEmpty()) {
             consumer.accept(this.buffer);
-            flushes++;
+            processed+=this.buffer.size();
             this.buffer.clear();
+            return true;
         }
+        return false;
     }
 
     /**
      * Flushes if buffer is full
      */
-    private void flushIfFull() {
+    private boolean flushIfFull() {
         if (this.buffer.size() >= capacity) {
-            this.flush();
+            return this.flush();
         }
+        return false;
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/ProcessingBuffer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/ProcessingBuffer.java
@@ -34,7 +34,8 @@ public class ProcessingBuffer<T> {
     }
 
     /**
-     * Flushes if buffer has anything
+     * Flushes if buffer has anything.
+     * @return true if flush happened
      */
     public boolean flush() {
         if (!this.buffer.isEmpty()) {
@@ -48,6 +49,7 @@ public class ProcessingBuffer<T> {
 
     /**
      * Flushes if buffer is full
+     * @return true if flush happened
      */
     private boolean flushIfFull() {
         if (this.buffer.size() >= capacity) {

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
@@ -90,8 +90,6 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
         try (InputStream fileInputStream = new FileInputStream(tmpFile);
             BufferedInputStream processedStream = new BufferedInputStream(fileInputStream, storageHandler.getBufferSize())) {
             ObjectMetadata destinationMetadata = new ObjectMetadata();
-            //NOTE: not setting content length here causes S3 client to buffer the output stream ...
-            //   --> OK, bc we have no way to know output length apriori
             destinationMetadata.setContentLength(tmpFile.length());
 
             // set headers iff they're non-null on source object

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import lombok.SneakyThrows;
 import lombok.extern.java.Log;
+import org.apache.commons.io.IOUtils;
 
 import javax.inject.Inject;
 import java.io.*;
@@ -69,20 +70,43 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
         }
 
         byte[] processedData = null;
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             PipedInputStream pis = new PipedInputStream();
+             PipedOutputStream pos = new PipedOutputStream(pis)) {
+
+            outputStream.writeTo(pos);
 
             StorageEventRequest request =
                 storageHandler.buildRequest(importBucket, sourceKey, transform, sourceMetadata.getContentEncoding());
+
+            ObjectMetadata destinationMetadata = new ObjectMetadata();
+            //NOTE: not setting content length here causes S3 client to buffer the output stream ...
+            //   --> OK, bc we have no way to know output length apriori
+            //meta.setContentLength(storageEventResponse.getBytes().length);
+
+            // set headers iff they're non-null on source object
+            Optional.ofNullable(sourceMetadata.getContentType())
+                .ifPresent(destinationMetadata::setContentType);
+            Optional.ofNullable(sourceMetadata.getContentEncoding())
+                .ifPresent(destinationMetadata::setContentEncoding);
+
+            destinationMetadata.setUserMetadata(storageHandler.buildObjectMetadata(importBucket, sourceKey, transform));
+
+            s3Client.putObject(request.getDestinationBucketName(),
+                request.getDestinationObjectPath(),
+                pis,
+                destinationMetadata);
 
             storageEventResponse = storageHandler.handle(request, transform, () -> {
                 S3Object sourceObject = s3Client.getObject(new GetObjectRequest(importBucket, sourceKey));
                 return sourceObject.getObjectContent();
             }, () -> outputStream);
 
-            processedData = outputStream.toByteArray();
             log.info(String.format("Successfully pseudonymized %s/%s to buffer", importBucket, sourceKey));
-        }
 
+
+        }
+/*
         try (InputStream processedStream = new ByteArrayInputStream(processedData)) {
             ObjectMetadata destinationMetadata = new ObjectMetadata();
             //NOTE: not setting content length here causes S3 client to buffer the output stream ...
@@ -109,7 +133,7 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
                 storageEventResponse.getDestinationBucketName(),
                 storageEventResponse.getDestinationObjectPath()));
         }
-
+*/
         return storageEventResponse;
     }
 

--- a/tools/bulk-generator/badge_generator.py
+++ b/tools/bulk-generator/badge_generator.py
@@ -1,0 +1,33 @@
+import csv
+import uuid
+import random
+from datetime import datetime, timedelta
+
+
+# Function to generate random timestamps within a range
+def random_date(start, end):
+    delta = end - start
+    random_seconds = int((start + timedelta(seconds=delta.total_seconds() * random.random())).timestamp())
+    return datetime.fromtimestamp(random_seconds).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+# Badge headers
+headers = ['EMPLOYEE_ID', 'SWIPE_DATE', 'BUILDING_ID', 'BUILDING_ASSIGNED']
+start_date = datetime(2020, 1, 1)
+end_date = datetime(2023, 12, 31)
+filename = 'badge_swipes.csv'
+rows_to_generate = 1000000
+
+with open(filename, 'w', newline='') as csvfile:
+    writer = csv.writer(csvfile)
+    writer.writerow(headers)
+
+    for _ in range(rows_to_generate):
+        row = [
+            str(uuid.uuid4()),  # UUID as string
+            random_date(start_date, end_date),  # Random timestamp
+            'BLOCK_' + str(_),  # Sample block data
+            'ASSIGNED_' + str(_),  # Sample assigned data
+        ]
+        writer.writerow(row)
+
+print("CSV generation complete.")


### PR DESCRIPTION
### Fixes
- [badge processing on proxy OOMing](https://app.asana.com/0/1207553650922163/1207652310186524)
- Used ephemeral storage for the AWS lambda to write the processed file, then upload to S3.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? no
   - breaking changes? no
