### PR TITLE
fix gcp build with latest maven

### DIFF
--- a/java/impl/gcp/check-grpc-services.sh
+++ b/java/impl/gcp/check-grpc-services.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# helper script to quickly check the gRPC services in a jar file, which seems to be root cause
+# of the gRPC issue in the cloud function
+
+# determine the jar file to check
+VERSION=$1
+JAR_FILE=target/psoxy-gcp-${VERSION}.jar
+
+BLUE='\e[34m'
+NC='\e[0m' # No Color
+
+printf "Checking grpc load balancer services in jar file: ${BLUE}${JAR_FILE}${NC}\n"
+printf " (as of 2024-07-10, good one contains 3 files, including 'io.grpc.internal.PickFirstLoadBalancerProvider')\n"
+jar xf $JAR_FILE META-INF/services/io.grpc.LoadBalancerProvider
+
+cat META-INF/services/io.grpc.LoadBalancerProvider
+rm -rf META-INF

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -177,6 +177,7 @@
             <!-- produces an 'uber' JAR, with all deps pkg'd -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -246,7 +247,7 @@
 
             <!-- add license plugin -->
             <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
-                 dependencies, to facillitate eventual distribution of built JAR -->
+                 dependencies, to facilitate eventual distribution of built JAR -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -177,7 +177,7 @@
             <!-- produces an 'uber' JAR, with all deps pkg'd -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version> <!-- 3.7.0, 3.7.1 don't work; 3.7.1 is default as of mvn 3.9.8 ... -->
+                <version>3.7.1</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -177,16 +177,16 @@
             <!-- produces an 'uber' JAR, with all deps pkg'd -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.0</version> <!-- 3.7.0, 3.7.1 don't work; 3.7.1 is default as of mvn 3.9.8 ... -->
                 <configuration>
                     <archive>
                         <manifest>
                             <mainClass>co.worklytics.psoxy.Route</mainClass>
                         </manifest>
                     </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+                    <descriptors>
+                        <descriptor>uber-jar.xml</descriptor>
+                    </descriptors>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>

--- a/java/impl/gcp/uber-jar.xml
+++ b/java/impl/gcp/uber-jar.xml
@@ -1,0 +1,25 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+
+    <id>uber-jar</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+    <!-- above from https://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#jar-with-dependencies -->
+    <!-- what we need is below, to merge all the META-INF/services files -->
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+</assembly>


### PR DESCRIPTION
### Fixes
 - GCP build gets incorrect services if built with latest Maven (3.9.8); caused by them changing the default version of `maven-assembly-plugin` from 3.6.0 to 3.7.1; with root cause being that we were depending on race-behavior of that plugin. Specifically, that it was copying over META-INF/services files one-by-one into the uber JAR, with the last one to arrive winning if name conflict. It so happened that an OK one won in 3.6.0 for us, but not with 3.7.x.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
