### PR TITLE
GittHub: include email in SAML graphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Changes to be including in future/planned release notes will be added here.
 ## Next
 
 ## [0.4.58](https://github.com/Worklytics/psoxy/release/tag/v0.4.58)
- - Including rules for Slack Huddles through *Rooms* as part of conversation history endpoint
+ - Slack: Including rules for Slack Huddles through *Rooms* as part of conversation history endpoint
+ - GitHub: Adding support for [email](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/iam-configuration-reference/saml-configuration-reference#saml-attributes) attribute in SAML response model on GraphQL 
 
 ## [0.4.57](https://github.com/Worklytics/psoxy/release/tag/v0.4.57)
 Several changes in this version will result in visible changes during `terraform plan`/`apply`:

--- a/docs/sources/github/example-api-responses/original/graph_api_users_saml.json
+++ b/docs/sources/github/example-api-responses/original/graph_api_users_saml.json
@@ -12,7 +12,12 @@
               "node": {
                 "guid": "abc3f758-1a88-11ee-85d2-07ac5bf201d6",
                 "samlIdentity": {
-                  "nameId": "fake1@contoso.com"
+                  "nameId": "fake1@contoso.com",
+                  "emails": [
+                    {
+                      "value": "fake1@contoso.com"
+                    }
+                  ]
                 },
                 "user": {
                   "login": "fake1"

--- a/docs/sources/github/example-api-responses/original/graph_api_users_saml.json
+++ b/docs/sources/github/example-api-responses/original/graph_api_users_saml.json
@@ -15,7 +15,7 @@
                   "nameId": "fake1@contoso.com",
                   "emails": [
                     {
-                      "value": "fake1@contoso.com"
+                      "value": "fake1_email_value@contoso.com"
                     }
                   ]
                 },

--- a/docs/sources/github/example-api-responses/sanitized/graph_api_users_saml.json
+++ b/docs/sources/github/example-api-responses/sanitized/graph_api_users_saml.json
@@ -15,7 +15,7 @@
                   "nameId":"{\"scope\":\"email\",\"domain\":\"contoso.com\",\"hash\":\"2cclTmgvAaaNoY_a3YFJVu1UUmwFw1MX9nrrF6oH9tM\"}",
                   "emails":[
                     {
-                      "value":"{\"scope\":\"email\",\"domain\":\"contoso.com\",\"hash\":\"2cclTmgvAaaNoY_a3YFJVu1UUmwFw1MX9nrrF6oH9tM\"}"
+                      "value":"{\"scope\":\"email\",\"domain\":\"contoso.com\",\"hash\":\"tJeMjd4Zz84TzbzdvLTpWPg1z3gf-5Icpqv7Cbg_c2c\"}"
                     }
                   ]
                 },

--- a/docs/sources/github/example-api-responses/sanitized/graph_api_users_saml.json
+++ b/docs/sources/github/example-api-responses/sanitized/graph_api_users_saml.json
@@ -12,7 +12,12 @@
               "node":{
                 "guid":"{\"scope\":\"github\",\"hash\":\"5yFLE9_eWMz8YE8Fp1Li0TuYIh_eP5WfzjogeJVfLsg\"}",
                 "samlIdentity":{
-                  "nameId":"{\"scope\":\"email\",\"domain\":\"contoso.com\",\"hash\":\"2cclTmgvAaaNoY_a3YFJVu1UUmwFw1MX9nrrF6oH9tM\"}"
+                  "nameId":"{\"scope\":\"email\",\"domain\":\"contoso.com\",\"hash\":\"2cclTmgvAaaNoY_a3YFJVu1UUmwFw1MX9nrrF6oH9tM\"}",
+                  "emails":[
+                    {
+                      "value":"{\"scope\":\"email\",\"domain\":\"contoso.com\",\"hash\":\"2cclTmgvAaaNoY_a3YFJVu1UUmwFw1MX9nrrF6oH9tM\"}"
+                    }
+                  ]
                 },
                 "user":{
                   "login":"p~MsZ4qsVoj0TU_io4Cz9mnMBWrZkfI89B-8qznWvl83mYA56fU9HQ_fR3fOvcTHkx"

--- a/docs/sources/github/github-enterprise-server.yaml
+++ b/docs/sources/github/github-enterprise-server.yaml
@@ -87,6 +87,7 @@ endpoints:
         jsonPaths:
           - "$..nameId"
           - "$..email"
+          - "$..value"
           - "$..guid"
           - "$..organizationVerifiedDomainEmails[*]"
         encoding: "JSON"
@@ -153,6 +154,13 @@ endpoints:
                                   samlIdentity:
                                     type: "object"
                                     properties:
+                                      emails:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          properties:
+                                            value:
+                                              type: "string"
                                       nameId:
                                         type: "string"
                                   user:

--- a/docs/sources/github/github-enterprise-server.yaml
+++ b/docs/sources/github/github-enterprise-server.yaml
@@ -87,7 +87,7 @@ endpoints:
         jsonPaths:
           - "$..nameId"
           - "$..email"
-          - "$..value"
+          - "$..emails[*].value"
           - "$..guid"
           - "$..organizationVerifiedDomainEmails[*]"
         encoding: "JSON"

--- a/docs/sources/github/github.yaml
+++ b/docs/sources/github/github.yaml
@@ -87,6 +87,7 @@ endpoints:
         jsonPaths:
           - "$..nameId"
           - "$..email"
+          - "$..value"
           - "$..guid"
           - "$..organizationVerifiedDomainEmails[*]"
         encoding: "JSON"
@@ -153,6 +154,13 @@ endpoints:
                                   samlIdentity:
                                     type: "object"
                                     properties:
+                                      emails:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          properties:
+                                            value:
+                                              type: "string"
                                       nameId:
                                         type: "string"
                                   user:

--- a/docs/sources/github/github.yaml
+++ b/docs/sources/github/github.yaml
@@ -87,7 +87,7 @@ endpoints:
         jsonPaths:
           - "$..nameId"
           - "$..email"
-          - "$..value"
+          - "$..emails[*].value"
           - "$..guid"
           - "$..organizationVerifiedDomainEmails[*]"
         encoding: "JSON"

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -111,7 +111,7 @@ public class PrebuiltSanitizerRules {
             .transform(Transform.Pseudonymize.builder()
                     .jsonPath("$..nameId")
                     .jsonPath("$..email")
-                    .jsonPath("$..value")
+                    .jsonPath("$..emails[*].value")
                     .jsonPath("$..guid")
                     .jsonPath("$..organizationVerifiedDomainEmails[*]")
                     .build())

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -111,6 +111,7 @@ public class PrebuiltSanitizerRules {
             .transform(Transform.Pseudonymize.builder()
                     .jsonPath("$..nameId")
                     .jsonPath("$..email")
+                    .jsonPath("$..value")
                     .jsonPath("$..guid")
                     .jsonPath("$..organizationVerifiedDomainEmails[*]")
                     .build())
@@ -697,6 +698,15 @@ public class PrebuiltSanitizerRules {
                     put("guid", JsonSchemaFilter.builder().type("string").build());
                     put("samlIdentity", JsonSchemaFilter.builder().type("object").properties(new LinkedHashMap<String, JsonSchemaFilter>() {{
                         put("nameId", JsonSchemaFilter.builder().type("string").build());
+                        put("emails", JsonSchemaFilter.builder()
+                                .type("array")
+                                .items(JsonSchemaFilter.builder()
+                                        .type("object")
+                                        .properties(new LinkedHashMap<String, JsonSchemaFilter>() {{ //req for java8-backwards compatibility
+                                            put("value", JsonSchemaFilter.builder().type("string").build());
+                                        }})
+                                        .build())
+                                .build());
                     }}).build());
                     put("user", JsonSchemaFilter.builder().type("object").properties(new LinkedHashMap<String, JsonSchemaFilter>() {{
                         put("login", JsonSchemaFilter.builder().type("string").build());

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
@@ -80,6 +80,7 @@ public class GitHubTests extends JavaRulesTestBaseCase {
 
         assertPseudonymized(sanitized, "fake1", "fake1@contoso.com");
         assertPseudonymized(sanitized, "fake2", "fake2@contoso.com");
+        assertPseudonymized(sanitized,"fake1_email_value@contoso.com");
 
         assertUrlAllowed("https://api.github.com/graphql");
     }


### PR DESCRIPTION
Adding support for emails in GraphQL response for Github.

### Features
[Update Psoxy rules](https://app.asana.com/0/0/1208008421755524)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes**
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
