### PR TITLE
S186 tenant api submodules integration

### DIFF
--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -94,6 +94,19 @@ module "psoxy" {
   bulk_input_expiration_days     = var.bulk_input_expiration_days
 }
 
+module "connection_via_tenant_api" {
+  # dev example path: "../../../../terraform-aws-worklytics/examples/create_psoxy_connections"
+  # TODO URL of the actual repo to illustrate... initial version not released yet
+  source = "git::https://github.com/worklytics/terraform-aws-worklytics/examples/create_psoxy_connections?ref=v0.1.0"
+
+  # TODO review this: using the 1st unique ID while testing is OK, but maybe we should define a
+  #  an explicit variable for it
+  worklytics_tenant_id         = var.caller_gcp_service_account_ids[0]
+  user_principal_email         = var.user_principal_email
+  psoxy_connections            = module.psoxy.tenant_api_connection_settings
+  psoxy_connection_script_path = path.module
+}
+
 # if you generated these, you may want them to import back into your data warehouse
 output "lookup_tables" {
   value = module.psoxy.lookup_tables

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -299,3 +299,8 @@ variable "todos_as_outputs" {
   description = "whether to render TODOs as outputs or flat files (former useful if you're using Terraform Cloud/Enterprise, or somewhere else where the filesystem is not readily accessible to you)"
   default     = false
 }
+
+variable "user_principal_email" {
+  type        = string
+  description = "The email of the user that has been granted access to the Worklytics Tenant API (configure in Worklytics Web App)."
+}

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -142,6 +142,18 @@ module "connection_in_worklytics" {
   try(each.value.settings_to_provide, {}))
 }
 
+module "connection_via_tenant_api" {
+  # dev example path  = "../../../../terraform-gcp-worklytics/examples/create_psoxy_connections"
+  # TODO URL of the actual repo to illustrate... initial version not released yet
+  source = "git::https://github.com/worklytics/terraform-gcp-worklytics/examples/create_psoxy_connections?ref=v0.1.0"
+
+  project_id                   = var.gcp_project_id
+  service_account_id           = "worklytics-tenant-api" # it's the default value
+  worklytics_tenant_id         = var.worklytics_tenant_id
+  psoxy_connections            = [for connection in module.connection_in_worklytics : connection.tenant_api_connection_settings]
+  psoxy_connection_script_path = path.module
+}
+
 output "path_to_deployment_jar" {
   description = "Path to the package to deploy (JAR)."
   value       = module.psoxy.path_to_deployment_jar

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -63,6 +63,16 @@ variable "worklytics_sa_emails" {
   description = "service accounts for your organization's Worklytics instances (list supported for test/dev scenarios)"
 }
 
+variable "worklytics_tenant_id" {
+  type        = string
+  description = "Numeric ID of your Worklytics tenant's service account (obtain from Worklytics Web App)."
+
+  validation {
+    condition     = var.worklytics_tenant_id == null || can(regex("^\\d{21}$", var.worklytics_tenant_id))
+    error_message = "`worklytics_tenant_id` must be a 21-digit numeric value."
+  }
+}
+
 variable "psoxy_base_dir" {
   type        = string
   description = "the path where your psoxy repo resides"

--- a/infra/modular-examples/aws/outputs.tf
+++ b/infra/modular-examples/aws/outputs.tf
@@ -46,3 +46,10 @@ output "caller_role_arn" {
   value       = module.psoxy_aws.api_caller_role_arn
 }
 
+output "tenant_api_connection_settings" {
+  value = concat(
+    values(module.worklytics_psoxy_connection)[*].tenant_api_settings,
+    values(module.worklytics_psoxy_connection_google_workspace)[*].tenant_api_settings,
+    values(module.psoxy_bulk_to_worklytics)[*].tenant_api_settings
+  )
+}

--- a/infra/modules/worklytics-psoxy-connection-aws/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-aws/main.tf
@@ -35,3 +35,7 @@ output "next_todo_step" {
 output "todo" {
   value = module.generic.todo
 }
+
+output "tenant_api_connection_settings" {
+  value = module.generic.tenant_api_connection_settings
+}

--- a/infra/modules/worklytics-psoxy-connection-generic/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-generic/main.tf
@@ -82,3 +82,15 @@ output "next_todo_step" {
 output "todo" {
   value = local.todo_content
 }
+
+output "tenant_api_connection_settings" {
+  value = merge(
+    { integration = var.connector_id },
+    contains(keys(var.settings_to_provide), "Psoxy Base URL") ? { endpoint = var.settings_to_provide["Psoxy Base URL"] } : {},
+    contains(keys(var.settings_to_provide), "Bucket Name") ? { bucket = var.settings_to_provide["Bucket Name"] } : {},
+    contains(keys(var.settings_to_provide), "AWS Psoxy Region") ? { region = var.settings_to_provide["AWS Psoxy Region"] } : {},
+    contains(keys(var.settings_to_provide), "AWS Psoxy Role ARN") ? { role_arn = var.settings_to_provide["AWS Psoxy Role ARN"] } : {},
+    contains(keys(var.settings_to_provide), "Parser") ? { parser_id = var.settings_to_provide["Parser"] } : {},
+    contains(keys(var.settings_to_provide), "GitHub Organization") ? { github_organization = var.settings_to_provide["GitHub Organization"] } : {},
+  )
+}

--- a/infra/modules/worklytics-psoxy-connection/main.tf
+++ b/infra/modules/worklytics-psoxy-connection/main.tf
@@ -28,3 +28,7 @@ output "todo" {
 output "next_todo_step" {
   value = module.generic.next_todo_step
 }
+
+output "tenant_api_connection_settings" {
+  value = module.generic.tenant_api_connection_settings
+}


### PR DESCRIPTION
Tenant API integration: just an example of submodules integration (tested and working). @eschultink thoughts on this? If you agree with this approach, there would still be a couple details left to implement: 
- [ ] update the appropriate TODO file to reference the script
- [ ] make it optional via `init` script?

### Fixes
.

### Features
- Integrate Tenant API submodules: create bash scripts (and required authentication resources) for each connection. Checks expected to fail, as submodules haven't been released.

### Change implications

 - dependencies added/changed? **yes** New submodules
 - something important to note in future release notes? **not yet**
