### PR TITLE
Slack huddles support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changes to be including in future/planned release notes will be added here.
 
 ## Next
 
+## [0.4.58](https://github.com/Worklytics/psoxy/release/tag/v0.4.58)
+ - Including rules for Slack Huddles through *Rooms* as part of conversation history endpoint
+
 ## [0.4.57](https://github.com/Worklytics/psoxy/release/tag/v0.4.57)
 Several changes in this version will result in visible changes during `terraform plan`/`apply`:
 - Permission changes on Microsoft 365:

--- a/docs/sources/slack/discovery.yaml
+++ b/docs/sources/slack/discovery.yaml
@@ -52,7 +52,6 @@ endpoints:
           - "$.messages[*].edited.user"
           - "$.messages[*].blocks[*].elements[*].elements[*].user_id"
           - "$.messages[*].room.created_by"
-          - "$.messages[*].room.participants[*]"
           - "$.messages[*].room.participant_history[*]"
         encoding: "JSON"
       - !<redact>
@@ -63,4 +62,4 @@ endpoints:
           - "$.messages[*].attachments[*]['fallback','service_name', 'thumb_url','thumb_width','thumb_height']"
           - "$.messages[*].files[*]['thumb_url','thumb_width','thumb_height','thumb_tiny']"
           - "$.messages[*].room.media_backend_type"
-          - "$.messages[*].room..['name','media_server','attached_file_ids','participants_events','participants_camera_on','participants_camera_off','participants_screenshare_on','participants_screenshare_off','pending_invitees','last_invite_status_by_user','knocks']"
+          - "$.messages[*].room..['name','media_server','attached_file_ids','participants','participants_events','participants_camera_on','participants_camera_off','participants_screenshare_on','participants_screenshare_off','pending_invitees','last_invite_status_by_user','knocks']"

--- a/docs/sources/slack/discovery.yaml
+++ b/docs/sources/slack/discovery.yaml
@@ -51,6 +51,9 @@ endpoints:
           - "$.messages[*].reply_users[*]"
           - "$.messages[*].edited.user"
           - "$.messages[*].blocks[*].elements[*].elements[*].user_id"
+          - "$.messages[*].room.created_by"
+          - "$.messages[*].room.participants[*]"
+          - "$.messages[*].room.participant_history[*]"
         encoding: "JSON"
       - !<redact>
         jsonPaths:
@@ -59,3 +62,5 @@ endpoints:
           - "$.messages[*].user_profile"
           - "$.messages[*].attachments[*]['fallback','service_name', 'thumb_url','thumb_width','thumb_height']"
           - "$.messages[*].files[*]['thumb_url','thumb_width','thumb_height','thumb_tiny']"
+          - "$.messages[*].room.media_backend_type"
+          - "$.messages[*].room..['name','media_server','attached_file_ids','participants_events','participants_camera_on','participants_camera_off','participants_screenshare_on','participants_screenshare_off','pending_invitees','last_invite_status_by_user','knocks']"

--- a/docs/sources/slack/example-api-responses/original/discovery-conversations-history.json
+++ b/docs/sources/slack/example-api-responses/original/discovery-conversations-history.json
@@ -196,6 +196,106 @@
           ]
         }
       ]
