### PR TITLE
GCP secret access robustness

### DIFF
--- a/infra/modules/gcp-secrets/main.tf
+++ b/infra/modules/gcp-secrets/main.tf
@@ -69,20 +69,9 @@ output "secret_ids" { # prefixed w `projects/{numeric_id}/secrets/`
   value = { for k, v in var.secrets : k => google_secret_manager_secret.secret[k].id }
 }
 
-#DEPRECATED; use `secret_ids_within_project` instead
-output "secret_secret_ids" {
-  # relative to project
-  value = { for k, v in var.secrets : k => google_secret_manager_secret.secret[k].secret_id }
-}
-
 output "secret_ids_within_project" {
   # relative to project
   value = { for k, v in var.secrets : k => google_secret_manager_secret.secret[k].secret_id }
-}
-
-#DEPRECATED; don't believe any modules use this, as of v0.4.29
-output "secret_version_names" {
-  value = { for k, v in local.secrets_w_terraform_managed_values : k => google_secret_manager_secret_version.version[k].name }
 }
 
 output "secret_version_numbers" {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -352,7 +352,10 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                         || storedToken.getLastModifiedDate().get()
                                 .isBefore(Instant.now().minus(MIN_DURATION_TO_KEEP_REFRESH_TOKEN)))
                     .ifPresent(storedTokenToRotate -> {
+                        // if reaching here, there's a new refresh token AND stored token was last written at least MIN_DURATION_TO_KEEP_REFRESH_TOKEN ago
+                        // (want to avoid churning through refresh tokens if source is giving us a new one every time, as this is pretty expensive for secret manager)
                         try {
+                            log.info("New oauth refresh_token came with access_token response; updating stored value");
                             secretStore.putConfigProperty(RefreshTokenTokenRequestBuilder.ConfigProperty.REFRESH_TOKEN,
                                     tokenResponse.getRefreshToken(), WRITE_RETRIES);
                         } catch (WritePropertyRetriesExhaustedException e) {


### PR DESCRIPTION
### Fixes
  - logic to access GCP secrets via explicit version stored on label on the secret MAY be causing issues, due to the label value being stale if someone updates the token outside of our code

### Features
  - more logging around GCP secret access
  - more logging when oauth refresh tokens updated

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208948645711048