### PR TITLE
Tokenize MSFT Teams PSTN call ids

### DIFF
--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Communications_callRecords_getPstnCalls_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Communications_callRecords_getPstnCalls_v1.0.json
@@ -4,7 +4,7 @@
   "value":[
     {
       "id":"9c4984c7-6c3c-427d-a30c-bd0b2eacee90",
-      "callId":"1835317186_112562680@61.221.3.176",
+      "callId":"p~Bvc4jV4RzsaEt4XIerSH40pfOsnpmsA1SuHUaIQ__1rmJYqLjsX9x4FjOXqaJLWshHPYWjB_xi0zPWc-9r6F_Nv5l7DJWsgKi0Kjd3k8hfU",
       "userId":"db03c14b-06eb-4189-939b-7cbf3a20ba27",
       "startDateTime":"2019-11-01T00:00:08.2589935Z",
       "endDateTime":"2019-11-01T00:03:47.2589935Z",

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Communications_callRecords_getPstnCalls_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Communications_callRecords_getPstnCalls_v1.0.json
@@ -2,7 +2,7 @@
   "value":[
     {
       "id":"9c4984c7-6c3c-427d-a30c-bd0b2eacee90",
-      "callId":"1835317186_112562680@61.221.3.176",
+      "callId":"p~Bvc4jV4RzsaEt4XIerSH40pfOsnpmsA1SuHUaIQ__1rmJYqLjsX9x4FjOXqaJLWshHPYWjB_xi0zPWc-9r6F_Nv5l7DJWsgKi0Kjd3k8hfU",
       "userId":"{\"scope\":\"azure-ad\",\"hash\":\"2ZGitAxyjkjPJ6l2GfLqf2kr0xFtleWfl5XA_zNbtMA\"}",
       "startDateTime":"2019-11-01T00:00:08.2589935Z",
       "endDateTime":"2019-11-01T00:03:47.2589935Z",

--- a/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
@@ -1,4 +1,3 @@
----
 endpoints:
   - pathTemplate: "/v1.0/teams"
     allowedQueryParams:
@@ -165,6 +164,9 @@ endpoints:
         jsonPaths:
           - "$..emailAddress"
         encoding: "JSON"
+      - !<tokenize>
+        jsonPaths:
+          - "$..callId"
       - !<redact>
         jsonPaths:
           - "$..value[*].userPrincipalName"

--- a/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
@@ -1,4 +1,3 @@
----
 endpoints:
   - pathTemplate: "/v1.0/teams"
     allowedQueryParams:
@@ -204,6 +203,9 @@ endpoints:
           - "$..user.id"
           - "$..userId"
         encoding: "JSON"
+      - !<tokenize>
+        jsonPaths:
+          - "$..callId"
       - !<redact>
         jsonPaths:
           - "$..value[*].userPrincipalName"

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -446,6 +446,11 @@ public class PrebuiltSanitizerRules {
             .jsonPath("$..joinMeetingIdSettings.isPasscodeRequired")
             .jsonPath("$..joinMeetingIdSettings.passcode")
             .build();
+
+    static final Transform.Tokenize MS_TEAMS_CALL_ID_TOKENIZATION = Transform.Tokenize.builder()
+            .jsonPath("$..callId")
+            .build();
+
     static final Endpoint MS_TEAMS_TEAMS = Endpoint.builder()
             .pathTemplate(MS_TEAMS_PATH_TEMPLATES_TEAMS)
             .allowedQueryParams(List.of("$select", "$top", "$skiptoken", "$filter", "$count"))
@@ -504,6 +509,7 @@ public class PrebuiltSanitizerRules {
             .pathTemplate(MS_TEAMS_PATH_TEMPLATES_COMMUNICATIONS_CALL_RECORDS_GET_PSTN_CALLS)
             .allowedQueryParams(List.of("$skip"))
             .transform(MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE)
+            .transform(MS_TEAMS_CALL_ID_TOKENIZATION)
             .build();
 
     static final Endpoint MS_TEAMS_USERS_ONLINE_MEETINGS = Endpoint.builder()
@@ -635,6 +641,7 @@ public class PrebuiltSanitizerRules {
                             .jsonPaths(REDACT_ODATA_COUNT.getJsonPaths())
                             .build())))
             .endpoint(MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_GET_PSTN_CALLS.withTransforms(Arrays.asList(PSEUDONYMIZE_USER_ID,
+                    MS_TEAMS_CALL_ID_TOKENIZATION,
                     MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_GET_PSTN_CALLS_REDACT
                             .toBuilder()
                             .jsonPaths(REDACT_ODATA_CONTEXT.getJsonPaths())


### PR DESCRIPTION
Reviewing #778 I've seen the `callId` may contain the IP of the caller.

### Features
[Psoxy: tokenize PSTN callId](https://app.asana.com/0/1208032421449960/1208075034541288)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
