### PR TITLE
drop zoom oauth refresh token

### DIFF
--- a/.github/workflows/require-merge-via-rc.yaml
+++ b/.github/workflows/require-merge-via-rc.yaml
@@ -1,0 +1,21 @@
+name: "require PRs to be merged via 'rc-*' branches"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check that PR's base branch is an 'rc-' branch, unless the head branch is an 'rc-' branch
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+          # Check if base branch starts with 'rc-'
+          if [[ "$BASE_BRANCH" != rc-* && "$HEAD_BRANCH" != rc-* ]]; then
+            echo "Error: The base branch '$BASE_BRANCH' is not an 'rc-' branch; and the head branch '$HEAD_BRANCH' is not an 'rc-' branch."
+            exit 1
+          fi

--- a/docs/sources/zoom/README.md
+++ b/docs/sources/zoom/README.md
@@ -81,3 +81,21 @@ sufficient, but as of May 2024 are no longer available for newly created Zoom ap
 Once the scopes are added, click on `Done` and then `Continue`.
 
 6. Activate the app
+
+## Troubleshooting
+
+### Zoom API Error : 400 invalid client
+
+`{"reason":"Invalid client_id or client_secret","error":"invalid_client"}`
+
+Causes:
+   - extra chars in Client ID; or incorrect Client ID
+
+Confirm that the `Client ID` and `Client Secret` are correctly set in your secret store solution (AWS Parameter Store, Secrets Manager, or GCP Secret Manager).
+
+### Zoom API Error : 400 Bad Request
+
+`{"reason":"Bad Request","error":"invalid_request"}`
+
+Causes:
+  - extra chars in Account ID; or incorrect Account ID

--- a/infra/examples-dev/aws-all/apply
+++ b/infra/examples-dev/aws-all/apply
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+terraform apply -auto-approve

