### PR TITLE
Add teams with default scopes

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/RulesUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/RulesUtils.java
@@ -165,6 +165,7 @@ public class RulesUtils {
         defaultScopeIdBySource.put("azure-ad", "azure-ad");
         defaultScopeIdBySource.put("outlook-cal", "azure-ad");
         defaultScopeIdBySource.put("outlook-mail", "azure-ad");
+        defaultScopeIdBySource.put("msft-teams", "azure-ad");
 
         defaultScopeIdBySource.put("github", "github");
         defaultScopeIdBySource.put("github-enterprise-server", "github");

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
@@ -15,12 +15,14 @@ public class TeamsTests extends JavaRulesTestBaseCase {
     @Getter
     final Rules2 rulesUnderTest = PrebuiltSanitizerRules.MS_TEAMS;
 
-    @Getter
-    final RulesTestSpec rulesTestSpec = RulesTestSpec.builder()
-            .sourceFamily("microsoft-365")
-            .defaultScopeId("azure-ad")
-            .sourceKind("msft-teams")
-            .build();
+    @Override
+    public RulesTestSpec getRulesTestSpec() {
+        return RulesTestSpec.builder()
+                .sourceFamily("microsoft-365")
+                .defaultScopeId(rulesUtils.getDefaultScopeIdFromSource("msft-teams"))
+                .sourceKind("msft-teams")
+                .build();
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"v1.0"})

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
@@ -2,6 +2,7 @@ package co.worklytics.psoxy.rules.msft;
 
 import co.worklytics.psoxy.rules.JavaRulesTestBaseCase;
 import co.worklytics.psoxy.rules.Rules2;
+import co.worklytics.psoxy.rules.RulesUtils;
 import jdk.jfr.Description;
 import lombok.Getter;
 import org.junit.jupiter.api.Disabled;
@@ -20,14 +21,16 @@ public class Teams_NoUserIds_Tests extends JavaRulesTestBaseCase {
     final Rules2 rulesUnderTest = PrebuiltSanitizerRules.MS_TEAMS_NO_USER_ID;
 
 
-    @Getter
-    final RulesTestSpec rulesTestSpec = RulesTestSpec.builder()
-            .sourceFamily("microsoft-365")
-            .defaultScopeId("azure-ad")
-            .sourceKind("msft-teams")
-            .rulesFile("msft-teams_no-userIds")
-            .exampleSanitizedApiResponsesPath("example-api-responses/sanitized_no-userIds/")
-            .build();
+    @Override
+    public RulesTestSpec getRulesTestSpec() {
+        return RulesTestSpec.builder()
+                .sourceFamily("microsoft-365")
+                .sourceKind("msft-teams")
+                .defaultScopeId(rulesUtils.getDefaultScopeIdFromSource("msft-teams"))
+                .rulesFile("msft-teams_no-userIds")
+                .exampleSanitizedApiResponsesPath("example-api-responses/sanitized_no-userIds/")
+                .build();
+    }
 
     @Test
     @Description("Test endpoint:" + PrebuiltSanitizerRules.MS_TEAMS_PATH_TEMPLATES_TEAMS)


### PR DESCRIPTION
`msft-teams` should use `azure-ad` as default scope, but it was using a deprecated property on that and no value was provided, leaving it as the same as source.

### Fixes
[Psoxy: msft-teams scope](https://app.asana.com/0/0/1208737224528874)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