+    },
+    {
+      "user": "USLACKBOT",
+      "channel": "D075J2RKK4Y",
+      "room": {
+        "id": "R07BNSQTZSP",
+        "name": "huddle test topic",
+        "media_server": "",
+        "created_by": "U02K5LRARED",
+        "date_start": 1720542372,
+        "date_end": 1720542756,
+        "participants": [],
+        "participant_history": [
+          "U02K5LRARED",
+          "U074XMEDGUU"
+        ],
+        "participants_events": {
+          "U02K5LRARED": {
+            "user_team": {},
+            "joined": true,
+            "camera_on": false,
+            "camera_off": false,
+            "screenshare_on": true,
+            "screenshare_off": true
+          },
+          "U074XMEDGUU": {
+            "user_team": {},
+            "joined": true,
+            "camera_on": false,
+            "camera_off": false,
+            "screenshare_on": false,
+            "screenshare_off": false
+          },
+          "U060ZTHGQ2H": {
+            "user_team": {},
+            "joined": false,
+            "camera_on": false,
+            "camera_off": false,
+            "screenshare_on": false,
+            "screenshare_off": false
+          }
+        },
+        "participants_camera_on": [],
+        "participants_camera_off": [],
+        "participants_screenshare_on": [],
+        "participants_screenshare_off": [],
+        "canvas_thread_ts": "1720542372.566689",
+        "thread_root_ts": "1720542372.566689",
+        "channels": [
+          "D075J2RKK4Y"
+        ],
+        "is_dm_call": true,
+        "was_rejected": false,
+        "was_missed": false,
+        "was_accepted": true,
+        "has_ended": true,
+        "background_id": "GRADIENT_03",
+        "canvas_background": "GRADIENT_03",
+        "is_prewarmed": false,
+        "is_scheduled": false,
+        "attached_file_ids": [],
+        "media_backend_type": "free_willy",
+        "display_id": "",
+        "external_unique_id": "b88ef6b8-9450-4633-83a2-dfb2cfd12713",
+        "app_id": "A00",
+        "call_family": "huddle",
+        "pending_invitees": {},
+        "last_invite_status_by_user": {
+          "U060ZTHGQ2H": "expired",
+          "U074XMEDGUU": "accepted"
+        },
+        "knocks": {}
+      },
+      "no_notifications": true,
+      "permalink": "https://some-company.enterprise.slack.com/call/R07BNSQTZSP",
+      "subtype": "huddle_thread",
+      "type": "message",
+      "ts": "1720542372.566689",
+      "edited": {
+        "user": "USLACKBOT",
+        "ts": "1720542757.000000"
+      },
+      "text": "",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "UoEcF",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "A huddle started"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "offset": "1463084600.000000"

--- a/docs/sources/slack/example-api-responses/sanitized/discovery-conversations-history.json
+++ b/docs/sources/slack/example-api-responses/sanitized/discovery-conversations-history.json
@@ -182,7 +182,6 @@
         "created_by":"{\"scope\":\"slack\",\"hash\":\"ht3jIZhCUKqR7UVboNfpxTZZUWLoExaW1WX6GG19JVg\"}",
         "date_start":1720542372,
         "date_end":1720542756,
-        "participants":[ ],
         "participant_history":[
           "{\"scope\":\"slack\",\"hash\":\"ht3jIZhCUKqR7UVboNfpxTZZUWLoExaW1WX6GG19JVg\"}",
           "{\"scope\":\"slack\",\"hash\":\"C35tSgm0FijTntSB1kSz4RzerO3J58n-H3rwI7A0698\"}"

--- a/docs/sources/slack/example-api-responses/sanitized/discovery-conversations-history.json
+++ b/docs/sources/slack/example-api-responses/sanitized/discovery-conversations-history.json
@@ -173,6 +173,64 @@
           ]
         }
       ]
