### PR TITLE
align metrics connector spec with w8s version

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -1415,16 +1415,15 @@ EOT
       source_kind               = "metrics"
       availability              = "beta"
       enable_by_default         = false
-      worklytics_connector_id   = "bulk-import-psoxy",
-      worklytics_connector_name = "Bulk Data Import via Psoxy"
+      worklytics_connector_id   = "metrics-import-psoxy",
+      worklytics_connector_name = "Metrics via Psoxy"
       rules = {
-        columnsToPseudonymize = [
-          "EMPLOYEE_ID", # primary key
-          # "employee_email", # if exists
+        columnsToPseudonymizeIfPresent = [
+          "EMPLOYEE_ID",
+          "EMPLOYEE_EMAIL",
         ]
       }
       settings_to_provide = {
-        "Parser" = "metrics"
       }
       example_file = "docs/sources/metrics/metrics-example.csv"
     }


### PR DESCRIPTION
### Features
 - align spec w metrics connector on worklytics side (standalone rather than a specific bulk import parser)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
