### PR TITLE
display processed bulk file metadata

### DIFF
--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psoxy-test",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": "true",
   "type": "module",
   "description": "Worklytics Psoxy testing tools",

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -60,11 +60,15 @@ async function testAWS(options, logger) {
   const sanitizedFilename = addFilenameSuffix(outputKey, SANITIZED_FILE_SUFFIX);
   const destination = `./${sanitizedFilename}`;
 
-  await aws.download(outputBucket, outputKey, destination, {
+  const file = await aws.download(outputBucket, outputKey, destination, {
       role: options.role,
       region: options.region,
     }, client, logger);
   logger.success('File downloaded');
+
+  if (file?.metadata) {
+    logger.verbose('File metadata:', { additional: file.metadata });
+  }
 
   if (!options.keepSanitizedFile) {
     logger.info(`Deleting sanitized file from output bucket: ${outputBucket}`);
@@ -129,8 +133,12 @@ async function testGCP(options, logger) {
   const sanitizedFilename = addFilenameSuffix(outputKey, SANITIZED_FILE_SUFFIX);
   const destination = `./${sanitizedFilename}`;
 
-  await gcp.download(outputBucket, outputKey, destination, client, logger);
+  const file = await gcp.download(outputBucket, outputKey, destination, client, logger);
   logger.success('File downloaded');
+
+  if (file?.metadata) {
+    logger.verbose('File metadata:', { additional: file.metadata });
+  }
 
   if (!options.keepSanitizedFile) {
     logger.info(`Deleting sanitized file from output bucket: ${outputBucket}`);

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -50,6 +50,7 @@ async function testAWS(options, logger) {
     throw new Error('Unable to upload file', { cause: uploadResult });
   }
   logger.success('File uploaded');
+  logger.verbose('Upload result:', { additional: uploadResult });
 
   const parsedBucketOutputOption = parseBucketOption(options.output)
   const outputBucket = parsedBucketOutputOption.bucket;


### PR DESCRIPTION
### Fixes
- Missing content type: enforce `text/csv` on file upload. Not sure if relevant.

### Features
 - [bulk test tool echo metadata about sanitized file ](https://app.asana.com/0/501803088048006/1208217977564287/f): given that use-case is debugging, metadata only displays in verbose mode `--verbose`.  

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
