### PR TITLE
S186 docs fixes

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 * [PSOXY](README.md)
 * [Overview](overview.md)
-  * [Authentication](authentication-authorization)
+  * [Authentication](authentication-authorization.md)
 * [Install Prerequisites](prereqs-ubuntu.md)
 * [AWS](aws/README.md)
   * [Getting Started](aws/getting-started.md)

--- a/docs/development/terraform-architecture.md
+++ b/docs/development/terraform-architecture.md
@@ -6,14 +6,22 @@ provide easy support for extending the examples/modules to support them in the e
 
 Composition is the canonical terraform approach.
 
-3 approaches:
+Two approaches:
 
-1. composition, which is canonical terraform a. commented out
-   - validation
-   - instructions to explain to customers are more complex b. conditional : validation will work,
-     but hacky 0 indexes around in places
-2. conditionals + variables pros:
-   - simplest for customers
-   - easiest to read/follow cons:
-   - verbose interfaces
-   - brittle stacks (changing variable requires changing many in hierarch)
+1. composition, which is canonical terraform
+
+    a. commented out
+    - validation
+    - instructions to explain to customers are more complex
+
+    b. conditional: validation will work, but hacky 0 indexes around in places
+
+2. conditionals + variables
+
+    pros:
+    - simplest for customers
+    - easiest to read/follow
+
+   cons:
+     - verbose interfaces
+     - brittle stacks (changing variable requires changing many in hierarchy)

--- a/docs/sources/atlassian/jira/README.md
+++ b/docs/sources/atlassian/jira/README.md
@@ -42,25 +42,25 @@ AWS CLoud Shell,
 
    - `read:jira-user`
    - `read:jira-work`
-   
-   ![Classic Scopes for Jira API](./img/jira-cloud-jira-api-scope-permissions.png) 
+
+   ![Classic Scopes for Jira API](./img/jira-cloud-jira-api-scope-permissions.png)
 
    And these from "Granular Scopes":
    - `read:group:jira`
    - `read:avatar:jira`
    - `read:user:jira`
-  
+
   ![Granular Scopes for Jira API](./img/jira-cloud-jira-api-scope-granular-permissions.png)
 
    Then go back to "Permissions" and click on "Add" for `User Identity API`, only selecting
    following scopes:
 
    - `read:account`
-  
+
   ![Classic Scopes for User Identity API](./img/jira-cloud-user-api-scope-permissions.png)
 
    After adding all the scopes, you should have 1 permission for `User Identity API` and 5 for
-   `Jira API`: 
+   `Jira API`:
 
   ![Permissions](./img/jira-cloud-final-permissions.png)
 
@@ -140,9 +140,9 @@ And its response will be something like:
 ]
 ```
 
-Add the `id` value from that JSON response as the value of the `jira_cloud_id` variable in the
-`terraform.tfvars` file of your Terraform configuration. This will generate all the test URLs with a
-proper value for targeting a valid Jira Cloud instance.
+In your Terraform configuration's `terraform.tfvars` file, set the `jira_cloud_id` variable to the
+`id` value from the JSON response. This will ensure that all **test URLs** are generated with the
+correct value, targeting a valid Jira Cloud instance.
 
 NOTE: A "token family" includes the initial access/refresh tokens generated above as well as all
 subsequent access/refresh tokens that Jira returns to any future token refresh requests. By default,

--- a/infra/modules/worklytics-psoxy-connection-generic/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-generic/main.tf
@@ -14,7 +14,6 @@ locals {
     PROXY_ENDPOINT      = "Psoxy Base URL"
     PROXY_BUCKET_NAME   = "Bucket Name"
     parserId            = "Parser"
-    CLOUD_ID            = "Jira Cloud Id"
     GITHUB_ORGANIZATION = "GitHub Organization"
   }
 

--- a/tools/jira-cloud-auth.sh
+++ b/tools/jira-cloud-auth.sh
@@ -2,7 +2,7 @@
 
 # a script to simplify the process of creating oauth app in Jira Cloud, authorizing it for the
 # the required scopes, and obtaining authentication credentials that can be used by the proxy
-# connector
+# connector (similar to https://github.com/Worklytics/psoxy-oauth-setup-tool)
 
 # Prefer printf over echo for compatibility and formatting
 # Use colors for output


### PR DESCRIPTION
### Fixes
 - Broken link: authentication page
 - Development format

### Features
 - Review `jira_cloud_id` var usage: removed from TODO. Value only required for "test URLs", not for actual connection in Worklytics.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
