### PR TITLE
update gcp deps 

### DIFF
--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -171,12 +171,12 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = coalesce(var.available_memory_mb, 1024)
   source_archive_bucket = var.artifacts_bucket_name
   source_archive_object = var.deployment_bundle_object_name
-  docker_repository     = var.artifact_repository_id
   entry_point           = "co.worklytics.psoxy.GCSFileEvent"
   service_account_email = google_service_account.service_account.email
   timeout               = 540 # 9 minutes, which is gen1 max allowed
   labels                = var.default_labels
-  docker_registry       = "CONTAINER_REGISTRY"
+  docker_registry       = "ARTIFACT_REGISTRY"
+  docker_repository     = var.artifact_repository_id
 
   environment_variables = merge(tomap({
     INPUT_BUCKET  = google_storage_bucket.input_bucket.name,

--- a/java/impl/cmd-line/pom.xml
+++ b/java/impl/cmd-line/pom.xml
@@ -20,7 +20,7 @@
         <dependencies>
             <dependency>
                 <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-bom</artifactId>
+                <artifactId>libraries-bom</artifactId>
                 <version>${dependency.google-cloud-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -96,6 +96,7 @@
             <groupId>com.google.cloud.functions</groupId>
             <artifactId>functions-framework-api</artifactId>
             <version>1.1.0</version> <!-- June 2023 - https://mvnrepository.com/artifact/com.google.cloud.functions/functions-framework-api -->
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -160,7 +160,7 @@
                 -->
                 <groupId>com.google.cloud.functions</groupId>
                 <artifactId>function-maven-plugin</artifactId>
-                <version>0.9.7</version>
+                <version>0.11.0</version> <!-- 2023-07 -->
                 <configuration>
                     <functionTarget>co.worklytics.psoxy.Route</functionTarget>
 

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>${google-libraries-bom.version}</version>
+                <version>${dependency.google-cloud-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -154,6 +154,8 @@
 
                   mvn function:run -Drun.functionTarget=your.package.yourFunction
 
+                  eg, mvn function:run -Drun.functionTarget=co.worklytics.psoxy.Route
+
                   NOTE: intellij deploy run config doesn't work the first time. you should run the
                   `gcloud functions deploy` cmd once interactively, and follow the prompt to confirm
                   that you wish to block unauthenticated connections

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -95,6 +95,8 @@
         <dependency>
             <groupId>com.google.cloud.functions</groupId>
             <artifactId>functions-framework-api</artifactId>
+            <!-- NOTE: does NOT appear to be available in the google-libraries-bom -->
+            <!-- does not appear to have any dependencies on other Google libraries -->
             <version>1.1.0</version> <!-- June 2023 - https://mvnrepository.com/artifact/com.google.cloud.functions/functions-framework-api -->
             <scope>provided</scope>
         </dependency>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -21,7 +21,7 @@
         <!-- serviceAccount that function will run as. For Google Workspace use cases, should be the
          one configured as OAuth Client and authorized for your instance. -->
         <serviceAccount>psoxy-gmail-dwd@psoxy-dev-erik.iam.gserviceaccount.com</serviceAccount>
-        <google-libraries-bom.version>26.42.0</google-libraries-bom.version>
+        <google-libraries-bom.version>${dependency.google-cloud-bom.version}</google-libraries-bom.version>
     </properties>
 
     <repositories>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -21,7 +21,7 @@
         <!-- serviceAccount that function will run as. For Google Workspace use cases, should be the
          one configured as OAuth Client and authorized for your instance. -->
         <serviceAccount>psoxy-gmail-dwd@psoxy-dev-erik.iam.gserviceaccount.com</serviceAccount>
-        <google-libraries-bom.version>26.1.4</google-libraries-bom.version>
+        <google-libraries-bom.version>26.42.0</google-libraries-bom.version>
     </properties>
 
     <repositories>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.google.cloud.functions</groupId>
             <artifactId>functions-framework-api</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.0</version> <!-- June 2023 - https://mvnrepository.com/artifact/com.google.cloud.functions/functions-framework-api -->
         </dependency>
 
         <dependency>

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/Route.java
@@ -1,6 +1,5 @@
 package co.worklytics.psoxy;
 
-import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.HttpEventResponse;
 import co.worklytics.psoxy.gateway.impl.CommonRequestHandler;
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
         <dependency.guava.version>32.0.1-jre</dependency.guava.version>
         <dependency.commons-io.version>2.13.0</dependency.commons-io.version>
         <dependency.apache-httpcore.version>5.2.2</dependency.apache-httpcore.version>
-        <dependency.google-cloud-bom.version>0.198.0</dependency.google-cloud-bom.version>
+        <dependency.google-cloud-bom.version>26.42.0</dependency.google-cloud-bom.version>
         <dependency.google-http-client.version>1.43.3</dependency.google-http-client.version>
         <dependency.google-auth-library-oauth2-http.version>1.18.0</dependency.google-auth-library-oauth2-http.version>
         <dependency.junit-jupiter.version>5.10.1</dependency.junit-jupiter.version>


### PR DESCRIPTION
### Features
 - update GCP deps, including BOM; unifying BOM between gcp and cmd-line implementations, and Cloud Functions FW/plugin
 - force `ARTIFACT_REGISTRY` for bulk case (already done in API case)

### Change implications

 - dependencies added/changed? **yes**
 - something important to note in future release notes? **yes; swap ARTIFACT_REGISTRY for CONTAINER_REGISTRY**
