### PR TITLE
gcp functions-framework-api as provided dep

### DIFF
--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -96,6 +96,7 @@
             <groupId>com.google.cloud.functions</groupId>
             <artifactId>functions-framework-api</artifactId>
             <version>1.0.4</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**this does NOT work, although unclear it's for reasons related to this change**

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
