### PR TITLE
enforce PRs via rc

### DIFF
--- a/.github/workflows/require-merge-via-rc.yaml
+++ b/.github/workflows/require-merge-via-rc.yaml
@@ -1,0 +1,29 @@
+name: "require PRs to be merged via 'rc-*' branches"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if base and head branches follow naming convention
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+          # Check if base branch starts with 'rc-'
+          if [[ "$BASE_BRANCH" != rc-* ]]; then
+            echo "Error: The base branch '$BASE_BRANCH' does not start with 'rc-'."
+            exit 1
+          fi
+
+          # Check if head branch starts with 'rc-'
+          if [[ "$HEAD_BRANCH" != rc-* ]]; then
+            echo "Error: The head branch '$HEAD_BRANCH' does not start with 'rc-'."
+            exit 1
+          fi
+
+          echo "Both base and head branches follow the 'rc-*' naming convention."

--- a/.github/workflows/require-merge-via-rc.yaml
+++ b/.github/workflows/require-merge-via-rc.yaml
@@ -9,21 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if base and head branches follow naming convention
+      - name: Check that PR's base branch is an 'rc-' branch, unless the head branch is an 'rc-' branch
         run: |
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
 
           # Check if base branch starts with 'rc-'
-          if [[ "$BASE_BRANCH" != rc-* ]]; then
-            echo "Error: The base branch '$BASE_BRANCH' does not start with 'rc-'."
+          if [[ "$BASE_BRANCH" != rc-* && "$HEAD_BRANCH" != rc-* ]]; then
+            echo "Error: The base branch '$BASE_BRANCH' is not an 'rc-' branch; and the head branch '$HEAD_BRANCH' is not an 'rc-' branch."
             exit 1
           fi
-
-          # Check if head branch starts with 'rc-'
-          if [[ "$HEAD_BRANCH" != rc-* ]]; then
-            echo "Error: The head branch '$HEAD_BRANCH' does not start with 'rc-'."
-            exit 1
-          fi
-
-          echo "Both base and head branches follow the 'rc-*' naming convention."

--- a/tools/psoxy-test/package-lock.json
+++ b/tools/psoxy-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psoxy-test",
-  "version": "0.4.9",
+  "version": "0.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "psoxy-test",
-      "version": "0.4.9",
+      "version": "0.4.11",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.350.0",


### PR DESCRIPTION
### Features
 - use GitHub action to check that base branch of PRs is rc-*, unless PR's branch is itself rc-*

this PR when base was `main`: https://github.com/Worklytics/psoxy/actions/runs/11077104037
this PR after changing base to the `rc-v0.4.61`: https://github.com/Worklytics/psoxy/actions/runs/11077104037

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
