### PR TITLE
Get default owners

### DIFF
--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -32,7 +32,7 @@ data "azuread_client_config" "current" {
 }
 
 data "azuread_users" "owners" {
-  count = local.provision_entraid_apps && length(var.msft_owners_email) > 0 ? 1 : 0
+  count = local.provision_entraid_apps ? 1 : 0
 
   user_principal_names = var.msft_owners_email
 }


### PR DESCRIPTION
If `msft_owners_email` is not populated (leaving empty, as default), `data.azuread_users` wasn't executed, causing an error (see in the ticket)

### Fixes
[Cannot get default owners in MSFT Entra Id apps](https://app.asana.com/0/1201039336231823/1207785655059382)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
