### PR TITLE
java17 runtimes by default

### DIFF
--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -44,7 +44,7 @@ resource "aws_lambda_function" "instance" {
   function_name                  = local.function_name
   role                           = aws_iam_role.iam_for_lambda.arn
   architectures                  = ["arm64"] # 20% cheaper per ms exec time than x86_64
-  runtime                        = "java11"
+  runtime                        = "java17"
   filename                       = local.bundle_from_s3 ? null : var.path_to_function_zip
   s3_bucket                      = local.s3_bucket # null if local file
   s3_key                         = local.s3_key    # null if local file

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -164,7 +164,7 @@ resource "google_service_account_iam_member" "act_as" {
 resource "google_cloudfunctions_function" "function" {
   name        = local.function_name
   description = "Psoxy instance to process ${var.source_kind} files"
-  runtime     = "java11"
+  runtime     = "java17"
   project     = var.project_id
   region      = var.region
 

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -58,7 +58,7 @@ resource "google_service_account_iam_member" "act_as" {
 resource "google_cloudfunctions_function" "function" {
   name        = "${var.environment_id_prefix}${var.instance_id}"
   description = "Psoxy Connector - ${var.source_kind}"
-  runtime     = "java11"
+  runtime     = "java17"
   project     = var.project_id
   region      = var.region
 


### PR DESCRIPTION
### Features
 - [java17 runtimes by default](https://app.asana.com/0/1201039336231823/1207783492196045)

NOTE: this does NOT change source code or byte code java versions - both still target to java 11.  So for clarity, this means we write java 11 code, which will be compiled to java 11 bytecode (using any JDK >= 11), which will be run by a java 17 JRE.


main driver of this is GCP, which is deprecating java11 runtime in Sept 2024; and generally doesn't maintain the java11 containers as robustly as the java17 ones.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **terraform apply will show `java11` --> `java17` runtime change**