### PR TITLE
Fix invalid link files

### DIFF
--- a/docs/sources/gcal
+++ b/docs/sources/gcal
@@ -1,1 +1,1 @@
-google-workspace/gcal/README.md
+google-workspace/calendar/README.md

--- a/docs/sources/survey/README.md
+++ b/docs/sources/survey/README.md
@@ -1,0 +1,7 @@
+# Survey
+
+## Examples
+
+- Example Data : 
+  - Original [surve-example.csv](surve-example.csv) |
+  - Sanitized [surve-example-sanitized.csv](surve-example-sanitized.csv)


### PR DESCRIPTION
Meanwhile doing #782, seen that since v.4.58 some invalid links (gcal and qualitrics) were preventing to run the build for tests in intelliJ. Worked fine from mvn command line, but not in the IDE with following error: *Maven Resources Compiler: Failed to copy [...]*:

- In case of gcal, fixing the link path
- In case of qualitrics, adding a README to the folder (so the link will be right). 

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
