### PR TITLE
java17 for both source and byte code

### DIFF
--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -13,11 +13,6 @@ on:
       - 'rc-*'
 
 jobs:
-  # Java 11 - Oracle support ended 30 Sept 2023 ... but still what ships with GCP cloud shell!!!
-  ci_java11:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '11'
 
   # Java 17 - supported until 30 Sept 2026; same as our default build as of Apr 2023
   ci_java17:
@@ -25,18 +20,14 @@ jobs:
     with:
       java-version: '17'
 
-  # Java 20 - support ended 19 Sept 2023
-  # NOTE: psoxy versions 0.4.40 supported this; if you need it, option to downgrade to that.
-  # although beyond me why 17 and 21 both work, but 20 doesn't; best guess is Mockito 5 degrading
-  # behavior in some way for 20 that isn't needed for 21 and doesn't matter for 17?
-
-  ci_java20:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '20'
-
   # Java 21 - released 19 Sept 2023, supported until Sept 2028 (LTS)
   ci_java21:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '21'
+
+  # Java 23 - released 17 Sept 2024, supported until March 2025
+  ci_java23:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '23'

--- a/.github/workflows/ci-java8-core.yaml
+++ b/.github/workflows/ci-java8-core.yaml
@@ -1,6 +1,8 @@
-name: CI - java8 core
+name: CI - java17 core
 
-# CI to build and test project components for which we need java8 builds
+# NOTE: as of Dec 2024, regulard build is ALSO java17, so not useful - but let's keep around bc possibly Worklytics will use 17 beyond when that's the proxy default
+
+# CI to build and test project components for which we need java17 builds
 # NOTE: this is ONLY core/gateway-core libraries; we don't build the executable/deployment bundles
 #      (eg, this does not build, cmd-line,aws, gcp)
 #
@@ -15,9 +17,9 @@ on:
 #      - '**' # should match all branches
 
 jobs:
-  ci_java8_core:
+  ci_java17_core:
     env:
-      compile-profile: '-P java8 ' # NOTE: trailing space is important
+      # compile-profile: '-P java8 ' # NOTE: trailing space is important
       java-version: '17' # build w java 17, but pom configured to still build java 8 byte code
     runs-on: ubuntu-latest
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -212,16 +212,15 @@ command line tools.
 
 You will need all the following in your deployment environment (eg, your laptop):
 
