### PR TITLE
bump ephermal amount for aws bulk mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changes to be including in future/planned release notes will be added here.
  - AWS: you'll see `moved` resources on next apply, relating to refactoring; as well as updating IAM policy that had a wildcard to instead be an explicit list of function ARNs. If you're upgrading from before v0.4.46, you'll see create + destroy instead of move.
  - AWS: if using `MinProvisioner` role from `psoxy-constants` module, we've added a req'd perm to
    that role (to allow tagging lambda functions); without this, `default_tags` option does not work.
+ - AWS: bulk-mode ephemeral storage set to 10240 (10GB), raised from free amount of 512MB; this will
+   incur small cost. It's billable at $0.0000000309 per GB-second. For most bulk use-cases, files
+   are processed in fewer than 30 seconds, and customers process fewer than 10 files per week. So
+   expected cost of this is $0.0000927 - less than one-thousandth of a cent.
 
 ## [0.4.57](https://github.com/Worklytics/psoxy/release/tag/v0.4.57)
 Several changes in this version will result in visible changes during `terraform plan`/`apply`:

--- a/infra/modules/aws-psoxy-bulk/main.tf
+++ b/infra/modules/aws-psoxy-bulk/main.tf
@@ -32,6 +32,7 @@ module "psoxy_lambda" {
   handler_class                        = "co.worklytics.psoxy.S3Handler"
   timeout_seconds                      = 600 # 10 minutes
   memory_size_mb                       = var.memory_size_mb
+  ephemeral_storage_mb                 = 10240 # max it out; expected to cost nothing
   source_kind                          = var.source_kind
   path_to_function_zip                 = var.path_to_function_zip
   function_zip_hash                    = var.function_zip_hash
@@ -47,6 +48,8 @@ module "psoxy_lambda" {
   vpc_config                           = var.vpc_config
   aws_lambda_execution_role_policy_arn = var.aws_lambda_execution_role_policy_arn
   iam_roles_permissions_boundary       = var.iam_roles_permissions_boundary
+
+
 
   environment_variables = merge(
     var.environment_variables,

--- a/infra/modules/aws-psoxy-lambda/main.tf
+++ b/infra/modules/aws-psoxy-lambda/main.tf
@@ -55,6 +55,14 @@ resource "aws_lambda_function" "instance" {
   reserved_concurrent_executions = coalesce(var.reserved_concurrent_executions, -1)
   kms_key_arn                    = var.function_env_kms_key_arn
 
+
+  ephemeral_storage {
+    size = var.ephemeral_storage_mb
+  }
+  # TODO: aws provider v5 this becomes
+  # ephemeral_storage              = var.ephemeral_storage_mb
+
+
   dynamic "vpc_config" {
     for_each = var.vpc_config[*]
 

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -119,7 +119,7 @@ variable "memory_size_mb" {
 variable "ephemeral_storage_mb" {
   type        = number
   description = "ephemeral storage size in MB"
-  default     = 512 # this is the free amount; over this though it's pretty
+  default     = 512 # this is the free amount; over this though it's pretty trivial cost for the use-case
 }
 
 variable "timeout_seconds" {

--- a/infra/modules/aws-psoxy-lambda/variables.tf
+++ b/infra/modules/aws-psoxy-lambda/variables.tf
@@ -116,6 +116,12 @@ variable "memory_size_mb" {
   default     = 512
 }
 
+variable "ephemeral_storage_mb" {
+  type        = number
+  description = "ephemeral storage size in MB"
+  default     = 512 # this is the free amount; over this though it's pretty
+}
+
 variable "timeout_seconds" {
   type        = number
   description = "lambda timeout in seconds"


### PR DESCRIPTION

### Features
 - increase ephemeral storage amount; free default wasn't enough in practice for some users

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes, users will see a change on apply; and possibly trivial cost increase**