+    },
+    {
+      "user":"{\"scope\":\"slack\",\"hash\":\"BMW33akERx6B1jg4ktZ3Q6lh18zJptJ0zYoRgqcjdxU\"}",
+      "channel":"D075J2RKK4Y",
+      "room":{
+        "id":"R07BNSQTZSP",
+        "created_by":"{\"scope\":\"slack\",\"hash\":\"ht3jIZhCUKqR7UVboNfpxTZZUWLoExaW1WX6GG19JVg\"}",
+        "date_start":1720542372,
+        "date_end":1720542756,
+        "participants":[ ],
+        "participant_history":[
+          "{\"scope\":\"slack\",\"hash\":\"ht3jIZhCUKqR7UVboNfpxTZZUWLoExaW1WX6GG19JVg\"}",
+          "{\"scope\":\"slack\",\"hash\":\"C35tSgm0FijTntSB1kSz4RzerO3J58n-H3rwI7A0698\"}"
+        ],
+        "canvas_thread_ts":"1720542372.566689",
+        "thread_root_ts":"1720542372.566689",
+        "channels":[
+          "D075J2RKK4Y"
+        ],
+        "is_dm_call":true,
+        "was_rejected":false,
+        "was_missed":false,
+        "was_accepted":true,
+        "has_ended":true,
+        "background_id":"GRADIENT_03",
+        "canvas_background":"GRADIENT_03",
+        "is_prewarmed":false,
+        "is_scheduled":false,
+        "attached_file_ids":[ ],
+        "display_id":"",
+        "external_unique_id":"b88ef6b8-9450-4633-83a2-dfb2cfd12713",
+        "app_id":"A00",
+        "call_family":"huddle"
+      },
+      "no_notifications":true,
+      "subtype":"huddle_thread",
+      "type":"message",
+      "ts":"1720542372.566689",
+      "edited":{
+        "user":"{\"scope\":\"slack\",\"hash\":\"BMW33akERx6B1jg4ktZ3Q6lh18zJptJ0zYoRgqcjdxU\"}",
+        "ts":"1720542757.000000"
+      },
+      "blocks":[
+        {
+          "type":"rich_text",
+          "block_id":"UoEcF",
+          "elements":[
+            {
+              "type":"rich_text_section",
+              "elements":[
+                {
+                  "type":"text"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "offset":"1463084600.000000"

--- a/docs/sources/slack/example-api-responses/sanitized/discovery-conversations-history.json
+++ b/docs/sources/slack/example-api-responses/sanitized/discovery-conversations-history.json
@@ -201,7 +201,6 @@
         "canvas_background":"GRADIENT_03",
         "is_prewarmed":false,
         "is_scheduled":false,
-        "attached_file_ids":[ ],
         "display_id":"",
         "external_unique_id":"b88ef6b8-9450-4633-83a2-dfb2cfd12713",
         "app_id":"A00",

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -7,95 +7,112 @@ import com.avaulta.gateway.rules.transforms.Transform;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+
 /**
  * Prebuilt sanitization rules for Slack Discovery API responses
  */
 public class PrebuiltSanitizerRules {
 
     static final RESTRules SLACK = Rules2.builder()
-        .endpoint(Endpoint.builder()
-            .pathTemplate("/api/discovery.enterprise.info")
-            .transform(Transform.Redact.builder()
-                // we don't care about names
-                .jsonPath("$.enterprise.teams[*]['name','description','icon','enterprise_name']")
-                .jsonPath("$.enterprise['icon','name']")
-                .build())
-            .build())
-        .endpoint(Endpoint.builder()
-            .pathTemplate("/api/discovery.users.list")
-            .transform(Transform.Pseudonymize.builder()
-                .jsonPath("$.users[*].id")
-                .jsonPath("$.users[*].profile.email")
-                .jsonPath("$.users[*].profile.guest_invited_by")
-                .build())
-            .transform(Transform.Redact.builder()
-                // we don't care about names
-                .jsonPath("$.users[*]['name','real_name']")
-                // profile contains a lot of stuff. We just mainly need "email" and "team". clean it up
-                // TODO: ideally this is a whitelist
-                .jsonPath("$.users[*].profile['title','phone','skype','first_name','last_name','real_name','real_name_normalized','display_name','display_name_normalized']")
-                .jsonPath("$.users[*].profile['fields','pronouns','status_text','status_emoji','status_emoji_display_info','status_expiration','avatar_hash']")
-                .jsonPath("$.users[*].profile['image_original','is_custom_image','image_24','image_32','image_48','image_72','image_192','image_512','image_1024','status_text_canonical']")
-                .build())
-            .build())
-        .endpoint(Endpoint.builder()
-            .pathTemplate("/api/discovery.conversations.list")
-            // no PII
-            // redact channel name, topic and purpose
-            .transform(Transform.Redact.builder()
-                // we don't care about names
-                // topic and purpose contains user ids, not used at all, so just get rid of the entire content
-                .jsonPath("$.channels[*]['name','topic','purpose']")
-                .build())
-            .build())
-        .endpoint(Endpoint.builder()
-            .pathTemplate("/api/discovery.conversations.recent")
-            // no PII
-            // redact channel name, topic and purpose
-            .transform(Transform.Redact.builder()
-                // we don't care about names
-                // topic and purpose contains user ids, not used at all, so just get rid of the entire content
-                .jsonPath("$.channels[*]['name','topic','purpose']")
-                .build())
-            .build())
-        .endpoint(Endpoint.builder()
-            .pathTemplate("/api/discovery.conversations.info")
-            .transform(Transform.Pseudonymize.builder()
-                .jsonPath("$.info[*].creator")
-                .build())
-            .transform(Transform.Redact.builder()
-                // we don't care about names
-                // topic and purpose contains user ids, not used at all, so just get rid of the entire content
-                .jsonPath("$.info[*]['name','name_normalized','previous_names','topic','purpose']")
-                .build())
-            .build())
-        .endpoint(Endpoint.builder()
-            .pathTemplate("/api/discovery.conversations.history")
-            .transform(Transform.Pseudonymize.builder()
-                .jsonPath("$.messages[*].user")
-                .jsonPath("$.messages[*].files[*].user")
-                .jsonPath("$.messages[*].reactions[*].users[*]")
-                .jsonPath("$.messages[*].replies[*].user")
-                .jsonPath("$.messages[*].replies[*].parent_user_id")
-                .jsonPath("$.messages[*].reply_users[*]")
-                .jsonPath("$.messages[*].edited.user")
-                .jsonPath("$.messages[*].blocks[*].elements[*].elements[*].user_id") // mentions in rich blocks
-                .build())
-            .transform(Transform.Redact.builder()
-                // we don't care about text
-                // username is a variation of user, so just skip it to avoid references
-                .jsonPath("$.messages[*]['text','username','permalink']")
-                .jsonPath("$.messages[*]..['text']")
-                .jsonPath("$.messages[*].user_profile")
-                // Thumbnails name or url may reveal content
-                .jsonPath("$.messages[*].attachments[*]['fallback','service_name', 'thumb_url','thumb_width','thumb_height']")
-                .jsonPath("$.messages[*].files[*]['thumb_url','thumb_width','thumb_height','thumb_tiny']")
-                .build())
-            .build())
-        .build();
+            .endpoint(Endpoint.builder()
+                    .pathTemplate("/api/discovery.enterprise.info")
+                    .transform(Transform.Redact.builder()
+                            // we don't care about names
+                            .jsonPath("$.enterprise.teams[*]['name','description','icon','enterprise_name']")
+                            .jsonPath("$.enterprise['icon','name']")
+                            .build())
+                    .build())
+            .endpoint(Endpoint.builder()
+                    .pathTemplate("/api/discovery.users.list")
+                    .transform(Transform.Pseudonymize.builder()
+                            .jsonPath("$.users[*].id")
+                            .jsonPath("$.users[*].profile.email")
+                            .jsonPath("$.users[*].profile.guest_invited_by")
+                            .build())
+                    .transform(Transform.Redact.builder()
+                            // we don't care about names
+                            .jsonPath("$.users[*]['name','real_name']")
+                            // profile contains a lot of stuff. We just mainly need "email" and "team". clean it up
+                            // TODO: ideally this is a whitelist
+                            .jsonPath("$.users[*].profile['title','phone','skype','first_name','last_name','real_name','real_name_normalized','display_name','display_name_normalized']")
+                            .jsonPath("$.users[*].profile['fields','pronouns','status_text','status_emoji','status_emoji_display_info','status_expiration','avatar_hash']")
+                            .jsonPath("$.users[*].profile['image_original','is_custom_image','image_24','image_32','image_48','image_72','image_192','image_512','image_1024','status_text_canonical']")
+                            .build())
+                    .build())
+            .endpoint(Endpoint.builder()
+                    .pathTemplate("/api/discovery.conversations.list")
+                    // no PII
+                    // redact channel name, topic and purpose
+                    .transform(Transform.Redact.builder()
+                            // we don't care about names
+                            // topic and purpose contains user ids, not used at all, so just get rid of the entire content
+                            .jsonPath("$.channels[*]['name','topic','purpose']")
+                            .build())
+                    .build())
+            .endpoint(Endpoint.builder()
+                    .pathTemplate("/api/discovery.conversations.recent")
+                    // no PII
+                    // redact channel name, topic and purpose
+                    .transform(Transform.Redact.builder()
+                            // we don't care about names
+                            // topic and purpose contains user ids, not used at all, so just get rid of the entire content
+                            .jsonPath("$.channels[*]['name','topic','purpose']")
+                            .build())
+                    .build())
+            .endpoint(Endpoint.builder()
+                    .pathTemplate("/api/discovery.conversations.info")
+                    .transform(Transform.Pseudonymize.builder()
+                            .jsonPath("$.info[*].creator")
+                            .build())
+                    .transform(Transform.Redact.builder()
+                            // we don't care about names
+                            // topic and purpose contains user ids, not used at all, so just get rid of the entire content
+                            .jsonPath("$.info[*]['name','name_normalized','previous_names','topic','purpose']")
+                            .build())
+                    .build())
+            .endpoint(Endpoint.builder()
+                    .pathTemplate("/api/discovery.conversations.history")
+                    .transform(Transform.Pseudonymize.builder()
+                            .jsonPath("$.messages[*].user")
+                            .jsonPath("$.messages[*].files[*].user")
+                            .jsonPath("$.messages[*].reactions[*].users[*]")
+                            .jsonPath("$.messages[*].replies[*].user")
+                            .jsonPath("$.messages[*].replies[*].parent_user_id")
+                            .jsonPath("$.messages[*].reply_users[*]")
+                            .jsonPath("$.messages[*].edited.user")
+                            .jsonPath("$.messages[*].blocks[*].elements[*].elements[*].user_id") // mentions in rich blocks
+                            .jsonPath("$.messages[*].room.created_by")
+                            .jsonPath("$.messages[*].room.participants[*]")
+                            .jsonPath("$.messages[*].room.participant_history[*]")
+                            .build())
+                    .transform(Transform.Redact.builder()
+                            // we don't care about text
+                            // username is a variation of user, so just skip it to avoid references
+                            .jsonPath("$.messages[*]['text','username','permalink']")
+                            .jsonPath("$.messages[*]..['text']")
+                            .jsonPath("$.messages[*].user_profile")
+                            // Thumbnails name or url may reveal content
+                            .jsonPath("$.messages[*].attachments[*]['fallback','service_name', 'thumb_url','thumb_width','thumb_height']")
+                            .jsonPath("$.messages[*].files[*]['thumb_url','thumb_width','thumb_height','thumb_tiny']")
+                            .jsonPath("$.messages[*].room.media_backend_type")
+                            .jsonPath("$.messages[*].room.name")
+                            .jsonPath("$.messages[*].room.media_server")
+                            .jsonPath("$.messages[*].room.attached_file_ids[*]")
+                            // This will be break JSON structure with pseudonymization
+                            .jsonPath("$.messages[*].room.participants_events")
+                            .jsonPath("$.messages[*].room.participants_camera_on")
+                            .jsonPath("$.messages[*].room.participants_camera_off")
+                            .jsonPath("$.messages[*].room.participants_screenshare_on")
+                            .jsonPath("$.messages[*].room.participants_screenshare_off")
+                            .jsonPath("$.messages[*].room.pending_invitees")
+                            .jsonPath("$.messages[*].room.last_invite_status_by_user")
+                            .jsonPath("$.messages[*].room.knocks")
+                            .build())
+                    .build())
+            .build();
 
     static public final Map<String, RESTRules> SLACK_DEFAULT_RULES_MAP =
-        ImmutableMap.<String, RESTRules>builder()
-        .put("slack", SLACK)
-        .build();
+            ImmutableMap.<String, RESTRules>builder()
+                    .put("slack", SLACK)
+                    .build();
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -82,7 +82,6 @@ public class PrebuiltSanitizerRules {
                             .jsonPath("$.messages[*].edited.user")
                             .jsonPath("$.messages[*].blocks[*].elements[*].elements[*].user_id") // mentions in rich blocks
                             .jsonPath("$.messages[*].room.created_by")
-                            .jsonPath("$.messages[*].room.participants[*]")
                             .jsonPath("$.messages[*].room.participant_history[*]")
                             .build())
                     .transform(Transform.Redact.builder()
@@ -96,7 +95,7 @@ public class PrebuiltSanitizerRules {
                             .jsonPath("$.messages[*].files[*]['thumb_url','thumb_width','thumb_height','thumb_tiny']")
                             .jsonPath("$.messages[*].room.media_backend_type")
                             // This will be break JSON structure with pseudonymization, so redact it
-                            .jsonPath("$.messages[*].room..['name','media_server','attached_file_ids','participants_events','participants_camera_on','participants_camera_off','participants_screenshare_on','participants_screenshare_off','pending_invitees','last_invite_status_by_user','knocks']")
+                            .jsonPath("$.messages[*].room..['name','media_server','attached_file_ids','participants','participants_events','participants_camera_on','participants_camera_off','participants_screenshare_on','participants_screenshare_off','pending_invitees','last_invite_status_by_user','knocks']")
                             .build())
                     .build())
             .build();

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -95,18 +95,8 @@ public class PrebuiltSanitizerRules {
                             .jsonPath("$.messages[*].attachments[*]['fallback','service_name', 'thumb_url','thumb_width','thumb_height']")
                             .jsonPath("$.messages[*].files[*]['thumb_url','thumb_width','thumb_height','thumb_tiny']")
                             .jsonPath("$.messages[*].room.media_backend_type")
-                            .jsonPath("$.messages[*].room.name")
-                            .jsonPath("$.messages[*].room.media_server")
-                            .jsonPath("$.messages[*].room.attached_file_ids[*]")
-                            // This will be break JSON structure with pseudonymization
-                            .jsonPath("$.messages[*].room.participants_events")
-                            .jsonPath("$.messages[*].room.participants_camera_on")
-                            .jsonPath("$.messages[*].room.participants_camera_off")
-                            .jsonPath("$.messages[*].room.participants_screenshare_on")
-                            .jsonPath("$.messages[*].room.participants_screenshare_off")
-                            .jsonPath("$.messages[*].room.pending_invitees")
-                            .jsonPath("$.messages[*].room.last_invite_status_by_user")
-                            .jsonPath("$.messages[*].room.knocks")
+                            // This will be break JSON structure with pseudonymization, so redact it
+                            .jsonPath("$.messages[*].room..['name','media_server','attached_file_ids','participants_events','participants_camera_on','participants_camera_off','participants_screenshare_on','participants_screenshare_off','pending_invitees','last_invite_status_by_user','knocks']")
                             .build())
                     .build())
             .build();

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/slack/SlackDiscoveryTests.java
@@ -129,8 +129,12 @@ public class SlackDiscoveryTests extends JavaRulesTestBaseCase {
         Collection<String> PIItoPseudonymize = Arrays.asList(
                 "W06CA4EAC", "W0G81RDQT", "W0N0ZQDED", "W0R8EBMXP", "W0G81RDQZ", "W000000", "U02DU306H0B",
                 "REPLYUSER",
-                "some parent user"
+                "some parent user",
+                "U02K5LRARED",
+                "U074XMEDGUU",
+                "USLACKBOT"
         );
+
         Collection<String> dataToRedact = Arrays.asList(
                 "Test message!",
                 "<@U06CA4EAC|bjin>",
@@ -144,7 +148,17 @@ public class SlackDiscoveryTests extends JavaRulesTestBaseCase {
                 "Leg end nary a laugh, Ink.",
                 "Some other text",
                 "https://badpuns.example.com/puns/123.png",
-                "permalink value"
+                "permalink value",
+                "huddle test topic",
+                "A huddle started"
+        );
+
+        Collection<String> dataToKeep = Arrays.asList(
+                "R07BNSQTZSP",
+                "D075J2RKK4Y",
+                "b88ef6b8-9450-4633-83a2-dfb2cfd12713",
+                "huddle",
+                "huddle_thread"
         );
 
         assertNotSanitized(jsonString, PIItoPseudonymize);
@@ -155,6 +169,7 @@ public class SlackDiscoveryTests extends JavaRulesTestBaseCase {
 
         assertPseudonymized(sanitized, PIItoPseudonymize);
         assertRedacted(sanitized, dataToRedact);
+        assertNotSanitized(sanitized, dataToKeep);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Adding rules for `Room` object as part of the response of *conversation history* endpoint for Slack.

### Features
[Huddle psoxy support](https://app.asana.com/0/0/1207877994208971)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? **no** if in module/example that is NOT marked `alpha`, requires major version
     change 