-| Tool                                            | Version                | Test Command          |
-|-------------------------------------------------|------------------------|-----------------------|
-| [git](https://git-scm.com/)                     | 2.17+                  | `git --version`       |
-| [Maven](https://maven.apache.org/)              | 3.6+                   | `mvn -v`              |
-| [Java JDK 11+](https://openjdk.org/install/) | 11, 17, 21 (see notes) | `mvn -v \| grep Java` |
-| [Terraform](https://www.terraform.io/)          | 1.6+, <= 1.9           | `terraform version`   |
+| Tool                                            | Version               | Test Command          |
+|-------------------------------------------------|-----------------------|-----------------------|
+| [git](https://git-scm.com/)                     | 2.17+                 | `git --version`       |
+| [Maven](https://maven.apache.org/)              | 3.6+                  | `mvn -v`              |
+| [Java JDK 11+](https://openjdk.org/install/) | 17, 21 (see notes) | `mvn -v \| grep Java` |
+| [Terraform](https://www.terraform.io/)          | 1.6+, < 2.0           | `terraform version`   |
 
 NOTE: we will support Java versions for duration of official support windows, in particular the
-LTS versions. As of Nov 2023, we  still support java 11 but may end this at any time. Minor
-versions, such as 12-16, and 18-20, which are out of official support, may work but are not
+LTS versions. Minor versions, such as 18-20, which are out of official support, may work but are not
 routinely tested.
 
 NOTE: Using `terraform` is not strictly necessary, but it is the only supported method. You may
@@ -229,8 +228,6 @@ provision your infrastructure via your host's CLI, web console, or another infra
 tool, but we don't offer documentation or support in doing so.  Adapting one of our
 [terraform examples](https://github.com/Worklytics/psoxy/tree/main/infra/examples) or writing your own config that re-uses our
 [modules](https://github.com/Worklytics/psoxy/tree/main/infra/modules) will simplify things greatly.
-
-NOTE: Refrain to use Terraform versions 1.4.x that are < v1.4.3. We've seen bugs.
 
 NOTE: from v0.4.59, we've relaxed Terraform version constraint on our modules to allow up to 1.9.x.
 However, we are not officially supporting this, as we strive to maintain compatibility with both

--- a/docs/prereqs-ubuntu.md
+++ b/docs/prereqs-ubuntu.md
@@ -12,10 +12,10 @@ sudo apt update
 2. install Java + maven (required to build the proxy binary to be deployed)
 
 ```shell
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-17-jdk
 sudo apt install maven
 
-# check that maven version at least 3.6+ and java 11+
+# check that maven version at least 3.6+ and java 17+
 mvn -v
 
 # if not, get latest direct from Apache Maven

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Users_onlineMeetings_attendanceReport_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Users_onlineMeetings_attendanceReport_v1.0.json
@@ -9,7 +9,7 @@
       "totalAttendanceInSeconds":1152,
       "role":"Presenter",
       "identity":{
-        "id":"{\"scope\":\"azure-ad\",\"hash\":\"MwYK48L-UYMIsFrz1EHA4xX8hwfxJQfyg_L-vtEV1Mc\"}",
+        "id":"{\"hash\":\"MwYK48L-UYMIsFrz1EHA4xX8hwfxJQfyg_L-vtEV1Mc\"}",
         "tenantId":null
       },
       "attendanceIntervals":[

--- a/infra/modules/aws-psoxy-rest/test_script.tftpl
+++ b/infra/modules/aws-psoxy-rest/test_script.tftpl
@@ -9,5 +9,5 @@ ${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param}
 
 echo "Invoke this script with any of the following as arguments to test other endpoints:"
 %{ for example_api_call in example_api_calls ~}
-  echo "\t\"${example_api_call}\""
+  printf "\t\"${example_api_call}\"\n"
 %{ endfor ~}

--- a/infra/modules/gcp-psoxy-rest/test_script.tftpl
+++ b/infra/modules/gcp-psoxy-rest/test_script.tftpl
@@ -9,5 +9,5 @@ ${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param}
 
 echo "Invoke this script with any of the following as arguments to test other endpoints:"
 %{ for example_api_call in example_api_calls ~}
-  echo "\t\"${example_api_call}\""
+  printf "\t\"${example_api_call}\"\n"
 %{ endfor ~}

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -16,28 +16,27 @@
     <description>Code that's core to both Psoxy clients and implementations</description>
 
     <properties>
-        <!-- empty for java 11 builds -->
+        <!-- empty for default java builds  (17 as of Dec 2024) -->
         <artifactSuffix></artifactSuffix>
     </properties>
 
-    <!-- generates a jdk8 compatible jar -->
-    <!-- mvn clean install -P java8 -->
+    <!-- generates a jdk17 compatible jar -->
+    <!-- mvn clean install -P java17 -->
     <profiles>
         <profile>
-            <id>java8</id>
+            <id>java17</id>
             <properties>
-                <artifactSuffix>-jdk8</artifactSuffix>
-                <dependency.mockito-junit-jupiter.version>4.11.0</dependency.mockito-junit-jupiter.version>
+                <artifactSuffix>-jdk17</artifactSuffix>
             </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.1</version>
+                        <version>3.13.0</version>
                         <configuration>
-                            <source>8</source>
-                            <target>8</target>
+                            <source>17</source>
+                            <target>17</target>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
@@ -19,7 +19,6 @@ public class TeamsTests extends JavaRulesTestBaseCase {
     public RulesTestSpec getRulesTestSpec() {
         return RulesTestSpec.builder()
                 .sourceFamily("microsoft-365")
-                .defaultScopeId(rulesUtils.getDefaultScopeIdFromSource("msft-teams"))
                 .sourceKind("msft-teams")
                 .build();
     }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
@@ -26,7 +26,6 @@ public class Teams_NoUserIds_Tests extends JavaRulesTestBaseCase {
         return RulesTestSpec.builder()
                 .sourceFamily("microsoft-365")
                 .sourceKind("msft-teams")
-                .defaultScopeId(rulesUtils.getDefaultScopeIdFromSource("msft-teams"))
                 .rulesFile("msft-teams_no-userIds")
                 .exampleSanitizedApiResponsesPath("example-api-responses/sanitized_no-userIds/")
                 .build();

--- a/java/gateway-core/pom.xml
+++ b/java/gateway-core/pom.xml
@@ -16,27 +16,27 @@
     <description>Code for pseuydonymizations</description>
 
     <properties>
-        <!-- empty for java 17 builds -->
+        <!-- empty for default java builds  (1 7 as of v0.5.0 )-->
         <artifactSuffix></artifactSuffix>
     </properties>
 
-    <!-- generates a jdk8 compatible jar -->
-    <!-- mvn clean install -P java8 -->
+    <!-- generates a jdk17 compatible jar -->
+    <!-- mvn clean install -P java17 -->
     <profiles>
         <profile>
-            <id>java8</id>
+            <id>java17</id>
             <properties>
-                <artifactSuffix>-jdk8</artifactSuffix>
+                <artifactSuffix>-jdk17</artifactSuffix>
             </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.1</version>
+                        <version>3.13.0</version>
                         <configuration>
-                            <source>8</source>
-                            <target>8</target>
+                            <source>17</source>
+                            <target>17</target>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -55,8 +55,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.google.dagger</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>


### PR DESCRIPTION

### Fixes
 - issue with merge conflicts; still using deprecated methods
 - fix test case that was added in 0.4.62, after branching for 0.5
 - test script template had literal `\t`, instead of rendering it


### Features
 - bump java source code and byte code versions to 17 (11 EoL in Oct-2024, although LTS so will still get critical fixes/extended support through ~2030 in most cases)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **java17 will not be min runtime was default for gcp/aws cases already**
