### PR TITLE
document scopes per-connector for MSFT sources 

### DIFF
--- a/docs/sources/microsoft-365/entra-id/README.md
+++ b/docs/sources/microsoft-365/entra-id/README.md
@@ -1,15 +1,39 @@
 # Entra ID
 
-## Examples
+Connect to Directory data in Microsoft 365. This allows enumeration of all users, groups, and group
+members in your organization, to provide additional segmentation, timezone/workday information, etc.
 
-- [Example Rules](entra-id.yaml)
-- [Example Rules: no App IDs](entra-id_no-app-ids.yaml)
-- [Example Rules: no App IDs, no orig](entra-id_no-app-ids_no-orig.yaml)
-- Example Data:
-  - [original/group-members.json](example-api-responses/original/group-members.json) |
-    [sanitized/group-members.json](example-api-responses/sanitized/group-members.json)
-  - [original/users.json](example-api-responses/original/users.json) |
-    [sanitized/users.json](example-api-responses/sanitized/users.json)
+## Required Scopes
+- [`User.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+- [`Group.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+
+## Authentication
+
+See the [Microsoft 365 Authentication](../README.md#authentication) section of the main README.
+
+## Authorization
+
+See the [Microsoft 365 Authorization](../README.md#authorization) section of the main README.
+
+## Example Data
+
+| API Endpoint | Example Response                                                             | Sanitized Example Response |
+| --- |------------------------------------------------------------------------------| --- |
+| `/v1.0/groups/{group-id}/members` | [original/group-members.json](example-api-responses/original/group-members.json) | [sanitized/group-members.json](example-api-responses/sanitized/group-members.json) |
+| `/v1.0/users` | [original/users.json](example-api-responses/original/users.json)             | [sanitized/users.json](example-api-responses/sanitized/users.json) |
+| `/v1.0/users/me` | [original/user.json](example-api-responses/original/user.json)              | [sanitized/user.json](example-api-responses/sanitized/user.json) |
+| `/v1.0/groups` | [original/groups.json](example-api-responses/original/groups.json)          | [sanitized/groups.json](example-api-responses/sanitized/groups.json) |
+
+
+Assuming proxy is auth'd as an application, you'll have to replace `me` with your MSFT ID or
+`UserPrincipalName` (often your email address).
 
 See more examples in the `docs/sources/microsoft-365/entra-id/example-api-responses` folder
 of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+
+## Sanitization Rule Examples
+
+- [Default Rules](entra-id.yaml)
+- [Rules, pseudonymizing MSFT account IDs](entra-id_no-app-ids.yaml)
+- [Rules, pseudonimizing MSFT account IDs](entra-id_no-app-ids_no-orig.yaml)
+

--- a/docs/sources/microsoft-365/entra-id/README.md
+++ b/docs/sources/microsoft-365/entra-id/README.md
@@ -35,5 +35,5 @@ of the [Psoxy repository](https://github.com/Worklytics/psoxy).
 
 - [Default Rules](entra-id.yaml)
 - [Rules, pseudonymizing MSFT account IDs](entra-id_no-app-ids.yaml)
-- [Rules, pseudonimizing MSFT account IDs](entra-id_no-app-ids_no-orig.yaml)
+- [Rules, pseudonymizing MSFT account IDs](entra-id_no-app-ids_no-orig.yaml)
 

--- a/docs/sources/microsoft-365/example-api-calls.md
+++ b/docs/sources/microsoft-365/example-api-calls.md
@@ -2,30 +2,6 @@
 
 Example test commands that you can use to validate proxy behavior against various source APIs.
 
-## Directory
-
-Assuming proxy is auth'd as an application, you'll have to replace `me` with your MSFT ID or
-UserPrincipalName (often your email address).
-
-```
-/v1.0/users
-/v1.0/users/me
-/v1.0/groups
-/v1.0/groups/{groupId}
-/v1.0/groups/{groupId}/members?$count=true
-```
-
-## Calendar
-
-Assuming proxy is auth'd as an application, you'll have to replace `me` with your MSFT ID or
-UserPrincipalName (often your email address).
-
-```
-/v1.0/users/me/events
-/v1.0/users/me/calendars
-/v1.0/users/me/events/{eventId}
-/v1.0/users/me/mailboxSettings
-```
 
 ## Mail
 

--- a/docs/sources/microsoft-365/msft-teams/README.md
+++ b/docs/sources/microsoft-365/msft-teams/README.md
@@ -1,6 +1,6 @@
 # Microsoft Teams
 
-Connect Micorosft Teams data to Worklytics, enabling communication analysis and general collaboration
+Connect Microsoft Teams data to Worklytics, enabling communication analysis and general collaboration
 insights based on collaboration via Micorosft Teams. Includes user enumeration to support fetching
 mailboxes from each account; and group enumeration to expand emails via mailing list (groups).
 

--- a/docs/sources/microsoft-365/msft-teams/README.md
+++ b/docs/sources/microsoft-365/msft-teams/README.md
@@ -1,4 +1,4 @@
-# Micorosft Teams
+# Microsoft Teams
 
 Connect Micorosft Teams data to Worklytics, enabling communication analysis and general collaboration
 insights based on collaboration via Micorosft Teams. Includes user enumeration to support fetching

--- a/docs/sources/microsoft-365/msft-teams/README.md
+++ b/docs/sources/microsoft-365/msft-teams/README.md
@@ -1,14 +1,42 @@
-# MSFT Teams
+# Micorosft Teams
 
-## Examples
+Connect Micorosft Teams data to Worklytics, enabling communication analysis and general collaboration
+insights based on collaboration via Micorosft Teams. Includes user enumeration to support fetching
+mailboxes from each account; and group enumeration to expand emails via mailing list (groups).
+
+## Required Scopes
+- [`User.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+- [`Team.ReadBasic.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#teamreadbasicall)
+- [`Channel.ReadBasic.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#channelreadbasicall)
+- [`Chat.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#chatreadbasicall)
+- [`ChannelMessage.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#channelmessagereadall)
+- [`CallRecords.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#callrecordsreadall)
+- [`OnlineMeetings.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#onlinemeetingsreadall)
+
+## Authentication
+
+See the [Microsoft 365 Authentication](../README.md#authentication) section of the main README.
+
+## Authorization
+
+See the [Microsoft 365 Authorization](../README.md#authorization) section of the main README.
+
+## Example Data
+
+| API Endpoint                        | Example Response                                                                                               | Sanitized Example Response                                                                     |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `/v1.0/teams`                       | [original/Teams_v1.0.json](example-api-responses/original/Teams_v1.0.json)                                     | [sanitized/Teams_v1.0.json](example-api-responses/sanitized/Teams_v1.0.json)                   |
+| `/v1.0/teams/{teamId}/allChannels`  | [original/Teams_allChannels_v1.0.json](example-api-responses/original/Teams_allChannels_v1.0.json)             | [sanitized/Teams_allChannels_v1.0.json](example-api-responses/sanitized/Teams_allChannels_v1.0.json) |
+| `/v1.0/teams/{teamId}/channels/{channelId}/messages` | [original/Teams_channels_messages_v1.0.json](example-api-responses/original/Teams_channels_messages_v1.0.json) | [sanitized/Teams_channels_messages_v1.0.json](example-api-responses/sanitized/Teams_channels_messages_v1.0.json) |
+| `/v1.0/users/{userId}/chats`        | [original/Chats_messages_v1.0.json](example-api-responses/original/Chats_messages_v1.0.json)                   | [sanitized/Chats_messages_v1.0.json](example-api-responses/sanitized/Chats_messages_v1.0.json) |
+| `/v1.0/users/{userId}/onlineMeetings` | [original/Users_onlineMeetings_v1.0.json](example-api-responses/original/Users_onlineMeetings_v1.0.json)       | [sanitized/Users_onlineMeetings_v1.0.json](example-api-responses/sanitized/Users_onlineMeetings_v1.0.json) |
+|
+See more examples in the `docs/sources/microsoft-365/msft-teams/example-api-responses` folder
+of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+
+## Example Rules
 
 - [Example Rules](msft-teams.yaml)
 - [Example Rules: no User IDs](msft-teams_no-userIds.yaml)
-- Example Data:
-  - [original/Teams_v1.0.json](example-api-responses/original/Teams_v1.0.json) |
-    [sanitized/Teams_v1.0.json](example-api-responses/sanitized/Teams_v1.0.json)
-  - [original/Chats_messages_v1.0.json](example-api-responses/original/Chats_messages_v1.0.json) |
-    [sanitized/Chats_messages_v1.0.json](example-api-responses/sanitized/Chats_messages_v1.0.json)
 
-See more examples in the `docs/sources/microsoft-365/msft-teams/example-api-responses` folder
-of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+

--- a/docs/sources/microsoft-365/msft-teams/README.md
+++ b/docs/sources/microsoft-365/msft-teams/README.md
@@ -1,7 +1,7 @@
 # Microsoft Teams
 
 Connect Microsoft Teams data to Worklytics, enabling communication analysis and general collaboration
-insights based on collaboration via Micorosft Teams. Includes user enumeration to support fetching
+insights based on collaboration via Microsoft Teams. Includes user enumeration to support fetching
 mailboxes from each account; and group enumeration to expand emails via mailing list (groups).
 
 ## Required Scopes

--- a/docs/sources/microsoft-365/outlook-cal/README.md
+++ b/docs/sources/microsoft-365/outlook-cal/README.md
@@ -1,15 +1,44 @@
 # Outlook Calendar
 
+Connect Outlook Calendar data to Worklytics, enabling meeting analysis and general collaboration
+insights based on collaboration via Outlook Calendar. Includes user enumeration to support fetching
+calendars from each account; and group enumeration to expand attendance/invitations to meetings
+via mailing list (groups).
+
+## Required Scopes
+- [`User.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+- [`Group.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+- [`Calendars.Read`](https://learn.microsoft.com/en-us/graph/permissions-reference#calendarsread)
+- [`MailboxSettings.Read`](https://learn.microsoft.com/en-us/graph/permissions-reference#mailboxsettingsread)
+- [`OnlineMeetings.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#onlinemeetingsreadall)
+
+## Authentication
+
+See the [Microsoft 365 Authentication](../README.md#authentication) section of the main README.
+
+## Authorization
+
+See the [Microsoft 365 Authorization](../README.md#authorization) section of the main README.
+
+
+## Example Data
+
+| API Endpoint                     | Example Response                                                                           | Sanitized Example Response                                                                     |
+|----------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `/v1.0/me/events`                | [original/Events_v1.0.json](example-api-responses/original/Events_v1.0.json)               | [sanitized/Events_v1.0.json](example-api-responses/sanitized/Events_v1.0.json)                 |
+| `/v1.0/me/events/{eventId}`      | [original/Event_v1.0.json](example-api-responses/original/Event_v1.0.json)                 | [sanitized/Event_v1.0.json](example-api-responses/sanitized/Event_v1.0.json)                   |
+| `/v1.0/me/calendar/calendarView` | [original/CalendarView_v1.0.json](example-api-responses/original/CalendarView_v1.0.json) | [sanitized/CalendarView_v1.0.json](example-api-responses/sanitized/CalendarView_v1.0.json) |
+| `/v1.0/me/calendar/events`       | [original/CalendarEvents_v1.0.json](example-api-responses/original/CalendarEvents_v1.0.json) | [sanitized/CalendarEvents_v1.0.json](example-api-responses/sanitized/CalendarEvents_v1.0.json) |
+
+Assuming proxy is auth'd as an application, you'll have to replace `me` with your MSFT ID or
+`UserPrincipalName` (often your email address).
+
+See more examples in the `docs/sources/microsoft-365/msft-teams/example-api-responses` folder
+of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+
 ## Examples
 
 - [Example Rules](outlook-cal.yaml)
 - [Example Rules: no App IDs](outlook-cal_no-app-ids.yaml)
 - [Example Rules: no App IDs, no groups](outlook-cal_no-app-ids_no-groups.yaml)
-- Example Data:
-  - [original/Event_v1.0.json](example-api-responses/original/Event_v1.0.json) |
-    [sanitized/Event_v1.0.json](example-api-responses/sanitized/Event_v1.0.json)
-  - [original/CalendarEvents_v1.0.json](example-api-responses/original/CalendarEvents_v1.0.json) |
-    [sanitized/CalendarEvents_v1.0.json](example-api-responses/sanitized/CalendarEvents_v1.0.json)
 
-See more examples in the `docs/sources/microsoft-365/msft-teams/example-api-responses` folder
-of the [Psoxy repository](https://github.com/Worklytics/psoxy).

--- a/docs/sources/microsoft-365/outlook-mail/README.md
+++ b/docs/sources/microsoft-365/outlook-mail/README.md
@@ -1,15 +1,39 @@
 # Outlook Mail
 
+Connect Outlook Mail data to Worklytics, enabling communication analysis and general collaboration
+insights based on collaboration via Outlook Mail. Includes user enumeration to support fetching
+mailboxes from each account; and group enumeration to expand emails via mailing list (groups).
+
+## Required Scopes
+- [`User.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+- [`Group.Read.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#userreadall)
+- [`MailboxSettings.Read`](https://learn.microsoft.com/en-us/graph/permissions-reference#mailboxsettingsread)
+- [`Mail.ReadBasic.All`](https://learn.microsoft.com/en-us/graph/permissions-reference#mailreadbasicall)
+
+## Authentication
+
+See the [Microsoft 365 Authentication](../README.md#authentication) section of the main README.
+
+## Authorization
+
+See the [Microsoft 365 Authorization](../README.md#authorization) section of the main README.
+
+## Example Data
+
+| API Endpoint                     | Example Response                                                                           | Sanitized Example Response                                                                     |
+|----------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `/v1.0/me/mailFolders/SentItems/messages` | [original/Messages_SentItems_v1.0.json](example-api-responses/original/Messages_SentItems_v1.0.json) | [sanitized/Messages_SentItems_v1.0.json](example-api-responses/sanitized/Messages_SentItems_v1.0.json) |
+| `/v1.0/me/messages/{messageId}`      | [original/Message_v1.0.json](example-api-responses/original/Message_v1.0.json)                 | [sanitized/Message_v1.0.json](example-api-responses/sanitized/Message_v1.0.json)                   |
+| `/v1.0/me/mailboxSettings` | [original/MailboxSettings_v1.0.json](example-api-responses/original/MailboxSettings_v1.0.json) | [sanitized/MailboxSettings_v1.0.json](example-api-responses/sanitized/MailboxSettings_v1.0.json) |
+
+Assuming proxy is auth'd as an application, you'll have to replace `me` with your MSFT ID or
+`UserPrincipalName` (often your email address).
+
+See more examples in the `docs/sources/microsoft-365/msft-teams/example-api-responses` folder
+of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+
 ## Examples
 
 - [Example Rules](outlook-mail.yaml)
 - [Example Rules: no App IDs](outlook-mail_no-app-ids.yaml)
 - [Example Rules: no App IDs, no groups](outlook-mail_no-app-ids_no-groups.yaml)
-- Example Data:
-  - [original/Messages_SentItems_v1.0.json](example-api-responses/original/Messages_SentItems_v1.0.json) |
-    [sanitized/Messages_SentItems_v1.0.json](example-api-responses/sanitized/Messages_SentItems_v1.0.json)
-  - [original/Message_v1.0.json](example-api-responses/original/Message_v1.0.json) |
-    [sanitized/Message_v1.0.json](example-api-responses/sanitized/Message_v1.0.json)
-
-See more examples in the `docs/sources/microsoft-365/msft-teams/example-api-responses` folder
-of the [Psoxy repository](https://github.com/Worklytics/psoxy).


### PR DESCRIPTION
### Features
 - add per-connector docs of required scopes.

This was rather tedious, I'm worried difficult to maintain; will see how Data Inventory project turns out, and probably refer customers to that (built programmatically) - than try to have this directly in proxy docs.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**