### PR TITLE
Fix missing attendance id pseudonymization for MSFT Teams

### DIFF
--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/original/Users_onlineMeetings_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/original/Users_onlineMeetings_v1.0.json
@@ -28,7 +28,7 @@
             "displayName": "Tyler Stein"
           }
         },
-        "upn": "upn-value"
+        "upn": "foo@some-domain.com"
       }
     ],
     "organizer": {

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Users_onlineMeetings_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Users_onlineMeetings_v1.0.json
@@ -26,8 +26,7 @@
             "@odata.type":"#microsoft.graph.identity",
             "id":"112f7296-5ca-bae8-6a692b15d4b8"
           }
-        },
-        "upn":"upn-value"
+        }
       }
     ],
     "organizer":{
@@ -37,8 +36,7 @@
           "@odata.type":"#microsoft.graph.identity",
           "id":"5810cedeb-b2c1-e9bd5d53ec96"
         }
-      },
-      "upn":"upn-value"
+      }
     }
   },
   "startDateTime":"2018-05-30T00:30:00Z",

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Users_onlineMeetings_attendanceReport_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Users_onlineMeetings_attendanceReport_v1.0.json
@@ -9,7 +9,7 @@
       "totalAttendanceInSeconds":1152,
       "role":"Presenter",
       "identity":{
-        "id":"dc17674c-81d9-4adb-bfb2-8f6a442e4623",
+        "id":"{\"scope\":\"azure-ad\",\"hash\":\"MwYK48L-UYMIsFrz1EHA4xX8hwfxJQfyg_L-vtEV1Mc\"}",
         "tenantId":null
       },
       "attendanceIntervals":[

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Users_onlineMeetings_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Users_onlineMeetings_v1.0.json
@@ -21,8 +21,7 @@
           "user":{
             "id":"{\"scope\":\"azure-ad\",\"hash\":\"KvrBhIhPrAEMwI320CqhyGSfgVmKedObWZ5X380uX04\"}"
           }
-        },
-        "upn":"upn-value"
+        }
       }
     ],
     "organizer":{
@@ -30,8 +29,7 @@
         "user":{
           "id":"{\"scope\":\"azure-ad\",\"hash\":\"OkGYJKhA8lYaD0IJw3YHj8cB9qiSMw6MA_70P99wa3o\"}"
         }
-      },
-      "upn":"upn-value"
+      }
     }
   },
   "startDateTime":"2018-05-30T00:30:00Z",

--- a/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
@@ -221,6 +221,7 @@ endpoints:
           - "$..joinInformation"
           - "$..joinMeetingIdSettings.isPasscodeRequired"
           - "$..joinMeetingIdSettings.passcode"
+          - "$..upn"
   - pathTemplate: "/v1.0/users/{userId}/onlineMeetings/{meetingId}/attendanceReports"
     allowedQueryParams:
       - "$select"
@@ -248,6 +249,7 @@ endpoints:
           - "$..joinInformation"
           - "$..joinMeetingIdSettings.isPasscodeRequired"
           - "$..joinMeetingIdSettings.passcode"
+          - "$..upn"
   - pathTemplate: "/v1.0/users/{userId}/onlineMeetings/{meetingId}/attendanceReports/{reportId}"
     allowedQueryParams:
       - "$select"
@@ -275,6 +277,7 @@ endpoints:
           - "$..joinInformation"
           - "$..joinMeetingIdSettings.isPasscodeRequired"
           - "$..joinMeetingIdSettings.passcode"
+          - "$..upn"
   - pathRegex: "^/v1.0/users/?[^/]*"
     allowedQueryParams:
       - "$top"

--- a/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
@@ -245,6 +245,10 @@ endpoints:
         encoding: "JSON"
       - !<pseudonymize>
         jsonPaths:
+          - "$..identity.id"
+        encoding: "JSON"
+      - !<pseudonymize>
+        jsonPaths:
           - "$..user.id"
           - "$..userId"
         encoding: "JSON"
@@ -255,6 +259,7 @@ endpoints:
           - "$..joinInformation"
           - "$..joinMeetingIdSettings.isPasscodeRequired"
           - "$..joinMeetingIdSettings.passcode"
+          - "$..upn"
       - !<redact>
         jsonPaths:
           - "$..['@odata.context']"
@@ -274,6 +279,10 @@ endpoints:
         encoding: "JSON"
       - !<pseudonymize>
         jsonPaths:
+          - "$..identity.id"
+        encoding: "JSON"
+      - !<pseudonymize>
+        jsonPaths:
           - "$..user.id"
           - "$..userId"
         encoding: "JSON"
@@ -284,6 +293,7 @@ endpoints:
           - "$..joinInformation"
           - "$..joinMeetingIdSettings.isPasscodeRequired"
           - "$..joinMeetingIdSettings.passcode"
+          - "$..upn"
       - !<redact>
         jsonPaths:
           - "$..['@odata.context']"
@@ -305,6 +315,10 @@ endpoints:
         jsonPaths:
           - "$..emailAddress"
         encoding: "JSON"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..identity.id"
+        encoding: "JSON"
       - !<tokenize>
         jsonPaths:
           - "$.['@odata.nextLink', '@odata.prevLink', 'sessions@odata.nextLink']"
@@ -316,6 +330,7 @@ endpoints:
           - "$..joinInformation"
           - "$..joinMeetingIdSettings.isPasscodeRequired"
           - "$..joinMeetingIdSettings.passcode"
