### PR TITLE
avoid fatal unmapped transforms

### DIFF
--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -217,6 +217,7 @@ variable "bulk_connectors" {
       columnsToRedact       = optional(list(string), [])
       columnsToInclude      = optional(list(string), null)
       columnsToPseudonymize = optional(list(string), [])
+      columnsToPseudonymizeIfPresent = optional(list(string), [])
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
       fieldsToTransform = optional(map(object({
@@ -251,6 +252,7 @@ variable "custom_bulk_connector_rules" {
     columnsToRedact       = optional(list(string))
     columnsToInclude      = optional(list(string))
     columnsToPseudonymize = optional(list(string))
+    columnsToPseudonymizeIfPresent = optional(list(string), null)
     columnsToDuplicate    = optional(map(string))
     columnsToRename       = optional(map(string))
     fieldsToTransform = optional(map(object({

--- a/infra/modules/aws-psoxy-bulk-existing/variables.tf
+++ b/infra/modules/aws-psoxy-bulk-existing/variables.tf
@@ -113,6 +113,7 @@ variable "rules" {
     columnsToRedact       = list(string)
     columnsToInclude      = list(string)
     columnsToPseudonymize = list(string)
+    columnsToPseudonymize = optional(list(string), [])
     columnsToDuplicate    = map(string)
     columnsToRename       = map(string)
     fieldsToTransform = optional(map(object({
@@ -126,6 +127,7 @@ variable "rules" {
     columnsToRedact       = []
     columnsToInclude      = null
     columnsToPseudonymize = []
+    columnsToPseudonymize = null
     columnsToDuplicate    = {}
     columnsToRename       = {}
     fieldsToTransform     = {}

--- a/infra/modules/aws-psoxy-bulk/variables.tf
+++ b/infra/modules/aws-psoxy-bulk/variables.tf
@@ -174,6 +174,7 @@ variable "rules" {
     columnsToRedact       = optional(list(string), [])
     columnsToInclude      = optional(list(string), null)
     columnsToPseudonymize = optional(list(string), [])
+    columnsToPseudonymizeIfPresent = optional(list(string), null)
     columnsToDuplicate    = optional(map(string), {})
     columnsToRename       = optional(map(string), {})
     fieldsToTransform = optional(map(object({

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -163,6 +163,7 @@ variable "bulk_connectors" {
       columnsToRedact       = optional(list(string), [])
       columnsToInclude      = optional(list(string), null)
       columnsToPseudonymize = optional(list(string), [])
+      columnsToPseudonymizeIfPresent = optional(list(string), null)
       columnsToDuplicate    = optional(map(string), {})
       columnsToRename       = optional(map(string), {})
       fieldsToTransform = optional(map(object({

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -1398,9 +1398,11 @@ EOT
         columnsToRedact = []
         columnsToPseudonymize = [
           "EMPLOYEE_ID",    # primary key
-          "EMPLOYEE_EMAIL", # for matching
+          "EMPLOYEE_EMAIL", # for linking to other data sources
           "MANAGER_ID",     # should match to employee_id
-          # "MANAGER_EMAIL"      # if exists
+        ]
+        columnsToPseudonymizeIfPresent = [
+          "MANAGER_EMAIL"
         ]
       }
       settings_to_provide = {

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -255,7 +255,7 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
         });
         // we apply pseudonymization in the pseudonymized columns, only if present
         columnsToPseudonymizeIfPresent.forEach(column -> {
-            if (headers.contains(column)) {
+            if (headersCI.contains(column)) {
                 addColumnTransform.accept(column, column, (s) -> Optional.of(pseudonymizationFunction.apply(s, column, pseudonymizer)));
             }
         });

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -134,9 +134,10 @@ public class BulkDataSanitizerImplTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"EMPLOYEE_EMAIL", "employee_email", "Employee_Email"})
     @SneakyThrows
-    void handle_pseudonymizeIfPresent() {
+    void handle_pseudonymizeIfPresent(String caseVariant) {
         final String EXPECTED = "EMPLOYEE_ID,EMPLOYEE_EMAIL,DEPARTMENT,SNAPSHOT,MANAGER_ID,JOIN_DATE,LEAVE_DATE\n" +
             "1,\"{\"\"scope\"\":\"\"email\"\",\"\"domain\"\":\"\"worklytics.co\"\",\"\"hash\"\":\"\"Qf4dLJ4jfqZLn9ef4VirvYjvOnRaVI5tf5oLnM65YOA\"\",\"\"h_4\"\":\"\"Qf4dLJ4jfqZLn9ef4VirvYjvOnRaVI5tf5oLnM65YOA\"\"}\",Engineering,2023-01-06,,2019-11-11,\n" +
             "2,\"{\"\"scope\"\":\"\"email\"\",\"\"domain\"\":\"\"workltyics.co\"\",\"\"hash\"\":\"\"al4JK5KlOIsneC2DM__P_HRYe28LWYTBSf3yWKGm5yQ\"\",\"\"h_4\"\":\"\"al4JK5KlOIsneC2DM__P_HRYe28LWYTBSf3yWKGm5yQ\"\"}\",Sales,2023-01-06,1,2020-01-01,\n" +
@@ -144,7 +145,7 @@ public class BulkDataSanitizerImplTest {
             "4,,Engineering,2023-01-06,1,2018-06-03,\n"; //blank ID
 
         ColumnarRules rules = ColumnarRules.builder()
-            .columnToPseudonymizeIfPresent("EMPLOYEE_EMAIL")
+            .columnToPseudonymizeIfPresent(caseVariant)
             .columnToPseudonymizeIfPresent("EXTRA_EMAIL") //unlike 'columnToPseudonymize', this doesn't throw error
             .build();
 


### PR DESCRIPTION
### Fixes
  - bulk mode fatal exception if transform defined for CSV column that doesn't exist (can happen if ppl use our hris example, but don't have expected column to redact or something)
  - `columnsToPseudonymizeIfPresent` wasn't case-insensitive

### Features
  - default HRIS rules will work for customers who provide `manager_email`


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
