### PR TITLE
drop basic exec policy from caller role 

### DIFF
--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -103,11 +103,6 @@ resource "aws_iam_policy" "execution_lambda_to_caller" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "invoker_lambda_execution" {
-  role       = aws_iam_role.api-caller.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
 resource "aws_iam_role_policy_attachment" "invoker_url_lambda_execution" {
   count = var.use_api_gateway_v2 ? 0 : 1
 


### PR DESCRIPTION
### Fixes
 - lambda basic exec role is effectively just logging perms, not needed - as lambdas have their own exec rules with those perms

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes - will see role attachment being destroyed**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206355928380269