### PR TITLE
customization fixes / support

### DIFF
--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -286,12 +286,13 @@ variable "custom_bulk_connectors" {
 
 variable "custom_bulk_connector_rules" {
   type = map(object({
-    pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
-    columnsToRedact       = optional(list(string), []) # columns to remove from CSV
-    columnsToInclude      = optional(list(string))     # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
-    columnsToPseudonymize = optional(list(string), []) # columns to pseudonymize
-    columnsToDuplicate    = optional(map(string))      # columns to create copy of; name --> new name
-    columnsToRename       = optional(map(string))      # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
+    pseudonymFormat                = optional(string, "URL_SAFE_TOKEN")
+    columnsToRedact                = optional(list(string), []) # columns to remove from CSV
+    columnsToInclude               = optional(list(string))     # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
+    columnsToPseudonymize          = optional(list(string), []) # columns to pseudonymize
+    columnsToPseudonymizeIfPresent = optional(list(string), null)
+    columnsToDuplicate             = optional(map(string)) # columns to create copy of; name --> new name
+    columnsToRename                = optional(map(string)) # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
     fieldsToTransform = optional(map(object({
       newName    = string
       transforms = optional(list(map(string)), [])

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -339,6 +339,7 @@ variable "lookup_table_builders" {
       columnsToDuplicate    = optional(map(string))
       columnsToRename       = optional(map(string))
     })
+    compress_output = optional(bool)
   }))
   default = {
     #    "hris-lookup" = {

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -279,7 +279,7 @@ variable "lookup_tables" {
     sanitized_accessor_principals = optional(list(string))
     expiration_days               = optional(number)
     output_bucket_name            = optional(string) # allow override of default bucket name
-    compress_output = optional(bool)
+    compress_output               = optional(bool)
   }))
   description = "Lookup tables to build from same source input as another connector, output to a distinct bucket. The original `join_key_column` will be preserved, "
 

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -279,6 +279,7 @@ variable "lookup_tables" {
     sanitized_accessor_principals = optional(list(string))
     expiration_days               = optional(number)
     output_bucket_name            = optional(string) # allow override of default bucket name
+    compress_output = optional(bool)
   }))
   description = "Lookup tables to build from same source input as another connector, output to a distinct bucket. The original `join_key_column` will be preserved, "
 

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -189,12 +189,13 @@ variable "custom_bulk_connectors" {
     worklytics_connector_id   = optional(string, "bulk-import-psoxy")
     worklytics_connector_name = optional(string, "Custom Bulk Data via Psoxy")
     rules = optional(object({
-      pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
-      columnsToRedact       = optional(list(string)) # columns to remove from CSV
-      columnsToInclude      = optional(list(string)) # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
-      columnsToPseudonymize = optional(list(string)) # columns to pseudonymize
-      columnsToDuplicate    = optional(map(string))  # columns to create copy of; name --> new name
-      columnsToRename       = optional(map(string))  # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
+      pseudonymFormat                = optional(string, "URL_SAFE_TOKEN")
+      columnsToRedact                = optional(list(string)) # columns to remove from CSV
+      columnsToInclude               = optional(list(string)) # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
+      columnsToPseudonymize          = optional(list(string)) # columns to pseudonymize
+      columnsToPseudonymizeIfPresent = optional(list(string))
+      columnsToDuplicate             = optional(map(string)) # columns to create copy of; name --> new name
+      columnsToRename                = optional(map(string)) # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
       fieldsToTransform = optional(map(object({
         newName    = string
         transforms = optional(list(map(string)), [])
@@ -222,12 +223,13 @@ variable "custom_bulk_connectors" {
 
 variable "custom_bulk_connector_rules" {
   type = map(object({
-    pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
-    columnsToRedact       = optional(list(string), []) # columns to remove from CSV
-    columnsToInclude      = optional(list(string))     # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
-    columnsToPseudonymize = optional(list(string), []) # columns to pseudonymize
-    columnsToDuplicate    = optional(map(string))      # columns to create copy of; name --> new name
-    columnsToRename       = optional(map(string))      # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
+    pseudonymFormat                = optional(string, "URL_SAFE_TOKEN")
+    columnsToRedact                = optional(list(string), []) # columns to remove from CSV
+    columnsToInclude               = optional(list(string))     # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
+    columnsToPseudonymize          = optional(list(string), []) # columns to pseudonymize
+    columnsToPseudonymizeIfPresent = optional(list(string))
+    columnsToDuplicate             = optional(map(string)) # columns to create copy of; name --> new name
+    columnsToRename                = optional(map(string)) # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
     fieldsToTransform = optional(map(object({
       newName    = string
       transforms = optional(list(map(string)), [])

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -277,7 +277,7 @@ resource "aws_ssm_parameter" "additional_transforms" {
   value = yamlencode([for k, v in var.lookup_table_builders : {
     destinationBucketName : module.lookup_output[k].output_bucket
     rules : v.rules
-    compressOutput: v.compress_output
+    compressOutput : v.compress_output
   } if v.input_connector_id == each.key])
 }
 

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -277,6 +277,7 @@ resource "aws_ssm_parameter" "additional_transforms" {
   value = yamlencode([for k, v in var.lookup_table_builders : {
     destinationBucketName : module.lookup_output[k].output_bucket
     rules : v.rules
+    compressOutput: v.compress_output
   } if v.input_connector_id == each.key])
 }
 

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -301,6 +301,7 @@ variable "lookup_table_builders" {
       columnsToDuplicate    = optional(map(string))
       columnsToRename       = optional(map(string))
     })
+    compress_output = optional(bool)
   }))
   default = {
     #    "lookup-hris" = {

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -249,20 +249,35 @@ variable "bulk_sanitized_expiration_days" {
 variable "custom_bulk_connector_rules" {
   type = map(object({
     pseudonymFormat                = optional(string, "URL_SAFE_TOKEN")
-    columnsToRedact                = optional(list(string))
-    columnsToInclude               = optional(list(string))
-    columnsToPseudonymize          = optional(list(string))
+    columnsToRedact                = optional(list(string), []) # columns to remove from CSV
+    columnsToInclude               = optional(list(string))     # if you prefer to include only an explicit list of columns, rather than redacting those you don't want
+    columnsToPseudonymize          = optional(list(string), []) # columns to pseudonymize
     columnsToPseudonymizeIfPresent = optional(list(string), null)
-    columnsToDuplicate             = optional(map(string))
-    columnsToRename                = optional(map(string))
+    columnsToDuplicate             = optional(map(string)) # columns to create copy of; name --> new name
+    columnsToRename                = optional(map(string)) # columns to rename: original name --> new name; renames applied BEFORE pseudonymization
     fieldsToTransform = optional(map(object({
       newName    = string
       transforms = optional(list(map(string)), [])
-    })), {})
+    })))
   }))
 
   description = "map of connector id --> rules object"
-  default     = {}
+  default = {
+    # hris = {
+    #   columnsToRedact       = []
+    #   columnsToPseudonymize = [
+    #     "EMPLOYEE_ID",
+    #     "EMPLOYEE_EMAIL",
+    #     "MANAGER_ID",
+    #     "MANAGER_EMAIL"
+    #  ]
+    # columnsToRename = {
+    #   # original --> new
+    #   "workday_id" = "employee_id"
+    # }
+    # columnsToInclude = [
+    # ]
+  }
 }
 
 variable "custom_bulk_connector_arguments" {

--- a/infra/modules/azuread-federated-credentials/main.tf
+++ b/infra/modules/azuread-federated-credentials/main.tf
@@ -10,11 +10,11 @@ terraform {
 
 resource "azuread_application_federated_identity_credential" "federated_credential" {
   application_id = var.application_id
-  display_name = var.display_name
-  description     = var.description
+  display_name   = var.display_name
+  description    = var.description
   audiences      = [var.audience]
-  issuer             = var.issuer
-  subject           = var.subject
+  issuer         = var.issuer
+  subject        = var.subject
 }
 
 output "credential" {

--- a/infra/modules/azuread-local-cert/main.tf
+++ b/infra/modules/azuread-local-cert/main.tf
@@ -25,10 +25,10 @@ data "external" "certificate" {
 # NOTE: have gotten '400 with OData error: KeyCredentialsInvalidEndDate: Key credential end date is invalid'
 # when trying to apply this, even though only using 6 month expiration window. Re-apply worked ...
 resource "azuread_application_certificate" "certificate" {
-  application_id        = var.application_id
-  type                  = "AsymmetricX509Cert"
-  value                 = base64decode(data.external.certificate.result.cert)
-  end_date              = timeadd(time_rotating.rotation.id, "${var.cert_expiration_days * 24}h")
+  application_id = var.application_id
+  type           = "AsymmetricX509Cert"
+  value          = base64decode(data.external.certificate.result.cert)
+  end_date       = timeadd(time_rotating.rotation.id, "${var.cert_expiration_days * 24}h")
 
   lifecycle {
     create_before_destroy = true

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -301,6 +301,7 @@ resource "google_secret_manager_secret_version" "additional_transforms" {
           v.join_key_column, "${v.join_key_column}_pseudonym"
         ]), null)
       }
+      compressOutput : v.compress_output
     } if v.source_connector_id == each.key
   ])
 }

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -195,12 +195,13 @@ variable "bulk_sanitized_expiration_days" {
 # q: move this into custom_bulk_connector_args
 variable "custom_bulk_connector_rules" {
   type = map(object({
-    pseudonymFormat       = optional(string, "URL_SAFE_TOKEN")
-    columnsToRedact       = optional(list(string), [])
-    columnsToInclude      = optional(list(string))
-    columnsToPseudonymize = optional(list(string), [])
-    columnsToDuplicate    = optional(map(string))
-    columnsToRename       = optional(map(string))
+    pseudonymFormat                = optional(string, "URL_SAFE_TOKEN")
+    columnsToRedact                = optional(list(string), [])
+    columnsToInclude               = optional(list(string))
+    columnsToPseudonymize          = optional(list(string), [])
+    columnsToPseudonymizeIfPresent = optional(list(string))
+    columnsToDuplicate             = optional(map(string))
+    columnsToRename                = optional(map(string))
     fieldsToTransform = optional(map(object({
       newName    = string
       transforms = optional(list(map(string)), [])

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -237,7 +237,7 @@ variable "lookup_tables" {
     columns_to_include            = optional(list(string))
     sanitized_accessor_principals = optional(list(string))
     expiration_days               = optional(number, 5 * 365)
-    compress_output = optional(bool)
+    compress_output               = optional(bool)
   }))
   description = "Lookup tables to build from same source input as another connector, output to a distinct bucket. The original `join_key_column` will be preserved, "
 

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -237,6 +237,7 @@ variable "lookup_tables" {
     columns_to_include            = optional(list(string))
     sanitized_accessor_principals = optional(list(string))
     expiration_days               = optional(number, 5 * 365)
+    compress_output = optional(bool)
   }))
   description = "Lookup tables to build from same source input as another connector, output to a distinct bucket. The original `join_key_column` will be preserved, "
 

--- a/infra/modules/worklytics-connectors-msft-365/outputs.tf
+++ b/infra/modules/worklytics-connectors-msft-365/outputs.tf
@@ -35,8 +35,8 @@ output "api_clients" {
   value = {
     for id, connection in module.msft_connection :
     id => {
-      oauth_client_id        = connection.connector.client_id # yes, it's same as application id; but duplicated for clarity
-      azuread_object_id      = connection.connector.object_id # used for terraform imports
+      oauth_client_id   = connection.connector.client_id # yes, it's same as application id; but duplicated for clarity
+      azuread_object_id = connection.connector.object_id # used for terraform imports
     }
   }
 }

--- a/infra/modules/worklytics-psoxy-connection-aws/main.tf
+++ b/infra/modules/worklytics-psoxy-connection-aws/main.tf
@@ -6,13 +6,13 @@
 module "generic" {
   source = "../worklytics-psoxy-connection-generic"
 
-  proxy_instance_id      = var.proxy_instance_id
-  host_platform_id       = "AWS"
-  todo_step              = var.todo_step
-  display_name           = var.display_name
-  worklytics_host        = var.worklytics_host
-  todos_as_local_files   = var.todos_as_local_files
-  connector_id           = var.connector_id
+  proxy_instance_id    = var.proxy_instance_id
+  host_platform_id     = "AWS"
+  todo_step            = var.todo_step
+  display_name         = var.display_name
+  worklytics_host      = var.worklytics_host
+  todos_as_local_files = var.todos_as_local_files
+  connector_id         = var.connector_id
 
 
   settings_to_provide = merge(

--- a/infra/modules/worklytics-psoxy-connection/main.tf
+++ b/infra/modules/worklytics-psoxy-connection/main.tf
@@ -6,13 +6,13 @@
 module "generic" {
   source = "../worklytics-psoxy-connection-generic"
 
-  proxy_instance_id      = var.psoxy_instance_id
-  connector_id           = var.connector_id
-  host_platform_id       = var.psoxy_host_platform_id
-  display_name           = var.display_name
-  todo_step              = var.todo_step
-  todos_as_local_files   = var.todos_as_local_files
-  worklytics_host        = var.worklytics_host
+  proxy_instance_id    = var.psoxy_instance_id
+  connector_id         = var.connector_id
+  host_platform_id     = var.psoxy_host_platform_id
+  display_name         = var.display_name
+  todo_step            = var.todo_step
+  todos_as_local_files = var.todos_as_local_files
+  worklytics_host      = var.worklytics_host
 
   settings_to_provide = merge(var.settings_to_provide,
     {


### PR DESCRIPTION
### Fixes
 - fix aws example variables to have consistent schema with aws-host; main implication of this is exposing `columnsToPseudonymizeIfPresent`; this isn't strictly needed, as in custom case, we presumably know CSV schema - so don't need this conditional case; but this does make things a bit easier
 - make compression behavior overridable on transform; helps with lookup table case, avoiding compressed output so customers can directly ingest even if their pipeline doesn't support copmression


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208719786863521