### PR TITLE
Fix reverse tokenized urls

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -163,7 +163,9 @@ public class CommonRequestHandler {
         String callLog = String.format("%s %s TokenInUrlReversed=%b", request.getHttpMethod(), URLUtils.relativeURL(toLog), tokenizedURLReversed);
         if (skipSanitization) {
             log.info(String.format("%s. Skipping sanitization.", callLog));
-        } else if (sanitizer.isAllowed(request.getHttpMethod(), targetUrl)) {
+        } else if (sanitizer.isAllowed(request.getHttpMethod(),
+                // Using original URL to check sanitized rules, as they should match the original URL
+                new URL(requestedTargetUrl))) {
             log.info(String.format("%s. Rules allowed call.", callLog));
         } else {
             builder.statusCode(HttpStatus.SC_FORBIDDEN);
@@ -402,7 +404,11 @@ public class CommonRequestHandler {
 
     // NOTE: not 'decrypt', as that is only one possible implementation of reversible tokenization
     String reverseTokenizedUrlComponents(String encodedURL) {
-        return pseudonymEncoder.decodeAndReverseAllContainedKeyedPseudonyms(encodedURL, reversibleTokenizationStrategy);
+        String result = pseudonymEncoder.decodeAndReverseAllContainedKeyedPseudonyms(encodedURL, reversibleTokenizationStrategy);
+
+        log.warning("Decoded URL: " + encodedURL + " to: " + result);
+
+        return result;
     }
 
     private void logIfDevelopmentMode(Supplier<String> messageSupplier) {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -412,8 +412,6 @@ public class CommonRequestHandler {
     String reverseTokenizedUrlComponents(String encodedURL) {
         String result = pseudonymEncoder.decodeAndReverseAllContainedKeyedPseudonyms(encodedURL, reversibleTokenizationStrategy);
 
-        log.warning("Decoded URL: " + encodedURL + " to: " + result);
-
         return result;
     }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -102,9 +102,6 @@ public class CommonRequestHandler {
             Pattern.compile(normalizeHeader("X-RateLimit.*"))
     );
 
-    @VisibleForTesting
-    volatile RESTApiSanitizer sanitizer;
-
     /**
      * <a href="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2">rfc7230</a>
      * "... A recipient MAY combine multiple header fields with the same field
@@ -113,6 +110,9 @@ public class CommonRequestHandler {
      * the combined field value in order, separated by a comma."
      */
     private static final Joiner HEADER_JOINER = Joiner.on(",");
+
+    @VisibleForTesting
+    volatile RESTApiSanitizer sanitizer;
 
     private final Object $writeLock = new Object[0];
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -102,6 +102,9 @@ public class CommonRequestHandler {
             Pattern.compile(normalizeHeader("X-RateLimit.*"))
     );
 
+    @VisibleForTesting
+    volatile RESTApiSanitizer sanitizer;
+
     /**
      * <a href="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2">rfc7230</a>
      * "... A recipient MAY combine multiple header fields with the same field
@@ -111,8 +114,6 @@ public class CommonRequestHandler {
      */
     private static final Joiner HEADER_JOINER = Joiner.on(",");
 
-
-    private volatile RESTApiSanitizer sanitizer;
     private final Object $writeLock = new Object[0];
 
     private RESTApiSanitizer loadSanitizerRules() {

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -124,7 +124,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     @Override
     public String sanitize(String httpMethod, URL url, String jsonResponse) {        //extra check ...
         if (!isAllowed(httpMethod, url)) {
-            throw new IllegalStateException(String.format("Sanitizer called to sanitize response that should not have been retrieved: %s", url.toString()));
+            throw new IllegalStateException(String.format("Sanitizer called to sanitize response that should not have been retrieved: %s", url));
         }
         if (StringUtils.isEmpty(jsonResponse)) {
             // Nothing to do

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -193,11 +193,13 @@ class CommonRequestHandlerTest {
         RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
 
         ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
-        doReturn(true).when(sanitizer).isAllowed(any(), urlArgumentCaptor.capture());
+        when(sanitizer.isAllowed(any(), urlArgumentCaptor.capture()))
+                .thenReturn(true);
 
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
         ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
-        doReturn(null).when(requestFactory).buildRequest(any(), targetUrlArgumentCaptor.capture(), any());
+        when(requestFactory.buildRequest(any(), targetUrlArgumentCaptor.capture(), any()))
+                .thenReturn(null);
 
         doReturn(requestFactory).when(spy).getRequestFactory(any());
 
@@ -236,11 +238,13 @@ class CommonRequestHandlerTest {
         RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
 
         ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
-        doReturn(true).when(sanitizer).isAllowed(any(), urlArgumentCaptor.capture());
+        when(sanitizer.isAllowed(any(), urlArgumentCaptor.capture()))
+                .thenReturn(true);
 
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
         ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
-        doReturn(null).when(requestFactory).buildRequest(any(), targetUrlArgumentCaptor.capture(), any());
+        when(requestFactory.buildRequest(any(), targetUrlArgumentCaptor.capture(), any()))
+                .thenReturn(null);
 
         doReturn(requestFactory).when(spy).getRequestFactory(any());
 

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -193,12 +193,13 @@ class CommonRequestHandlerTest {
         RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
 
         ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
-        when(sanitizer.isAllowed(any(), urlArgumentCaptor.capture()))
+        when(sanitizer.isAllowed(anyString(), any()))
                 .thenReturn(true);
 
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
+
         ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
-        when(requestFactory.buildRequest(any(), targetUrlArgumentCaptor.capture(), any()))
+        when(requestFactory.buildRequest(anyString(), any(), any()))
                 .thenReturn(null);
 
         doReturn(requestFactory).when(spy).getRequestFactory(any());
@@ -210,6 +211,9 @@ class CommonRequestHandlerTest {
         } catch (Exception ignored) {
             // it should raise an exception due missing configuration
         }
+
+        verify(sanitizer).isAllowed(anyString(), urlArgumentCaptor.capture());
+        verify(requestFactory).buildRequest(anyString(), targetUrlArgumentCaptor.capture(), any());
 
         // Sanitization should receive original URL requested
         assertEquals("https://google.apis.com/admin/directory/v1/users/" + encodedPseudonym + "?%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled",
@@ -238,12 +242,13 @@ class CommonRequestHandlerTest {
         RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
 
         ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
-        when(sanitizer.isAllowed(any(), urlArgumentCaptor.capture()))
+        when(sanitizer.isAllowed(anyString(), any()))
                 .thenReturn(true);
 
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
+
         ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
-        when(requestFactory.buildRequest(any(), targetUrlArgumentCaptor.capture(), any()))
+        when(requestFactory.buildRequest(anyString(), any(), any()))
                 .thenReturn(null);
 
         doReturn(requestFactory).when(spy).getRequestFactory(any());
@@ -255,6 +260,9 @@ class CommonRequestHandlerTest {
         } catch (Exception ignored) {
             // it should raise an exception due missing configuration
         }
+
+        verify(sanitizer).isAllowed(anyString(), urlArgumentCaptor.capture());
+        verify(requestFactory).buildRequest(anyString(), targetUrlArgumentCaptor.capture(), any());
 
         // Sanitization should receive original URL requested
         assertEquals("https://google.apis.com/admin/directory/v1/users/" + original + "?%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled",

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -1,12 +1,11 @@
 package co.worklytics.psoxy.gateway.impl;
 
-import co.worklytics.psoxy.ControlHeader;
-import co.worklytics.psoxy.Pseudonymizer;
-import co.worklytics.psoxy.PsoxyModule;
-import co.worklytics.psoxy.RESTApiSanitizer;
+import co.worklytics.psoxy.*;
+import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.HttpEventRequest;
 import co.worklytics.psoxy.gateway.HttpEventResponse;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
+import co.worklytics.psoxy.impl.RESTApiSanitizerImpl;
 import co.worklytics.psoxy.rules.RESTRules;
 import co.worklytics.psoxy.rules.google.PrebuiltSanitizerRules;
 import co.worklytics.test.MockModules;
@@ -190,17 +189,14 @@ class CommonRequestHandlerTest {
         when(request.getQuery())
                 .thenReturn(Optional.of("%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled"));
 
-        RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
-        doReturn(true).when(sanitizer).isAllowed(anyString(), any());
-        when(sanitizer.isAllowed(anyString(), any()))
-                .thenReturn(true);
-
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
         when(requestFactory.buildRequest(anyString(), any(), any()))
                 .thenReturn(null);
-
         doReturn(requestFactory).when(spy).getRequestFactory(any());
 
+        RESTApiSanitizerImpl sanitizer = mock(RESTApiSanitizerImpl.class);
+        when(sanitizer.isAllowed(anyString(), any()))
+                .thenReturn(true);
         spy.sanitizer = sanitizer;
 
         try {
@@ -239,15 +235,14 @@ class CommonRequestHandlerTest {
         when(request.getQuery())
                 .thenReturn(Optional.of("%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled"));
 
-        RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
-        when(sanitizer.isAllowed(anyString(), any()))
-                .thenReturn(true);
-
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
         when(requestFactory.buildRequest(anyString(), any(), any()))
                 .thenReturn(null);
-
         doReturn(requestFactory).when(spy).getRequestFactory(any());
+
+        RESTApiSanitizerImpl sanitizer = mock(RESTApiSanitizerImpl.class);
+        when(sanitizer.isAllowed(anyString(), any()))
+                .thenReturn(true);
 
         spy.sanitizer = sanitizer;
 

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -191,14 +191,11 @@ class CommonRequestHandlerTest {
                 .thenReturn(Optional.of("%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled"));
 
         RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
-
-        ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
+        doReturn(true).when(sanitizer).isAllowed(anyString(), any());
         when(sanitizer.isAllowed(anyString(), any()))
                 .thenReturn(true);
 
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
-
-        ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
         when(requestFactory.buildRequest(anyString(), any(), any()))
                 .thenReturn(null);
 
@@ -211,6 +208,9 @@ class CommonRequestHandlerTest {
         } catch (Exception ignored) {
             // it should raise an exception due missing configuration
         }
+
+        ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
+        ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
 
         verify(sanitizer).isAllowed(anyString(), urlArgumentCaptor.capture());
         verify(requestFactory).buildRequest(anyString(), targetUrlArgumentCaptor.capture(), any());
@@ -240,14 +240,10 @@ class CommonRequestHandlerTest {
                 .thenReturn(Optional.of("%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled"));
 
         RESTApiSanitizer sanitizer = mock(RESTApiSanitizer.class);
-
-        ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
         when(sanitizer.isAllowed(anyString(), any()))
                 .thenReturn(true);
 
         HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
-
-        ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
         when(requestFactory.buildRequest(anyString(), any(), any()))
                 .thenReturn(null);
 
@@ -260,6 +256,9 @@ class CommonRequestHandlerTest {
         } catch (Exception ignored) {
             // it should raise an exception due missing configuration
         }
+
+        ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
+        ArgumentCaptor<GenericUrl> targetUrlArgumentCaptor = ArgumentCaptor.forClass(GenericUrl.class);
 
         verify(sanitizer).isAllowed(anyString(), urlArgumentCaptor.capture());
         verify(requestFactory).buildRequest(anyString(), targetUrlArgumentCaptor.capture(), any());

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/EntraID_NoAppIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/EntraID_NoAppIds_Tests.java
@@ -127,6 +127,7 @@ public class EntraID_NoAppIds_Tests extends EntraIDTests {
     public Stream<InvocationExample> getExamples() {
         return Stream.of(
             InvocationExample.of("https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315/members?$count=true", "group-members.json"),
+            InvocationExample.of("https://graph.microsoft.com/v1.0/users/p~JuB1uFI_rtVS0Ygtc3m4uxhEiLI-6vn5ySKma20etlGvAJvlFOlnYuRejZSdIm5tmHzio-TdKzazWRwL50vNeFravJETR0l1WAvE219Jwug?%24select=proxyAddresses%2CotherMails%2ChireDate%2CisResourceAccount%2Cmail%2CemployeeId%2Cid%2CuserType%2CmailboxSettings%2CaccountEnabled", "user.json"),
             InvocationExample.of("https://graph.microsoft.com/v1.0/users/p~12398123012312", "user.json"),
             InvocationExample.of("https://graph.microsoft.com/v1.0/users", "users.json")
         );

--- a/java/core/src/test/java/co/worklytics/test/TestUtils.java
+++ b/java/core/src/test/java/co/worklytics/test/TestUtils.java
@@ -1,10 +1,12 @@
 package co.worklytics.test;
 
+import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 
+import javax.crypto.spec.SecretKeySpec;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -116,5 +118,9 @@ public class TestUtils {
         String expectedJson = expected.replaceAll("\n", ",");
 
         assertEquals(expected, actual);
+    }
+
+    public static SecretKeySpec testKey() {
+        return AESReversibleTokenizationStrategy.aesKeyFromPassword("secret", "salt");
     }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -24,7 +24,7 @@
         <dependency.google-http-client.version>1.43.3</dependency.google-http-client.version>
         <dependency.google-auth-library-oauth2-http.version>1.18.0</dependency.google-auth-library-oauth2-http.version>
         <dependency.junit-jupiter.version>5.10.1</dependency.junit-jupiter.version>
-        <dependency.mockito-junit-jupiter.version>5.7.0</dependency.mockito-junit-jupiter.version>
+        <dependency.mockito-junit-jupiter.version>5.12.0</dependency.mockito-junit-jupiter.version>
         <dependency.json-path.version>2.8.0</dependency.json-path.version>
         <dependency.bettercloud-vault-java-driver>5.1.0</dependency.bettercloud-vault-java-driver>
     </properties>


### PR DESCRIPTION
When the request URL includes a token, the *reversed* URL was using to check in rules check and sanitization instead of the original one.

For example, following URL `/v1.0/users/p~something/items` needs to be reversed as `/v1.0/users/12345/items` as *p~something* is decoded to *12345*. That is the URL used to against the actual source, but if rules are like MSFT/GAAPS where is the pseudonym app id flag is enabled, the regex could contain that it expects the token *p~...*  in the URL. In such case, the reversed url is not going to match the rules, generating blocking by rules error for valid URLs.

### Fixes
[MSFT: Full representation blocked by psoxy rules](https://app.asana.com/0/1206952473261039/1207122031251555)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