+          - "$..upn"
           - "$..['@odata.context']"
           - "$..['@odata.type']"
   - pathRegex: "^/v1.0/users(/p~[a-zA-Z0-9_-]+?)?[^/]*"

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -436,6 +436,7 @@ public class PrebuiltSanitizerRules {
             .jsonPath("$..joinInformation")
             .jsonPath("$..joinMeetingIdSettings.isPasscodeRequired")
             .jsonPath("$..joinMeetingIdSettings.passcode")
+            .jsonPath("$..upn")
             .build();
 
     static final Transform.Tokenize MS_TEAMS_CALL_ID_TOKENIZATION = Transform.Tokenize.builder()
@@ -650,6 +651,9 @@ public class PrebuiltSanitizerRules {
             .endpoint(Endpoint.builder()
                     .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO + "/onlineMeetings/[a-zA-Z0-9_-]+/attendanceReports/[a-zA-Z0-9_-]+(\\?.*)?")
                     .transform(MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE)
+                    .transform(Transform.Pseudonymize.builder()
+                            .jsonPath("$..identity.id")
+                            .build())
                     .transform(PSEUDONYMIZE_USER_ID)
                     .transform(MS_TEAMS_USERS_ONLINE_MEETINGS_REDACT)
                     .transform(REDACT_ODATA_CONTEXT)
@@ -659,6 +663,9 @@ public class PrebuiltSanitizerRules {
             .endpoint(Endpoint.builder()
                     .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO + "/onlineMeetings/[a-zA-Z0-9_-]+/attendanceReports(\\?.*)?")
                     .transform(MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE)
+                    .transform(Transform.Pseudonymize.builder()
+                            .jsonPath("$..identity.id")
+                            .build())
                     .transform(PSEUDONYMIZE_USER_ID)
                     .transform(MS_TEAMS_USERS_ONLINE_MEETINGS_REDACT)
                     .transform(REDACT_ODATA_CONTEXT)
@@ -669,6 +676,9 @@ public class PrebuiltSanitizerRules {
                     .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO + "/onlineMeetings(\\?.*)?")
                     .transforms(Arrays.asList(PSEUDONYMIZE_USER_ID,
                             MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE,
+                            Transform.Pseudonymize.builder()
+                                    .jsonPath("$..identity.id")
+                                    .build(),
                             TOKENIZE_ODATA_LINKS,
                             MS_TEAMS_USERS_ONLINE_MEETINGS_REDACT
                                     .toBuilder()

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
@@ -424,6 +424,7 @@ public class TeamsTests extends JavaRulesTestBaseCase {
         String userId = "dc17674c-81d9-4adb-bfb2-8f6a442e4622";
         String endpoint = "https://graph.microsoft.com/" + apiVersion + "/users/" + userId + "/onlineMeetings";
         String jsonResponse = asJson("Users_onlineMeetings_" + apiVersion + ".json");
+
         assertNotSanitized(jsonResponse,
                 "everyone",
                 "5552478",
@@ -437,7 +438,8 @@ public class TeamsTests extends JavaRulesTestBaseCase {
                 "https://teams.microsoft.com/l/meetup-join/19%3a:meeting_NTg0NmQ3NTctZDVkZC00YzRhLThmNmEtOGQDdmZDZk@thread.v2/0?context=%7b%22Tid%22%3a%aa67bd4c-8475-432d-bd41-39f255720e0a%22%2c%22Oid%22%3a%22112f7296-5fa4-42ca-bb15d4b8%22%7d",
                 "112f7296-5ca-bae8-6a692b15d4b8",
                 "5810cedeb-b2c1-e9bd5d53ec96",
-                "joinMeetingId", "1234567890"
+                "joinMeetingId",
+                "1234567890"
         );
 
         String sanitized = sanitize(endpoint, jsonResponse);
@@ -451,7 +453,9 @@ public class TeamsTests extends JavaRulesTestBaseCase {
                 "macAddress",
                 "reflexiveIPAddress",
                 "relayIPAddress",
-                "subnet"
+                "subnet",
+                "foo@some-domain.com",
+                "upn-value"
         );
         assertUrlWithSubResourcesBlocked(endpoint);
     }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
@@ -272,6 +272,7 @@ public class Teams_NoUserIds_Tests extends JavaRulesTestBaseCase {
         String jsonResponse = asJson("Users_onlineMeetings_" + "v1.0" + ".json");
 
         String sanitized = sanitize(endpoint, jsonResponse);
+
         assertPseudonymized(sanitized, "112f7296-5ca-bae8-6a692b15d4b8", "5810cedeb-b2c1-e9bd5d53ec96");
         assertRedacted(sanitized,
                 "@odata.type",
@@ -279,7 +280,9 @@ public class Teams_NoUserIds_Tests extends JavaRulesTestBaseCase {
                 "#microsoft.graph.chatInfo",
                 "#microsoft.graph.meetingParticipants",
                 "#microsoft.graph.identitySet",
-                "#microsoft.graph.identity"
+                "#microsoft.graph.identity",
+                "foo@some-domain.com",
+                "upn-value"
         );
         assertUrlWithSubResourcesBlocked(endpoint);
     }


### PR DESCRIPTION
`id` was leaving when it is referring to user identities, which should be pseudonymized in case of *no user ids rules*

### Fixes
[AttendanceReport user id not pseudonymized?](https://app.asana.com/0/1208685314640389/1208740643943926)
 - []()

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
