### PR TITLE
 fix bulk test tool for ALWAYS_COMPRESS mode

### DIFF
--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -24,7 +24,6 @@ import {
 import fs from 'fs';
 import getLogger from './logger.js';
 import _ from 'lodash';
-import {execSync} from 'child_process';
 import zlib from 'node:zlib';
 
 

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -24,6 +24,8 @@ import {
 import fs from 'fs';
 import getLogger from './logger.js';
 import _ from 'lodash';
+import {execSync} from 'child_process';
+import zlib from 'node:zlib';
 
 
 /**
@@ -292,7 +294,12 @@ async function download(bucket, key, destination, options, client, logger) {
 
   // save file locally
   await new Promise((resolve, reject) => {
-    downloadResponse.Body.pipe(fs.createWriteStream(destination))
+    let stream = downloadResponse.Body;
+    if (downloadResponse.ContentEncoding?.toLowerCase() === 'gzip') {
+      stream = stream.pipe(zlib.createGunzip());
+    }
+    stream
+      .pipe(fs.createWriteStream(destination))
       .on('error', err => reject(err))
       .on('close', () => resolve())
   })

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -247,7 +247,7 @@ async function download(bucketName, fileName, destination, client, logger) {
   }
 
   const downloadFunction = async () => client.bucket(bucketName).file(fileName)
-    .download({ destination: destination, decompress: false });
+    .download({ destination: destination, decompress: true });
   const onErrorStop = (error) => error.code !== 404;
 
   const downloadResponse = await executeWithRetry(downloadFunction, onErrorStop,

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -175,9 +175,7 @@ export default async function (options = {}) {
   let sanitizedDiffPath = sanitized;
   const isOriginalGzipped = await isGzipped(original);
   if (isOriginalGzipped) {
-    // Assume sanitized file is also gzipped
     originalDiffPath = await unzip(original);
-    sanitizedDiffPath = await unzip(sanitized);
   }
 
   let diff;


### PR DESCRIPTION
### Fixes
  - after #785, test tool needs to consider that bulk-mode may ALWAYS produce compressed files

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