--- a/infra/examples-dev/aws-all/google-workspace.tf
+++ b/infra/examples-dev/aws-all/google-workspace.tf
@@ -8,7 +8,7 @@ provider "google" {
 
 module "worklytics_connectors_google_workspace" {
   source = "../../modules/worklytics-connectors-google-workspace"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-google-workspace?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-google-workspace?ref=rc-v0.5.0"
 
   providers = {
     google = google.google_workspace

--- a/infra/examples-dev/aws-all/main.tf
+++ b/infra/examples-dev/aws-all/main.tf
@@ -21,7 +21,7 @@ terraform {
 # general cases
 module "worklytics_connectors" {
   source = "../../modules/worklytics-connectors"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=rc-v0.5.0"
 
   enabled_connectors               = var.enabled_connectors
   jira_cloud_id                    = var.jira_cloud_id
@@ -101,7 +101,7 @@ locals {
 
 module "psoxy" {
   source = "../../modules/aws-host"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-host?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-host?ref=rc-v0.5.0"
 
   environment_name                     = var.environment_name
   aws_account_id                       = var.aws_account_id
@@ -159,7 +159,7 @@ module "connection_in_worklytics" {
   for_each = local.all_instances
 
   source = "../../modules/worklytics-psoxy-connection-aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-aws?ref=rc-v0.5.0"
 
   psoxy_instance_id    = each.key
   worklytics_host      = var.worklytics_host

--- a/infra/examples-dev/aws-all/msft-365.tf
+++ b/infra/examples-dev/aws-all/msft-365.tf
@@ -2,7 +2,7 @@
 
 module "worklytics_connectors_msft_365" {
   source = "../../modules/worklytics-connectors-msft-365"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=rc-v0.5.0"
 
   enabled_connectors                         = var.enabled_connectors
   environment_id                             = var.environment_name
@@ -48,7 +48,7 @@ module "cognito_identity_pool" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-pool"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=rc-v0.5.0"
 
   developer_provider_name = local.developer_provider_name
   name                    = "${local.env_qualifier}-azure-ad-federation"
@@ -71,7 +71,7 @@ module "cognito_identity" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-identity-cli"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-identity-cli?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-identity-cli?ref=rc-v0.5.0"
 
   aws_region       = data.aws_region.current.id
   aws_role         = var.aws_assume_role_arn
@@ -108,7 +108,7 @@ module "msft_connection_auth_federation" {
   for_each = local.provision_entraid_apps ? local.enabled_to_entraid_object : local.shared_to_entraid_object
 
   source = "../../modules/azuread-federated-credentials"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=rc-v0.5.0"
 
   application_object_id = each.value.connector_id
   display_name          = "${local.env_qualifier}AccessFromAWS"

--- a/infra/examples-dev/aws-google-workspace/main.tf
+++ b/infra/examples-dev/aws-google-workspace/main.tf
@@ -59,7 +59,7 @@ data "google_project" "psoxy-google-connectors" {
 
 module "psoxy" {
   source = "../../modular-examples/aws-google-workspace"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=rc-v0.5.0"
 
   aws_account_id                 = var.aws_account_id
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)

--- a/infra/examples-dev/aws-msft-365/main.tf
+++ b/infra/examples-dev/aws-msft-365/main.tf
@@ -51,7 +51,7 @@ provider "azuread" {
 
 module "psoxy" {
   source = "../../modular-examples/aws-msft-365"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-msft-365?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-msft-365?ref=rc-v0.5.0"
 
   aws_account_id                 = var.aws_account_id
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -57,7 +57,7 @@ provider "azuread" {
 
 module "psoxy" {
   source = "../../modular-examples/aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws?ref=rc-v0.5.0"
 
   aws_account_id                 = var.aws_account_id
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)

--- a/infra/examples-dev/gcp-google-workspace/main.tf
+++ b/infra/examples-dev/gcp-google-workspace/main.tf
@@ -28,7 +28,7 @@ provider "google" {
 
 module "psoxy" {
   source = "../../modular-examples/gcp-google-workspace"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp-google-workspace?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp-google-workspace?ref=rc-v0.5.0"
 
   gcp_project_id                 = var.gcp_project_id
   environment_name               = var.environment_name

--- a/infra/examples-dev/gcp/apply
+++ b/infra/examples-dev/gcp/apply
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+terraform apply -auto-approve

--- a/infra/examples-dev/gcp/google-workspace.tf
+++ b/infra/examples-dev/gcp/google-workspace.tf
@@ -8,7 +8,7 @@ provider "google" {
 
 module "worklytics_connectors_google_workspace" {
   source = "../../modules/worklytics-connectors-google-workspace"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-google-workspace?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-google-workspace?ref=rc-v0.5.0"
 
   providers = {
     google = google.google_workspace

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -29,7 +29,7 @@ locals {
 # call this 'generic_source_connectors'?
 module "worklytics_connectors" {
   source = "../../modules/worklytics-connectors"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors?ref=rc-v0.5.0"
 
 
   enabled_connectors               = var.enabled_connectors
@@ -81,7 +81,7 @@ locals {
 
 module "psoxy" {
   source = "../../modules/gcp-host"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-host?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-host?ref=rc-v0.5.0"
 
   gcp_project_id                    = var.gcp_project_id
   environment_name                  = var.environment_name
@@ -121,7 +121,7 @@ module "connection_in_worklytics" {
   for_each = local.all_instances
 
   source = "../../modules/worklytics-psoxy-connection-generic"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key

--- a/infra/examples-dev/gcp/msft-365.tf
+++ b/infra/examples-dev/gcp/msft-365.tf
@@ -2,7 +2,7 @@
 
 module "worklytics_connectors_msft_365" {
   source = "../../modules/worklytics-connectors-msft-365"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connectors-msft-365?ref=rc-v0.5.0"
 
   enabled_connectors                         = var.enabled_connectors
   environment_id                             = var.environment_name
@@ -34,7 +34,7 @@ module "msft-connection-auth-federation" {
   for_each = module.worklytics_connectors_msft_365.enabled_api_connectors
 
   source = "../../modules/azuread-federated-credentials"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=rc-v0.5.0"
 
   application_object_id = each.value.connector.id
   display_name          = "GcpFederation"

--- a/infra/examples/aws-google-workspace/main.tf
+++ b/infra/examples/aws-google-workspace/main.tf
@@ -59,7 +59,7 @@ data "google_project" "psoxy-google-connectors" {
 
 module "psoxy" {
   # source = "../../modular-examples/aws-google-workspace"
-  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-google-workspace?ref=rc-v0.5.0"
 
   aws_account_id                 = var.aws_account_id
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)

--- a/infra/examples/aws-msft-365/main.tf
+++ b/infra/examples/aws-msft-365/main.tf
@@ -51,7 +51,7 @@ provider "azuread" {
 
 module "psoxy" {
   # source = "../../modular-examples/aws-msft-365"
-  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-msft-365?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/aws-msft-365?ref=rc-v0.5.0"
 
   aws_account_id                 = var.aws_account_id
   aws_assume_role_arn            = var.aws_assume_role_arn # role that can test the instances (lambdas)

--- a/infra/examples/gcp-google-workspace/main.tf
+++ b/infra/examples/gcp-google-workspace/main.tf
@@ -28,7 +28,7 @@ provider "google" {
 
 module "psoxy" {
   # source = "../../modular-examples/gcp-google-workspace"
-  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp-google-workspace?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modular-examples/gcp-google-workspace?ref=rc-v0.5.0"
 
   gcp_project_id                 = var.gcp_project_id
   environment_name               = var.environment_name

--- a/infra/examples/msft-365/main.tf
+++ b/infra/examples/msft-365/main.tf
@@ -34,7 +34,7 @@ data "azuread_client_config" "current" {}
 
 module "worklytics_connector_specs" {
   # source = "../../modules/worklytics-connector-specs"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=rc-v0.5.0"
 
   enabled_connectors = var.enabled_connectors
 
@@ -52,7 +52,7 @@ module "msft-connection" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-connection"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=rc-v0.5.0"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -65,7 +65,7 @@ module "msft-connection-auth-federation" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-federated-credentials"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=rc-v0.5.0"
 
   application_object_id = module.msft-connection[each.key].connector.id
   display_name          = "AccessFromAWS"
@@ -107,7 +107,7 @@ module "msft_365_grants" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   # source = "../../modules/azuread-grant-all-users"
-  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.61"
+  source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=rc-v0.5.0"
 
   psoxy_instance_id        = each.key
   application_id           = module.msft-connection[each.key].connector.application_id

--- a/infra/modular-examples/aws-google-workspace/main.tf
+++ b/infra/modular-examples/aws-google-workspace/main.tf
@@ -22,7 +22,7 @@ locals {
 
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=rc-v0.5.0
 
   enabled_connectors             = var.enabled_connectors
   google_workspace_example_user  = var.google_workspace_example_user
@@ -41,7 +41,7 @@ module "worklytics_connector_specs" {
 
 module "psoxy-aws" {
   source = "../../modules/aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=rc-v0.5.0
 
   aws_account_id                 = var.aws_account_id
   region                         = var.aws_region
@@ -55,7 +55,7 @@ module "psoxy-aws" {
 # secrets shared across all instances
 module "global_secrets" {
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=rc-v0.5.0
 
   path       = var.aws_ssm_param_root_path
   kms_key_id = var.aws_ssm_key_id
@@ -83,7 +83,7 @@ module "google-workspace-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/google-workspace-dwd-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=rc-v0.5.0
 
   project_id                   = var.gcp_project_id
   connector_service_account_id = "${module.env_id_gcp_sa.id}-${each.key}"
@@ -101,7 +101,7 @@ module "google-workspace-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/gcp-sa-auth-key"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key?ref=rc-v0.5.0"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
 }
@@ -110,7 +110,7 @@ module "sa-key-secrets" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=rc-v0.5.0"
   # other possibly implementations:
   # source = "../hashicorp-vault-secrets"
 
@@ -129,7 +129,7 @@ module "psoxy-google-workspace-connector" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                      = var.environment_name
   instance_id                           = each.key
@@ -171,7 +171,7 @@ module "worklytics-psoxy-connection-google-workspace" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_instance_id      = each.key
   psoxy_host_platform_id = local.host_platform_id
@@ -217,7 +217,7 @@ module "parameter-fill-instructions" {
   for_each = local.long_access_parameters
 
   source = "../../modules/aws-ssm-fill-md"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-fill-md?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-fill-md?ref=rc-v0.5.0"
 
   region         = var.aws_region
   parameter_name = aws_ssm_parameter.long-access-secrets[each.key].name
@@ -227,7 +227,7 @@ module "source_token_external_todo" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors_todos
 
   source = "../../modules/source-token-external-todo"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=rc-v0.5.0"
 
   source_id                         = each.key
   connector_specific_external_steps = each.value.external_token_todo
@@ -240,7 +240,7 @@ module "aws-psoxy-long-auth-connectors" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                = var.environment_name
   instance_id                     = each.key
@@ -285,7 +285,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_instance_id  = each.key
   connector_id       = try(each.value.worklytics_connector_id, "")
@@ -318,7 +318,7 @@ module "psoxy-bulk" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors, var.custom_bulk_connectors)
 
   source = "../../modules/aws-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=rc-v0.5.0"
 
   environment_name                 = var.environment_name
   instance_id                      = each.key
@@ -358,7 +358,7 @@ module "psoxy-bulk-to-worklytics" {
   var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -378,7 +378,7 @@ module "lookup_output" {
   for_each = var.lookup_table_builders
 
   source = "../../modules/aws-psoxy-output-bucket"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=rc-v0.5.0"
 
   environment_name              = var.environment_name
   instance_id                   = each.key

--- a/infra/modular-examples/aws-msft-365/main.tf
+++ b/infra/modular-examples/aws-msft-365/main.tf
@@ -24,7 +24,7 @@ data "azuread_client_config" "current" {}
 
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=rc-v0.5.0"
 
   enabled_connectors = var.enabled_connectors
   msft_tenant_id     = var.msft_tenant_id
@@ -44,7 +44,7 @@ module "worklytics_connector_specs" {
 
 module "psoxy-aws" {
   source = "../../modules/aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=rc-v0.5.0"
 
   aws_account_id                 = var.aws_account_id
   region                         = var.aws_region
@@ -57,7 +57,7 @@ module "psoxy-aws" {
 
 module "global_secrets" {
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=rc-v0.5.0"
 
   path       = var.aws_ssm_param_root_path
   kms_key_id = var.aws_ssm_key_id
@@ -76,7 +76,7 @@ moved {
 
 module "cognito-identity-pool" {
   source = "../../modules/aws-cognito-pool"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=rc-v0.5.0"
 
 
   developer_provider_name = "azure-access"
@@ -91,7 +91,7 @@ module "msft-connection" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/azuread-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=rc-v0.5.0"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -113,7 +113,7 @@ module "msft-connection-auth-federation" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/azuread-federated-credentials"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=rc-v0.5.0"
 
   application_object_id = module.msft-connection[each.key].connector.id
   display_name          = "AccessFromAWS"
@@ -130,7 +130,7 @@ module "msft_365_grants" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/azuread-grant-all-users"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=rc-v0.5.0"
 
   psoxy_instance_id        = each.key
   application_id           = module.msft-connection[each.key].connector.application_id
@@ -144,7 +144,7 @@ module "psoxy-msft-connector" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                = var.environment_name
   instance_id                     = each.key
@@ -194,7 +194,7 @@ module "worklytics-psoxy-connection-msft-365" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -239,7 +239,7 @@ module "parameter-fill-instructions" {
   for_each = local.long_access_parameters
 
   source = "../../modules/aws-ssm-fill-md"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-fill-md?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-fill-md?ref=rc-v0.5.0"
 
   region         = var.aws_region
   parameter_name = aws_ssm_parameter.long-access-secrets[each.key].name
@@ -249,7 +249,7 @@ module "source_token_external_todo" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors_todos
 
   source = "../../modules/source-token-external-todo"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=rc-v0.5.0"
 
   source_id                         = each.key
   connector_specific_external_steps = each.value.external_token_todo
@@ -262,7 +262,7 @@ module "aws-psoxy-long-auth-connectors" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                      = var.environment_name
   instance_id                           = each.key
@@ -305,7 +305,7 @@ module "worklytics-psoxy-connection-oauth-long-access" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -364,7 +364,7 @@ module "psoxy-bulk" {
   var.custom_bulk_connectors)
 
   source = "../../modules/aws-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=rc-v0.5.0"
 
   environment_name                 = var.environment_name
   aws_account_id                   = var.aws_account_id
@@ -409,7 +409,7 @@ module "psoxy-bulk-to-worklytics" {
   var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -429,7 +429,7 @@ module "lookup_output" {
   for_each = var.lookup_table_builders
 
   source = "../../modules/aws-psoxy-output-bucket"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=rc-v0.5.0"
 
   environment_name              = var.environment_name
   instance_id                   = each.key

--- a/infra/modular-examples/aws/main.tf
+++ b/infra/modular-examples/aws/main.tf
@@ -33,7 +33,7 @@ locals {
 
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=rc-v0.5.0
 
   enabled_connectors             = var.enabled_connectors
   google_workspace_example_user  = var.google_workspace_example_user
@@ -52,7 +52,7 @@ module "worklytics_connector_specs" {
 
 module "psoxy_aws" {
   source = "../../modules/aws"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws?ref=rc-v0.5.0
 
   aws_account_id                 = var.aws_account_id
   region                         = data.aws_region.current.id
@@ -75,7 +75,7 @@ moved {
 # secrets shared across all instances
 module "global_secrets" {
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=rc-v0.5.0
 
   path       = var.aws_ssm_param_root_path
   kms_key_id = var.aws_ssm_key_id
@@ -92,7 +92,7 @@ module "google_workspace_connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/google-workspace-dwd-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.61
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=rc-v0.5.0
 
   project_id                   = var.gcp_project_id
   connector_service_account_id = "${local.function_name_prefix}${local.deployment_id_sa_id_part}${each.key}"
@@ -117,7 +117,7 @@ module "google_workspace_connection_auth" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/gcp-sa-auth-key"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key?ref=rc-v0.5.0"
 
   service_account_id = module.google_workspace_connection[each.key].service_account_id
 }
@@ -133,7 +133,7 @@ module "sa_key_secrets" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/aws-ssm-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-secrets?ref=rc-v0.5.0"
   # other possibly implementations:
   # source = "../hashicorp-vault-secrets"
 
@@ -159,7 +159,7 @@ module "psoxy_google_workspace_connector" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                      = var.environment_name
   instance_id                           = each.key
@@ -203,7 +203,7 @@ module "worklytics_psoxy_connection_google_workspace" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_instance_id      = each.key
   psoxy_host_platform_id = local.host_platform_id
@@ -237,7 +237,7 @@ module "cognito_identity_pool" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-pool"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-pool?ref=rc-v0.5.0"
 
   developer_provider_name = "azure-access"
   name                    = "azure-ad-federation"
@@ -247,7 +247,7 @@ module "cognito_identity" {
   count = local.msft_365_enabled ? 1 : 0 # only provision identity pool if MSFT-365 connectors are enabled
 
   source = "../../modules/aws-cognito-identity-cli"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-identity-cli?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-cognito-identity-cli?ref=rc-v0.5.0"
 
   identity_pool_id = module.cognito_identity_pool[0].pool_id
   aws_region       = data.aws_region.current.id
@@ -269,7 +269,7 @@ module "msft_connection" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/azuread-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-connection?ref=rc-v0.5.0"
 
   display_name                      = "Psoxy Connector - ${each.value.display_name}${var.connector_display_name_suffix}"
   tenant_id                         = var.msft_tenant_id
@@ -288,7 +288,7 @@ module "msft_connection_auth_federation" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/azuread-federated-credentials"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-federated-credentials?ref=rc-v0.5.0"
 
   application_object_id = module.msft_connection[each.key].connector.id
   display_name          = "AccessFromAWS"
@@ -312,7 +312,7 @@ module "msft_365_grants" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/azuread-grant-all-users"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/azuread-grant-all-users?ref=rc-v0.5.0"
 
   psoxy_instance_id        = each.key
   application_id           = module.msft_connection[each.key].connector.application_id
@@ -326,7 +326,7 @@ module "psoxy_msft_connector" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                = var.environment_name
   instance_id                     = each.key
@@ -380,7 +380,7 @@ module "worklytics_psoxy_connection_msft_365" {
   for_each = module.worklytics_connector_specs.enabled_msft_365_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -433,7 +433,7 @@ module "parameter_fill_instructions" {
   for_each = local.long_access_parameters
 
   source = "../../modules/aws-ssm-fill-md"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-fill-md?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-ssm-fill-md?ref=rc-v0.5.0"
 
   region         = data.aws_region.current.id
   parameter_name = aws_ssm_parameter.long-access-secrets[each.key].name
@@ -449,7 +449,7 @@ module "source_token_external_todo" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors_todos
 
   source = "../../modules/source-token-external-todo"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=rc-v0.5.0"
 
   source_id                         = each.key
   connector_specific_external_steps = each.value.external_token_todo
@@ -462,7 +462,7 @@ module "aws_psoxy_long_auth_connectors" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/aws-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-rest?ref=rc-v0.5.0"
 
   environment_name                = var.environment_name
   instance_id                     = each.key
@@ -510,7 +510,7 @@ module "worklytics_psoxy_connection" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_instance_id  = each.key
   connector_id       = try(each.value.worklytics_connector_id, "")
@@ -549,7 +549,7 @@ module "psoxy_bulk" {
   for_each = merge(module.worklytics_connector_specs.enabled_bulk_connectors, var.custom_bulk_connectors)
 
   source = "../../modules/aws-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-bulk?ref=rc-v0.5.0"
 
   environment_name                 = var.environment_name
   instance_id                      = each.key
@@ -593,7 +593,7 @@ module "psoxy_bulk_to_worklytics" {
   var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -620,7 +620,7 @@ module "lookup_output" {
   for_each = var.lookup_table_builders
 
   source = "../../modules/aws-psoxy-output-bucket"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/aws-psoxy-output-bucket?ref=rc-v0.5.0"
 
   environment_name              = var.environment_name
   instance_id                   = each.key

--- a/infra/modular-examples/gcp-google-workspace/main.tf
+++ b/infra/modular-examples/gcp-google-workspace/main.tf
@@ -13,7 +13,7 @@ locals {
 
 module "worklytics_connector_specs" {
   source = "../../modules/worklytics-connector-specs"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-connector-specs?ref=rc-v0.5.0"
 
 
   enabled_connectors             = var.enabled_connectors
@@ -33,7 +33,7 @@ module "worklytics_connector_specs" {
 
 module "psoxy-gcp" {
   source = "../../modules/gcp"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp?ref=rc-v0.5.0"
 
   project_id        = var.gcp_project_id
   psoxy_base_dir    = var.psoxy_base_dir
@@ -47,7 +47,7 @@ module "google-workspace-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/google-workspace-dwd-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/google-workspace-dwd-connection?ref=rc-v0.5.0"
 
   project_id                   = var.gcp_project_id
   connector_service_account_id = "psoxy-${substr(each.key, 0, 24)}"
@@ -65,7 +65,7 @@ module "google-workspace-connection-auth" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/gcp-sa-auth-key"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-sa-auth-key?ref=rc-v0.5.0"
 
   service_account_id = module.google-workspace-connection[each.key].service_account_id
 }
@@ -75,7 +75,7 @@ module "google-workspace-key-secrets" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/gcp-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-secrets?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-secrets?ref=rc-v0.5.0"
 
   secret_project = var.gcp_project_id
   default_labels = var.default_labels
@@ -116,7 +116,7 @@ module "psoxy-google-workspace-connector" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/gcp-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=rc-v0.5.0"
 
   project_id                            = var.gcp_project_id
   source_kind                           = each.value.source_kind
@@ -159,7 +159,7 @@ module "worklytics-psoxy-connection" {
   for_each = module.worklytics_connector_specs.enabled_google_workspace_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key
@@ -192,7 +192,7 @@ module "connector-oauth" {
   for_each = local.long_access_parameters
 
   source = "../../modules/gcp-oauth-secrets"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-oauth-secrets?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-oauth-secrets?ref=rc-v0.5.0"
 
   secret_name           = "PSOXY_${upper(replace(each.value.connector_name, "-", "_"))}_${upper(each.value.secret_name)}"
   project_id            = var.gcp_project_id
@@ -213,7 +213,7 @@ module "long-auth-token-secret-fill-instructions" {
   for_each = local.long_access_parameters
 
   source = "../../modules/gcp-secret-fill-md"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-secret-fill-md?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-secret-fill-md?ref=rc-v0.5.0"
 
   project_id = var.gcp_project_id
   secret_id  = module.connector-oauth[each.key].secret_id
@@ -223,7 +223,7 @@ module "source_token_external_todo" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors_todos
 
   source = "../../modules/source-token-external-todo"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/source-token-external-todo?ref=rc-v0.5.0"
 
   source_id                         = each.key
   connector_specific_external_steps = each.value.external_token_todo
@@ -236,7 +236,7 @@ module "connector-long-auth-function" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/gcp-psoxy-rest"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-rest?ref=rc-v0.5.0"
 
   project_id                    = var.gcp_project_id
   source_kind                   = each.value.source_kind
@@ -281,7 +281,7 @@ module "worklytics-psoxy-connection-long-auth" {
   for_each = module.worklytics_connector_specs.enabled_oauth_long_access_connectors
 
   source = "../../modules/worklytics-psoxy-connection"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = "GCP"
   psoxy_instance_id      = each.key
@@ -299,7 +299,7 @@ module "psoxy-gcp-bulk" {
   var.custom_bulk_connectors)
 
   source = "../../modules/gcp-psoxy-bulk"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/gcp-psoxy-bulk?ref=rc-v0.5.0"
 
   project_id                    = var.gcp_project_id
   worklytics_sa_emails          = var.worklytics_sa_emails
@@ -333,7 +333,7 @@ module "psoxy-bulk-to-worklytics" {
   var.custom_bulk_connectors)
 
   source = "../../modules/worklytics-psoxy-connection-generic"
-  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=v0.4.61"
+  # source = "git::https://github.com/worklytics/psoxy//infra/modules/worklytics-psoxy-connection-generic?ref=rc-v0.5.0"
 
   psoxy_host_platform_id = local.host_platform_id
   psoxy_instance_id      = each.key

--- a/infra/modules/aws-ssm-secrets/main.tf
+++ b/infra/modules/aws-ssm-secrets/main.tf
@@ -13,21 +13,18 @@ locals {
 
   externally_managed_secrets = { for k, spec in var.secrets : k => spec if !(spec.value_managed_by_tf) }
   terraform_managed_secrets  = { for k, spec in var.secrets : k => spec if spec.value_managed_by_tf }
-
-  tf_management_description_appendix = "Value managed by a Terraform configuration; changes outside Terraform may be overwritten by subsequent 'terraform apply' runs"
 }
 
 # see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
 resource "aws_ssm_parameter" "secret" {
   for_each = local.terraform_managed_secrets
 
-  name = "${local.path_prefix}${each.key}"
-  # Due https://github.com/hashicorp/terraform-provider-aws/issues/31267
-  # all are added as secureString
-  type        = "SecureString"
-  description = each.value.description
-  value       = sensitive(coalesce(each.value.value, local.PLACEHOLDER_VALUE))
-  key_id      = coalesce(var.kms_key_id, "alias/aws/ssm")
+  name           = "${local.path_prefix}${each.key}"
+  type           = each.value.sensitive ? "SecureString" : "String"
+  description    = each.value.description
+  value          = each.value.sensitive ? sensitive(coalesce(each.value.value, local.PLACEHOLDER_VALUE)) : null
+  insecure_value = each.value.sensitive ? null : coalesce(each.value.value, local.PLACEHOLDER_VALUE)
+  key_id         = coalesce(var.kms_key_id, "alias/aws/ssm")
 
   lifecycle {
     ignore_changes = [
@@ -41,17 +38,17 @@ resource "aws_ssm_parameter" "secret" {
 resource "aws_ssm_parameter" "secret_with_externally_managed_value" {
   for_each = local.externally_managed_secrets
 
-  name = "${local.path_prefix}${each.key}"
-  # Due https://github.com/hashicorp/terraform-provider-aws/issues/31267
-  # all are added as secureString
-  type        = "SecureString"
-  description = each.value.description
-  value       = sensitive(coalesce(each.value.value, local.PLACEHOLDER_VALUE))
-  key_id      = coalesce(var.kms_key_id, "alias/aws/ssm")
+  name           = "${local.path_prefix}${each.key}"
+  type           = each.value.sensitive ? "SecureString" : "String"
+  description    = each.value.description
+  value          = each.value.sensitive ? sensitive(coalesce(each.value.value, local.PLACEHOLDER_VALUE)) : null
+  insecure_value = each.value.sensitive ? null : coalesce(each.value.value, local.PLACEHOLDER_VALUE)
+  key_id         = coalesce(var.kms_key_id, "alias/aws/ssm")
 
   lifecycle {
     ignore_changes = [
       value, # key difference here; we don't want to overwrite values filled by the external process
+      insecure_value,
       tags
     ]
   }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -971,14 +971,14 @@ EOT
         {
           name : "CLIENT_ID"
           writable : false
-          sensitive : false
+          sensitive : false # zoom renders in clear in console
           value_managed_by_tf : false
           description : "Client ID of the Zoom 'Server-to-Server' OAuth App used by the Connector to retrieve Zoom data. Value should be obtained from your Zoom admin."
         },
         {
           name : "ACCOUNT_ID"
           writable : false
-          sensitive : false
+          sensitive : false # zoom renders in clear in console
           value_managed_by_tf : false
           description : "Account ID of the Zoom tenant from which the Connector will retrieve Zoom data. Value should be obtained from your Zoom admin."
         },

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -978,7 +978,7 @@ EOT
         {
           name : "ACCOUNT_ID"
           writable : false
-          sensitive : true
+          sensitive : false
           value_managed_by_tf : false
           description : "Account ID of the Zoom tenant from which the Connector will retrieve Zoom data. Value should be obtained from your Zoom admin."
         },

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -989,13 +989,7 @@ EOT
           value_managed_by_tf : false
           description : "Short-lived Oauth access_token used by connector to retrieve Zoom data. Filled by Proxy instance."
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
-        }, # q: needed? per logic as of 9 June 2023, would be created
+        # used to have OAUTH_REFRESH_TOKEN; but as of Sept 2024, seeing that it's not being used
       ],
       reserved_concurrent_executions : null # 1
       example_api_calls_user_to_impersonate : null

--- a/java/core/src/main/java/co/worklytics/psoxy/ErrorCauses.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ErrorCauses.java
@@ -18,6 +18,12 @@ public enum ErrorCauses {
     /**
      * Third party call returned error
      */
-    API_ERROR;
+    API_ERROR,
+
+    /**
+     * request was not sent over HTTPS
+     */
+    HTTPS_REQUIRED,
+    ;
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/HttpEventRequest.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/HttpEventRequest.java
@@ -10,8 +10,11 @@ import java.util.Optional;
  */
 public interface HttpEventRequest {
 
-    // standard: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    // "de-facto" standard: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
     public static final String HTTP_HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
+
+    // "de-facto" standard:  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+    public static final String HTTP_HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
 
 
     String getPath();
@@ -35,4 +38,8 @@ public interface HttpEventRequest {
      */
     Optional<String> getClientIp();
 
+    /**
+     * @return whether original protocol of request is HTTPS, if known
+     */
+    Optional<Boolean> isHttps();
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -212,11 +212,10 @@ public class CommonRequestHandler {
             sourceApiRequest = requestFactory.buildRequest(request.getHttpMethod(), new GenericUrl(targetForSourceApiRequest), content);
         } catch (IOException e) {
             builder.statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            builder.body("Failed to parse request; review logs");
+            builder.body("Failed to parse response; review logs");
             builder.header(ResponseHeader.ERROR.getHttpHeader(), ErrorCauses.CONNECTION_SETUP.name());
-            log.log(Level.WARNING, e.getMessage(), e);
+            log.log(Level.WARNING, e.getMessage());
             //something like "Error getting access token for service account: 401 Unauthorized POST https://oauth2.googleapis.com/token,"
-            log.log(Level.WARNING, "Confirm oauth scopes set in config.yaml match those granted in data source");
             return builder.build();
         } catch (java.util.NoSuchElementException e) {
             // missing config, such as ACCESS_TOKEN
@@ -225,8 +224,6 @@ public class CommonRequestHandler {
             log.log(Level.WARNING, e.getMessage(), e);
             return builder.build();
         }
-
-        //TODO: what headers to forward???
         populateHeadersFromSource(sourceApiRequest, request, targetForSourceApiRequest);
 
         //setup request

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandler.java
@@ -137,6 +137,17 @@ public class CommonRequestHandler {
 
         logRequestIfVerbose(request);
 
+        // application-level enforcement of HTTPS
+        // (NOTE: should be redundant with infrastructure-level configuration)
+        if (!request.isHttps().orElse(true)) {
+            return HttpEventResponse.builder()
+                    .statusCode(HttpStatus.SC_BAD_REQUEST)
+                    .header(ResponseHeader.ERROR.getHttpHeader(), ErrorCauses.HTTPS_REQUIRED.name())
+                    .body("Requests MUST be sent over HTTPS")
+                    .build();
+        }
+
+
         Optional<HttpEventResponse> healthCheckResponse = healthCheckRequestHandler.handleIfHealthCheck(request);
         if (healthCheckResponse.isPresent()) {
             return healthCheckResponse.get();

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 @Log
 public class HealthCheckRequestHandler {
 
-    static final String JAVA_SOURCE_CODE_VERSION = "v0.4.61";
+    static final String JAVA_SOURCE_CODE_VERSION = "rc-v0.5.0";
 
     @Inject
     EnvVarsConfigService envVarsConfigService;

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -140,6 +140,11 @@ class CommonRequestHandlerTest {
             public Optional<String> getClientIp() {
                 return Optional.of("127.0.0.1");
             }
+
+            @Override
+            public Optional<Boolean> isHttps() {
+                return Optional.empty();
+            }
         };
         when(handler.config.getConfigPropertyOrError(eq(ProxyConfigProperty.TARGET_HOST))).thenReturn("proxyhost.com");
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -115,7 +115,7 @@ public class ParameterStoreConfigService implements SecretStore, LockService {
 
             Optional<T> r;
             if (Objects.equals(parameterResponse.parameter().value(), PLACEHOLDER_VALUE)) {
-                log.warning("Found placeholder value for " + paramName + "; this is either a misconfiguration, or a value that proxy itself should later fill.");
+                log.info("Found placeholder value for " + paramName + "; this is either a misconfiguration, or a value that proxy itself should later fill.");
                 r = Optional.empty();
             } else {
                 if (envVarsConfig.isDevelopment()) {

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapter.java
@@ -94,6 +94,12 @@ public class APIGatewayV1ProxyEventRequestAdapter implements co.worklytics.psoxy
         return Optional.ofNullable(ip);
     }
 
+    @Override
+    public Optional<Boolean> isHttps() {
+        return Optional.ofNullable(event.getHeaders().get(HTTP_HEADER_X_FORWARDED_PROTO.toLowerCase()))
+            .map(p -> p.equals("https"));
+    }
+
     /**
      * @return view of Headers with lower-case names
      *

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapter.java
@@ -95,6 +95,10 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
         return event.getRequestContext().getHttp().getMethod();
     }
 
+    public String getProtocol() {
+        return event.getRequestContext().getHttp().getProtocol();
+    }
+
     @Override
     @SneakyThrows
     public byte[] getBody() {
@@ -109,6 +113,12 @@ public class APIGatewayV2HTTPEventRequestAdapter implements HttpEventRequest {
     @Override
     public Optional<String> getClientIp() {
        return Optional.ofNullable(this.getCaseInsensitiveHeaders().get(HTTP_HEADER_X_FORWARDED_FOR.toLowerCase()));
+    }
+
+    @Override
+    public Optional<Boolean> isHttps() {
+        return Optional.ofNullable(this.getCaseInsensitiveHeaders().get(HTTP_HEADER_X_FORWARDED_PROTO.toLowerCase()))
+            .map(p -> p.equals("https"));
     }
 
     /**

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
@@ -28,6 +28,8 @@ public class APIGatewayV1ProxyEventRequestAdapterTest {
         assertFalse(requestAdapter.getQuery().isPresent());
 
         assertFalse(requestAdapter.getClientIp().isPresent());
+
+        assertFalse(requestAdapter.isHttps().isPresent());
     }
 
     @SneakyThrows
@@ -46,5 +48,7 @@ public class APIGatewayV1ProxyEventRequestAdapterTest {
 
         assertEquals("name=John", requestAdapter.getQuery().get());
 
+
+        assertFalse(requestAdapter.isHttps().isPresent());
     }
 }

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV2HTTPEventRequestAdapterTest.java
@@ -4,6 +4,7 @@ import co.worklytics.test.TestUtils;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -33,6 +34,10 @@ class APIGatewayV2HTTPEventRequestAdapterTest {
         assertEquals("value1,value2", String.join(",", requestAdapter.getMultiValueHeader("multi-header").get()));
 
         assertEquals("73.19.103.123", requestAdapter.getClientIp().get());
+
+        assertEquals("GET", requestAdapter.getHttpMethod());
+
+        assertTrue(requestAdapter.isHttps().get());
     }
 
     @SneakyThrows
@@ -47,6 +52,9 @@ class APIGatewayV2HTTPEventRequestAdapterTest {
         assertEquals("/", requestAdapter.getPath());
 
         assertEquals("205.255.255.176", requestAdapter.getClientIp().get());
+
+
+        assertTrue(requestAdapter.isHttps().get());
     }
 
     @SneakyThrows

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/CloudFunctionRequest.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/CloudFunctionRequest.java
@@ -101,6 +101,12 @@ public class CloudFunctionRequest implements HttpEventRequest {
             .map(values -> values.get(0));
     }
 
+    @Override
+    public Optional<Boolean> isHttps() {
+        return Optional.ofNullable(request.getHeaders().get(HttpEventRequest.HTTP_HEADER_X_FORWARDED_PROTO))
+            .map(values -> values.get(0).equals("https"));
+    }
+
 
     public List<String> getWarnings() {
         List<String> warnings = new LinkedList<>();

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.4.61</revision>
+        <revision>0.5.0</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.lombok.version>1.18.30</dependency.lombok.version> <!-- 1.18.30 is min compatible with jdk 21+ -->
         <dependency.dagger.version>2.40.5</dependency.dagger.version>

--- a/tools/init-tfvars.sh
+++ b/tools/init-tfvars.sh
@@ -7,7 +7,7 @@ PSOXY_BASE_DIR=$2
 DEPLOYMENT_ENV=${3:-"local"}
 HOST_PLATFORM=${4:-"aws"}
 
-SCRIPT_VERSION="v0.4.61"
+SCRIPT_VERSION="rc-v0.5.0"
 
 if [ -z "$PSOXY_BASE_DIR" ]; then
   printf "Usage: init-tfvars.sh <path-to-terraform.tfvars> <path-to-psoxy-base-directory> [DEPLOYMENT_ENV]\n"

--- a/tools/psoxy-test/package-lock.json
+++ b/tools/psoxy-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psoxy-test",
-  "version": "0.4.9",
+  "version": "0.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "psoxy-test",
-      "version": "0.4.9",
+      "version": "0.4.11",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.350.0",


### PR DESCRIPTION
### Features
 - zoom account id, client id don't need to be sensitive

### Fixes
  - fix AWS parameter store stuff so `String` rather than `SecureString` used

TODO
  - [ ] test carefully that bug previously noted is no longer a problem; possibly pin AWS provider version to avoid it

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes, ppl will see a change**
