### PR TITLE
default to TLS 1.3 out to datasource

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,6 +37,7 @@
   * [API Data Sanitization](configuration/api-data-sanitization.md)
   * [Bulk File Sanitization](configuration/bulk-file-sanitization.md)
   * [JSON Filter](configuration/json-filter.md)
+  * [TLS Version](configuration/tls.md)
 * [Development](development/README.md)
   * [Approaches for Example / Module design](development/terraform-architecture.md)
   * [Create a private fork](development/private-fork.md)

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -1,0 +1,30 @@
+# Configuring Transport Layer Security (TLS)
+
+By default, proxy from version 0.4.61 will connect to data source APIs using TLS 1.3.
+
+Prior to 0.4.61, the proxy should have negotiated to use 1.3 with all sources that supported it;
+but may have fallen back to 1.2 for some sources.
+
+It will no longer fall back; but you can configure the proxy to use TLS 1.2 for a given source by
+setting the `TLS_VERSION` environment variable on a proxy instance to `TLSv1.2`. As TLS 1.3 offers
+security and performance improvements, we recommend using it whenever possible.
+
+As of Sept 2024, we've confirmed that the following public APIs of various data sources support
+TLS 1.3, either through end-to-end proxy testing OR via openssl negotiation (see next section):
+  - Google Workspace
+  - Microsoft 365 (Microsoft Graph)
+  - GitHub (cloud version)
+  - Asana
+  - Atlassian (JIRA, etc)
+  - Slack
+  - Zoom
+
+## Testing TLS 1.3 Support for a Source API
+
+To test TLS 1.3 support, you can use something like the following command (assuming you have
+`openssl` installed on  a Mac):
+
+```shell
+openssl s_client -connect api.asana.com:443 -tls1_3
+```
+

--- a/infra/examples-dev/aws-all/api-gateway-advanced.tf
+++ b/infra/examples-dev/aws-all/api-gateway-advanced.tf
@@ -17,7 +17,7 @@
 #   domain_name_configuration {
 #     certificate_arn = aws_acm_certificate.cert.arn
 #     endpoint_type   = "REGIONAL"
-#     security_policy = "TLS_1_2"
+#     security_policy = "TLS_1_2" # this is a 'min version'; 'TLS_1_2' allows TLS v1.2 or TLS v1.3 in practice; see https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html
 #   }
 # }
 #

--- a/java/core/src/main/java/co/worklytics/psoxy/FunctionRuntimeModule.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/FunctionRuntimeModule.java
@@ -14,8 +14,13 @@ import dagger.Provides;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.UUID;
 
 /**
@@ -49,9 +54,31 @@ public class FunctionRuntimeModule {
     }
 
     @Provides @Singleton
-    HttpTransportFactory providesHttpTransportFactory() {
-        //atm, all function runtimes expected to use generic java NetHttpTransport
-        return () -> new NetHttpTransport();
+    HttpTransportFactory providesHttpTransportFactory(EnvVarsConfigService envVarsConfigService) {
+        return this::createMinTLSNetTransport;
+    }
+
+    @Provides
+    private NetHttpTransport createMinTLSNetTransport(EnvVarsConfigService envVarsConfigService) {
+        try {
+            String sslContextProtocol =
+                envVarsConfigService.getConfigPropertyAsOptional(ProxyConfigProperty.TLS_VERSION)
+                    .orElse(ProxyConfigProperty.TlsVersions.TLSv1_3);
+            if (Arrays.stream(ProxyConfigProperty.TlsVersions.ALL).noneMatch(s -> sslContextProtocol.equals(s))) {
+                throw new IllegalArgumentException("Invalid TLS version: " + sslContextProtocol);
+            }
+
+            SSLContext sslContext = SSLContext.getInstance(sslContextProtocol);
+            sslContext.init(null, null, new java.security.SecureRandom());
+            SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+            // Configure the NetHttpTransport to use the custom SSL context
+            return new NetHttpTransport.Builder()
+                .setSslSocketFactory(sslSocketFactory)
+                .build();
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException("Failed to create custom SSL context with TLSv1.2", e);
+        }
     }
 
     @Provides @Singleton
@@ -62,8 +89,6 @@ public class FunctionRuntimeModule {
             .fallback(nativeConfigService)
             .build();
     }
-
-
 
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
@@ -67,5 +67,21 @@ public enum ProxyConfigProperty implements ConfigService.ConfigProperty {
     SOURCE_AUTH_STRATEGY_IDENTIFIER,
     //target API endpoint to forward request to
     TARGET_HOST,
-    BUNDLE_FILENAME;
+
+    /**
+     * control the TLS protocol version used by proxy for outbound connections (eg, to data source)
+     * OPTIONAL; default to 'TLSv1.3'
+     * only safe alternative setting would be 'TLSv1.2'; we provide option to configure this in
+     * case there is some API supported by proxy that doesn't support TLSv1.3 (we're not aware of
+     * any as of Sept 2024)
+     */
+    TLS_VERSION,
+
+    BUNDLE_FILENAME, ;
+
+    public static class TlsVersions {
+        public final static String TLSv1_2 = "TLSv1.2";
+        public final static String TLSv1_3 = "TLSv1.3";
+        public final  static String[] ALL = {TLSv1_2, TLSv1_3};
+    }
 }


### PR DESCRIPTION
### Features
 - default TLS 1.3 out to data source APIs (option to configure down to 1.2; but nothing else supported)
 

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes **maybe; some risk of breaking sources that we haven't tested .. major ones all seem OK ... worry about github onprem?**




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201795195529611