### PR TITLE
consistent sanitized bucket names in GCP

### DIFF
--- a/infra/modules/gcp-output-bucket/main.tf
+++ b/infra/modules/gcp-output-bucket/main.tf
@@ -20,6 +20,7 @@ resource "google_storage_bucket" "bucket" {
   # TODO: remove in v0.5
   lifecycle {
     ignore_changes = [
+      name, # due to name change from -output --> -sanitized, ignore name change to avoid recreating bucket
       labels
     ]
   }

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -91,7 +91,7 @@ module "output_bucket" {
   bucket_write_role_id           = var.bucket_write_role_id
   function_service_account_email = google_service_account.service_account.email
   bucket_name_prefix             = coalesce(var.sanitized_bucket_name, local.bucket_prefix)
-  bucket_name_suffix             = var.sanitized_bucket_name == null ? "-output" : ""
+  bucket_name_suffix             = var.sanitized_bucket_name == null ? "-sanitized" : ""
   region                         = var.region
   expiration_days                = var.sanitized_expiration_days
   bucket_labels                  = var.default_labels


### PR DESCRIPTION
### Features
  - call GCP output buckets `-sanitized`, for consistency w AWS

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
