### PR TITLE
add explicit deny of non-SSL s3 actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Changes to be including in future/planned release notes will be added here.
 
 ## Next
 
+
+## [0.4.58](https://github.com/Worklytics/psoxy/release/tag/v0.4.58)
+- AWS-only: added SIDs to IAM policies for clarity; and added additional statements to
+  S3 policies to explicitly deny non-SSL operations
+
+
 ## [0.4.57](https://github.com/Worklytics/psoxy/release/tag/v0.4.57)
 Several changes in this version will result in visible changes during `terraform plan`/`apply`:
 - Permission changes on Microsoft 365:

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -154,11 +154,28 @@ resource "aws_iam_policy" "input_bucket_getObject_policy" {
       "Version" : "2012-10-17",
       "Statement" : [
         {
+          "Sid": "AllowObjectRead"
           "Action" : [
             "s3:GetObject"
           ],
           "Effect" : "Allow",
           "Resource" : "${aws_s3_bucket.input.arn}/*"
+        },
+        {
+          "Sid": "DenyNonSSLActions",
+          "Action" : [
+            "s3:*"
+          ],
+          "Effect" : "Deny",
+          "Resource" : [
+            "${aws_s3_bucket.input.arn}",
+            "${aws_s3_bucket.input.arn}/*"
+          ],
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "false"
+            }
+          }
         }
       ]
   })
@@ -185,11 +202,28 @@ resource "aws_iam_policy" "sanitized_bucket_write_policy" {
       "Version" : "2012-10-17",
       "Statement" : [
         {
+          "Sid": "AllowObjectWrite",
           "Action" : [
             "s3:PutObject",
           ],
           "Effect" : "Allow",
           "Resource" : "${aws_s3_bucket.sanitized.arn}/*"
+        },
+        {
+          "Sid": "DenyNonSSLActions",
+          "Action" : [
+            "s3:*"
+          ],
+          "Effect" : "Deny",
+          "Resource" : [
+            "${aws_s3_bucket.sanitized.arn}",
+            "${aws_s3_bucket.sanitized.arn}/*"
+          ],
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "false"
+            }
+          }
         }
       ]
   })

--- a/infra/modules/aws-psoxy-output-bucket/main.tf
+++ b/infra/modules/aws-psoxy-output-bucket/main.tf
@@ -72,6 +72,7 @@ resource "aws_iam_policy" "sanitized_bucket_read" {
       "Version" : "2012-10-17",
       "Statement" : [
         {
+          "Sid": "AllowRead"
           "Action" : [
             "s3:GetObject",
             "s3:ListBucket"


### PR DESCRIPTION
customer request .. but dismissing as 1) easy for them to compose into terraform config if they wish, 2) this kind of thing is better done as a blanket, global policy - rather than sprinkling these denials throughout a bunch of policies.

### Features
  - add explicit deny statements to S3 policies for non-SSL actions

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207791014624267