### PR TITLE
BYO msft connector app

### DIFF
--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -35,6 +35,8 @@ module "worklytics_connectors" {
   github_organization              = var.github_organization
   github_example_repository        = var.github_example_repository
   salesforce_example_account_id    = var.salesforce_example_account_id
+  todos_as_local_files             = var.todos_as_local_files
+  todo_step                        = 1
 }
 
 # sources which require additional dependencies are split into distinct Terraform files, following

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -133,6 +133,7 @@ module "psoxy" {
   custom_bulk_connector_rules          = var.custom_bulk_connector_rules
   custom_bulk_connector_arguments      = var.custom_bulk_connector_arguments
   todo_step                            = local.max_auth_todo_step
+  todos_as_local_files                 = var.todos_as_local_files
 
 
   #  vpc_config = {
@@ -157,15 +158,16 @@ module "connection_in_worklytics" {
   source = "../../modules/worklytics-psoxy-connection-aws"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.56"
 
-  psoxy_instance_id  = each.key
-  worklytics_host    = var.worklytics_host
-  aws_region         = var.aws_region
-  aws_role_arn       = module.psoxy.caller_role_arn
-  psoxy_endpoint_url = try(each.value.endpoint_url, null)
-  bucket_name        = try(each.value.sanitized_bucket, null)
-  connector_id       = try(local.all_connectors[each.key].worklytics_connector_id, "")
-  display_name       = try(local.all_connectors[each.key].worklytics_connector_name, "${local.all_connectors[each.key].display_name} via Psoxy")
-  todo_step          = module.psoxy.next_todo_step
+  psoxy_instance_id    = each.key
+  worklytics_host      = var.worklytics_host
+  aws_region           = var.aws_region
+  aws_role_arn         = module.psoxy.caller_role_arn
+  psoxy_endpoint_url   = try(each.value.endpoint_url, null)
+  bucket_name          = try(each.value.sanitized_bucket, null)
+  connector_id         = try(local.all_connectors[each.key].worklytics_connector_id, "")
+  display_name         = try(local.all_connectors[each.key].worklytics_connector_name, "${local.all_connectors[each.key].display_name} via Psoxy")
+  todo_step            = module.psoxy.next_todo_step
+  todos_as_local_files = var.todos_as_local_files
 
   connector_settings_to_provide = try(each.value.settings_to_provide, {})
 

--- a/infra/examples-dev/aws-all/msft-365-variables.tf
+++ b/infra/examples-dev/aws-all/msft-365-variables.tf
@@ -7,8 +7,14 @@ variable "msft_tenant_id" {
 
 variable "msft_owners_email" {
   type        = set(string)
-  description = "(Only if config includes MSFT connectors). Optionally, set of emails to apply as owners on AAD apps apart from current logged user"
+  description = "(Only if config includes MSFT connectors). Optionally, set of emails to apply as owners on AAD apps apart from current logged user. Ignored if `existing_app_object_id` provided."
   default     = []
+}
+
+variable "msft_connector_app_object_id" {
+  type        = string
+  description = "BETA; if provided, the app corresponding to this object id will be used instead of creating new ones per source. User must ensure that roles/scopes are appropriate for the connector"
+  default     = null
 }
 
 variable "example_msft_user_guid" {

--- a/infra/examples-dev/aws-all/msft-365.tf
+++ b/infra/examples-dev/aws-all/msft-365.tf
@@ -4,7 +4,6 @@ module "worklytics_connectors_msft_365" {
   source = "../../modules/worklytics-connectors-msft-365"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=v0.4.56"
 
-
   enabled_connectors                  = var.enabled_connectors
   environment_id                      = var.environment_name
   msft_tenant_id                      = var.msft_tenant_id
@@ -15,6 +14,7 @@ module "worklytics_connectors_msft_365" {
   msft_teams_example_chat_guid        = var.msft_teams_example_chat_guid
   msft_teams_example_call_guid        = var.msft_teams_example_call_guid
   msft_teams_example_call_record_guid = var.msft_teams_example_call_record_guid
+  msft_connector_app_object_id        = var.msft_connector_app_object_id
   todos_as_local_files                = var.todos_as_local_files
   todo_step                           = 1
 }

--- a/infra/examples-dev/gcp/msft-365-variables.tf
+++ b/infra/examples-dev/gcp/msft-365-variables.tf
@@ -7,8 +7,14 @@ variable "msft_tenant_id" {
 
 variable "msft_owners_email" {
   type        = set(string)
-  description = "(Only if config includes MSFT connectors). Optionally, set of emails to apply as owners on AAD apps apart from current logged user"
+  description = "(Only if config includes MSFT connectors). Optionally, set of emails to apply as owners on AAD apps apart from current logged user. Ignored if `existing_app_object_id` provided."
   default     = []
+}
+
+variable "msft_connector_app_object_id" {
+  type        = string
+  description = "BETA; if provided, the app corresponding to this object id will be used instead of creating new ones per source. User must ensure that roles/scopes are appropriate for the connector"
+  default     = null
 }
 
 variable "example_msft_user_guid" {

--- a/infra/examples-dev/gcp/msft-365.tf
+++ b/infra/examples-dev/gcp/msft-365.tf
@@ -4,7 +4,6 @@ module "worklytics_connectors_msft_365" {
   source = "../../modules/worklytics-connectors-msft-365"
   # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=v0.4.56"
 
-
   enabled_connectors                  = var.enabled_connectors
   environment_id                      = var.environment_name
   msft_tenant_id                      = var.msft_tenant_id
@@ -15,6 +14,7 @@ module "worklytics_connectors_msft_365" {
   msft_teams_example_chat_guid        = var.msft_teams_example_chat_guid
   msft_teams_example_call_guid        = var.msft_teams_example_call_guid
   msft_teams_example_call_record_guid = var.msft_teams_example_call_record_guid
+  msft_connector_app_object_id        = var.msft_connector_app_object_id
   todos_as_local_files                = var.todos_as_local_files
   todo_step                           = 1
 }

--- a/infra/modules/azuread-connection/main.tf
+++ b/infra/modules/azuread-connection/main.tf
@@ -60,5 +60,9 @@ resource "azuread_application" "connector" {
 }
 
 output "connector" {
-  value = azuread_application.connector
+  value = merge(azuread_application.connector,
+    # ensure client_id is filled, even for older versions of Azure AD provider
+    {
+      client_id = try(azuread_application.connector.client_id, azuread_application.connector.application_id)
+    })
 }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -370,9 +370,9 @@ Connect-MicrosoftTeams
 ```
 
 4. Follow steps on [Configure application access to online meetings or virtual events](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy):
-  - Add a policy for the application created for the connector, providing its `application id`
+  - Add a policy for the application created for the connector, providing its `application id` (client ID)
 ```shell
-New-CsApplicationAccessPolicy -Identity Teams-Policy-For-Worklytics -AppIds "%%entraid.application_id%%" -Description "Policy for MSFT Teams used for Worklytics Psoxy connector"
+New-CsApplicationAccessPolicy -Identity Teams-Policy-For-Worklytics -AppIds "%%entraid.client_id%%" -Description "Policy for MSFT Teams used for Worklytics Psoxy connector"
 ```
   - Grant the policy to the whole tenant (NOT to any specific application or user)
 ```shell

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -211,7 +211,8 @@ locals {
         GRANT_TYPE : "workload_identity_federation" # by default, assumed to be of type 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
         TOKEN_SCOPE : "https://graph.microsoft.com/.default"
         REFRESH_ENDPOINT = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
-      },
+      }
+      external_todo : null
       example_api_calls : [
         "/v1.0/users",
         "/v1.0/users/${var.example_msft_user_guid}",
@@ -228,7 +229,7 @@ locals {
       identifier_scope_id : "azure-ad"
       source_auth_strategy : "oauth2_refresh_token"
       target_host : "graph.microsoft.com"
-      required_oauth2_permission_scopes : [],
+      required_oauth2_permission_scopes : []
       # Delegated permissions (from `az ad sp list --query "[?appDisplayName=='Microsoft Graph'].oauth2Permissions" --all`)
       required_app_roles : [
         # Application permissions (form az ad sp list --query "[?appDisplayName=='Microsoft Graph'].appRoles" --all
@@ -239,7 +240,8 @@ locals {
         GRANT_TYPE : "workload_identity_federation" # by default, assumed to be of type 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
         TOKEN_SCOPE : "https://graph.microsoft.com/.default"
         REFRESH_ENDPOINT = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
-      },
+      }
+      external_todo : null
       example_api_calls : [
         "/v1.0/users",
         "/v1.0/users/${var.example_msft_user_guid}",
@@ -256,7 +258,7 @@ locals {
       identifier_scope_id : "azure-ad"
       source_auth_strategy : "oauth2_refresh_token"
       target_host : "graph.microsoft.com"
-      required_oauth2_permission_scopes : [],
+      required_oauth2_permission_scopes : []
       required_app_roles : [
         "OnlineMeetings.Read.All",
         "OnlineMeetingArtifact.Read.All",
@@ -270,6 +272,7 @@ locals {
         TOKEN_SCOPE : "https://graph.microsoft.com/.default"
         REFRESH_ENDPOINT = "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
       },
+      external_todo : null
       example_api_calls : [
         "/v1.0/users",
         "/v1.0/users/${var.example_msft_user_guid}/events",
@@ -288,19 +291,20 @@ locals {
       identifier_scope_id : "azure-ad"
       source_auth_strategy : "oauth2_refresh_token"
       target_host : "graph.microsoft.com"
-      required_oauth2_permission_scopes : [],
+      required_oauth2_permission_scopes : []
       required_app_roles : [
         "Mail.ReadBasic.All",
         "MailboxSettings.Read",
         "Group.Read.All",
         "User.Read.All"
-      ],
+      ]
       environment_variables : {
         GRANT_TYPE : "workload_identity_federation"
         # by default, assumed to be of type 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
         TOKEN_SCOPE : "https://graph.microsoft.com/.default"
         REFRESH_ENDPOINT : "https://login.microsoftonline.com/${var.msft_tenant_id}/oauth2/v2.0/token"
       }
+      external_todo : null
       example_api_calls : [
         "/v1.0/users",
         "/v1.0/users/${var.example_msft_user_guid}/mailboxSettings",
@@ -311,7 +315,7 @@ locals {
     },
     "msft-teams" : {
       source_kind : "msft-teams"
-      availability : "ga",
+      availability : "beta",
       enable_by_default : false,
       worklytics_connector_id : "msft-teams-psoxy",
       display_name : "Microsoft Teams"
@@ -348,7 +352,7 @@ locals {
         "/v1.0/communications/callRecords/getPstnCalls(fromDateTime=${urlencode(timeadd(time_static.deployment.id, "-2160h"))},toDateTime=${urlencode(time_static.deployment.id)})",
         "/v1.0/users/${var.example_msft_user_guid}/onlineMeetings"
       ]
-      external_token_todo : <<EOT
+      external_todo : <<EOT
 To enable the connector, you need to allow permissions on the application created for reading OnlineMeetings. You will need Powershell for this.
 
 Please follow the steps below:

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -22,7 +22,7 @@ module "worklytics_connector_specs" {
 }
 
 locals {
-  provision_entraid_apps = var.existing_app_object_id == null
+  provision_entraid_apps = var.msft_connector_app_object_id == null
   connectors_needing_apps = local.provision_entraid_apps ? module.worklytics_connector_specs.enabled_msft_365_connectors : {}
 }
 
@@ -55,9 +55,9 @@ module "msft_connection" {
 # if an existing app object id is provided, use it as a shared app for ALL MSFT connectors
 # (requires that it has the superset of permissions required by all connectors)
 data "azuread_application" "existing_connector_app" {
-  count = var.existing_app_object_id == null ? 0 : 1
+  count = var.msft_connector_app_object_id == null ? 0 : 1
 
-  object_id = var.existing_app_object_id
+  object_id = var.msft_connector_app_object_id
 }
 
 

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -70,7 +70,7 @@ module "msft_365_grants" {
   source = "../../modules/azuread-grant-all-users"
 
   psoxy_instance_id        = each.key
-  application_id           = module.msft_connection[each.key].connector.application_id
+  application_id           = module.msft_connection[each.key].connector.client_id
   oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
   app_roles                = each.value.required_app_roles
   application_name         = each.key
@@ -95,8 +95,8 @@ ${ module.msft_365_grants[each.key].todo}
 ## Setup
 Then, please follow next instructions to complete the setup:
 
-${replace(each.value.external_token_todo, "%%entraid.application_id%%",
-    try(module.msft_connection[each.key].connector.application_id, data.azuread_application.existing_connector_app[0].application_id))}
+${replace(each.value.external_token_todo, "%%entraid.client_id%%",
+    try(module.msft_connection[each.key].connector.client_id, data.azuread_application.existing_connector_app[0].client_id))}
 EOT
 }
 
@@ -106,7 +106,7 @@ locals {
     k => merge(v, {
       connector = try(module.msft_connection[k].connector, data.azuread_application.existing_connector_app[0])
       environment_variables = merge(v.environment_variables, {
-        CLIENT_ID = try(module.msft_connection[k].connector.application_id, data.azuread_application.existing_connector_app[0].application_id)
+        CLIENT_ID = try(module.msft_connection[k].connector.client_id, data.azuread_application.existing_connector_app[0].client_id)
       })
     })
   }

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -78,6 +78,22 @@ module "msft_365_grants" {
   todo_step                = var.todo_step
 }
 
+module "msft_365_grant_to_shared" {
+  count = local.provision_entraid_apps ? 0 : 1
+
+  source = "../../modules/azuread-grant-all-users"
+
+  psoxy_instance_id        = "msft-365"
+  application_id           = data.azuread_application.existing_connector_app[0].client_id
+  oauth2_permission_scopes = data.azuread_application.existing_connector_app[0].api[0].oauth2_permission_scopes[*].admin_consent_display_name
+  # TODO: this is a list of GUIDs, so not very user-friendly
+  app_roles                = flatten([for id in [ for k, v in data.azuread_application.existing_connector_app[0].required_resource_access[*].resource_access[*] : v[*].id ] : id[*] ])
+  application_name         = data.azuread_application.existing_connector_app[0].display_name
+  todos_as_local_files     = var.todos_as_local_files
+  todo_step                = var.todo_step
+}
+
+
 # NOTE: this OVERWRITES the todo_file created by the azuread-grant-all-users module, if there's an
 # external_token_todo to append to that file
 locals {

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -22,19 +22,24 @@ module "worklytics_connector_specs" {
 }
 
 locals {
-  todos_to_populate = { for k, v in module.worklytics_connector_specs.enabled_msft_365_connectors : k => v if try(v.external_token_todo != null, false) && var.todos_as_local_files }
+  provision_entraid_apps = var.existing_app_object_id == null
+  connectors_needing_apps = local.provision_entraid_apps ? module.worklytics_connector_specs.enabled_msft_365_connectors : {}
 }
 
 data "azuread_client_config" "current" {
+  count = local.provision_entraid_apps ? 1 : 0
 
 }
 
 data "azuread_users" "owners" {
+  count = local.provision_entraid_apps && length(var.msft_owners_email) > 0 ? 1 : 0
+
   user_principal_names = var.msft_owners_email
 }
 
+
 module "msft_connection" {
-  for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
+  for_each = local.connectors_needing_apps
 
   source = "../../modules/azuread-connection"
 
@@ -42,16 +47,25 @@ module "msft_connection" {
   tenant_id                         = var.msft_tenant_id
   required_app_roles                = each.value.required_app_roles
   required_oauth2_permission_scopes = each.value.required_oauth2_permission_scopes
-  owners = toset(concat(data.azuread_users.owners.object_ids, [
-    data.azuread_client_config.current.object_id
+  owners = toset(concat(data.azuread_users.owners[0].object_ids, [
+    data.azuread_client_config.current[0].object_id
   ]))
 }
+
+# if an existing app object id is provided, use it as a shared app for ALL MSFT connectors
+# (requires that it has the superset of permissions required by all connectors)
+data "azuread_application" "existing_connector_app" {
+  count = var.existing_app_object_id == null ? 0 : 1
+
+  object_id = var.existing_app_object_id
+}
+
 
 # grant required permissions to connectors via Azure AD
 # (requires terraform configuration being applied by an Azure User with privileges to do this; it
 #  usually requires a 'Global Administrator' for your tenant)
 module "msft_365_grants" {
-  for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
+  for_each = local.connectors_needing_apps
 
   source = "../../modules/azuread-grant-all-users"
 
@@ -64,20 +78,35 @@ module "msft_365_grants" {
   todo_step                = var.todo_step
 }
 
+# NOTE: this OVERWRITES the todo_file created by the azuread-grant-all-users module, if there's an
+# external_token_todo to append to that file
+locals {
+  todos_to_populate = { for k, v in module.worklytics_connector_specs.enabled_msft_365_connectors :
+    k => v if try(v.external_token_todo != null, false) && var.todos_as_local_files
+  }
+}
+
 resource "local_file" "todo-with-external-todo" {
   for_each = local.todos_to_populate
 
   filename = module.msft_365_grants[each.key].filename
-  content  = format("%s\n## Setup\nThen, please follow next instructions for complete the setup: \n\n%s", module.msft_365_grants[each.key].todo, replace(each.value.external_token_todo, "%%entraid.application_id%%", module.msft_connection[each.key].connector.application_id))
+  content  = <<EOT
+${ module.msft_365_grants[each.key].todo}
+## Setup
+Then, please follow next instructions to complete the setup:
+
+${replace(each.value.external_token_todo, "%%entraid.application_id%%",
+    try(module.msft_connection[each.key].connector.application_id, data.azuread_application.existing_connector_app[0].application_id))}
+EOT
 }
 
 locals {
   enabled_api_connectors = {
     for k, v in module.worklytics_connector_specs.enabled_msft_365_connectors :
     k => merge(v, {
-      connector = module.msft_connection[k].connector
+      connector = try(module.msft_connection[k].connector, data.azuread_application.existing_connector_app[0])
       environment_variables = merge(v.environment_variables, {
-        CLIENT_ID = module.msft_connection[k].connector.application_id
+        CLIENT_ID = try(module.msft_connection[k].connector.application_id, data.azuread_application.existing_connector_app[0].application_id)
       })
     })
   }

--- a/infra/modules/worklytics-connectors-msft-365/migration_0_4_56.tf
+++ b/infra/modules/worklytics-connectors-msft-365/migration_0_4_56.tf
@@ -1,0 +1,10 @@
+
+moved {
+  from = data.azuread_users.owners
+  to   = data.azuread_users.owners[0]
+}
+
+moved {
+  from = data.azuread_client_config.current
+  to   = data.azuread_client_config.current[0]
+}

--- a/infra/modules/worklytics-connectors-msft-365/outputs.tf
+++ b/infra/modules/worklytics-connectors-msft-365/outputs.tf
@@ -35,8 +35,8 @@ output "api_clients" {
   value = {
     for id, connection in module.msft_connection :
     id => {
-      azuread_application_id = connection.connector.application_id
-      oauth_client_id        = connection.connector.application_id # yes, it's same as application id; but duplicated for clarity
+      azuread_application_id = connection.connector.client_id
+      oauth_client_id        = connection.connector.client_id # yes, it's same as application id; but duplicated for clarity
       azuread_object_id      = connection.connector.object_id      # used for terraform imports
     }
   }

--- a/infra/modules/worklytics-connectors-msft-365/variables.tf
+++ b/infra/modules/worklytics-connectors-msft-365/variables.tf
@@ -58,9 +58,16 @@ variable "msft_teams_example_call_record_guid" {
 
 variable "msft_owners_email" {
   type        = set(string)
-  description = "(Only if config includes MSFT connectors). Optionally, set of emails to apply as owners on AAD apps apart from current logged user"
+  description = "(Only if config includes MSFT connectors). Optionally, set of emails to apply as owners on AAD apps apart from current logged user. Ignored if `existing_app_object_id` provided."
   default     = []
 }
+
+variable "existing_app_object_id" {
+  type        = string
+  description = "BETA; if provided, the app corresponding to this object id will be used instead of creating new ones per source. User must ensure that roles/scopes are appropriate for the connector"
+  default     = null
+}
+
 
 variable "todos_as_local_files" {
   type        = bool

--- a/infra/modules/worklytics-connectors-msft-365/variables.tf
+++ b/infra/modules/worklytics-connectors-msft-365/variables.tf
@@ -62,12 +62,11 @@ variable "msft_owners_email" {
   default     = []
 }
 
-variable "existing_app_object_id" {
+variable "msft_connector_app_object_id" {
   type        = string
   description = "BETA; if provided, the app corresponding to this object id will be used instead of creating new ones per source. User must ensure that roles/scopes are appropriate for the connector"
   default     = null
 }
-
 
 variable "todos_as_local_files" {
   type        = bool


### PR DESCRIPTION
alternative to #740 - think this is a better approach, fewer conditional resources; simpler.

### Features
 - support customers bring a single Microsoft App listing provisioned outside of terraform, instead of provisioning one per source with our terraform modules

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes**
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **moves some msft components; may churn some TODO files**