### PR TITLE
end tf < 1.6 support

### DIFF
--- a/.github/workflows/ci-terraform-examples-release.yaml
+++ b/.github/workflows/ci-terraform-examples-release.yaml
@@ -21,7 +21,7 @@ jobs:
           'examples/gcp-google-workspace',
           'examples/msft-365'
         ]
-        terraform_version: [ '~1.3.0', '~1.4.0', '~1.5.0', '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', 'latest' ]
+        terraform_version: [ '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', 'latest' ]
     uses: ./.github/workflows/ci-terraform-example.yaml
     with:
       terraform_version: ${{ matrix.terraform_version }}

--- a/.github/workflows/ci-terraform-examples.yaml
+++ b/.github/workflows/ci-terraform-examples.yaml
@@ -19,7 +19,7 @@ jobs:
                         'examples-dev/gcp',
                         'examples-dev/gcp-google-workspace',
         ]
-        terraform_version: [ '~1.3.0', '~1.4.0', '~1.5.0', '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', 'latest' ]
+        terraform_version: [ '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', 'latest' ]
     uses: ./.github/workflows/ci-terraform-example.yaml
     with:
       terraform_version: ${{ matrix.terraform_version }}

--- a/.github/workflows/ci-terraform-modules.yaml
+++ b/.github/workflows/ci-terraform-modules.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform_version: [ '~1.3.0', '~1.4.0', '~1.5.0', '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', 'latest' ]
+        terraform_version: [ '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', 'latest' ]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -217,7 +217,7 @@ You will need all the following in your deployment environment (eg, your laptop)
 | [git](https://git-scm.com/)                     | 2.17+                  | `git --version`       |
 | [Maven](https://maven.apache.org/)              | 3.6+                   | `mvn -v`              |
 | [Java JDK 11+](https://openjdk.org/install/) | 11, 17, 21 (see notes) | `mvn -v \| grep Java` |
-| [Terraform](https://www.terraform.io/)          | 1.3+, <= 1.9           | `terraform version`   |
+| [Terraform](https://www.terraform.io/)          | 1.6+, <= 1.9           | `terraform version`   |
 
 NOTE: we will support Java versions for duration of official support windows, in particular the
 LTS versions. As of Nov 2023, we  still support java 11 but may end this at any time. Minor


### PR DESCRIPTION
### Features
 - terraform support to 1.6+

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **yes - terraform version >1.6, which most ppl should have anyways**