### PR TITLE
bulk mode compress always

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/BulkModeConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/BulkModeConfigProperty.java
@@ -39,6 +39,15 @@ public enum BulkModeConfigProperty implements ConfigService.ConfigProperty {
      * default: 65536 (64KB)
      */
     BUFFER_SIZE,
-    ;
 
+
+    /**
+     * whether output files produced by proxy instance should be compressed, regardless of whether
+     * input files were compressed.
+     *
+     * default; true
+     */
+    COMPRESS_OUTPUT_ALWAYS,
+
+    ;
 }

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSFileEvent.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSFileEvent.java
@@ -20,6 +20,7 @@ import javax.inject.Singleton;
 import java.io.*;
 import java.nio.channels.Channels;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 @Singleton
@@ -71,13 +72,18 @@ public class GCSFileEvent implements BackgroundFunction<GCSFileEvent.GcsEvent> {
             };
 
             Supplier<OutputStream> outputStreamSupplier = () -> {
-                BlobInfo destBlobInfo = BlobInfo.newBuilder(BlobId.of(request.getDestinationBucketName(), request.getDestinationObjectPath()))
+                BlobInfo.Builder blobInfoBuilder = BlobInfo.newBuilder(BlobId.of(request.getDestinationBucketName(), request.getDestinationObjectPath()))
                     .setContentType(sourceBlobInfo.getContentType())
-                    .setContentEncoding(sourceBlobInfo.getContentEncoding())
-                    .setMetadata(storageHandler.buildObjectMetadata(importBucket, sourceName, transform))
-                    .build();
+                    .setMetadata(storageHandler.buildObjectMetadata(importBucket, sourceName, transform));
+
+                if (request.getCompressOutput()) {
+                    blobInfoBuilder.setContentEncoding(StorageHandler.CONTENT_ENCODING_GZIP);
+                } else {
+                    Optional.ofNullable(sourceBlobInfo.getContentEncoding())
+                        .ifPresent(blobInfoBuilder::setContentEncoding);
+                }
                 //NOTE: disableGzipContent() is important to avoid double compression
-                WriteChannel writeChannel = storage.writer(destBlobInfo, Storage.BlobWriteOption.disableGzipContent());
+                WriteChannel writeChannel = storage.writer(blobInfoBuilder.build(), Storage.BlobWriteOption.disableGzipContent());
                 //NOTE: when close() called on the stream, close is called on channel, so should be OK
                 return Channels.newOutputStream(writeChannel);
             };


### PR DESCRIPTION
### Features
 - change bulk mode behavior to ALWAYS compress output by default

just will improve perf for everyone.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yeah, so technically changes behavior; although should be transparent and preferred for all existing use-cases**
