### PR TITLE
drop OAUTH_REFRESH_TOKEN parameters (no longer used)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changes to be including in future/planned release notes will be added here.
 
 ## Next
 
+## [0.5.1](https://github.com/Worklytics/psoxy/release/tag/v0.5.1) - unreleased
+  - legacy OAUTH_REFRESH_TOKEN secrets/parameters have been removed; these were previously used to
+     "lock" token refresh process, but are no longer used. You may see these destroyed in your terraform plan.
+
 ## [0.5.0](https://github.com/Worklytics/psoxy/release/tag/v0.5.0)
 
 BREAKING:

--- a/docs/sources/zoom/README.md
+++ b/docs/sources/zoom/README.md
@@ -81,3 +81,21 @@ sufficient, but as of May 2024 are no longer available for newly created Zoom ap
 Once the scopes are added, click on `Done` and then `Continue`.
 
 6. Activate the app
+
+## Troubleshooting
+
+### Zoom API Error : 400 invalid client
+
+`{"reason":"Invalid client_id or client_secret","error":"invalid_client"}`
+
+Causes:
+   - extra chars in Client ID; or incorrect Client ID
+
+Confirm that the `Client ID` and `Client Secret` are correctly set in your secret store solution (AWS Parameter Store, Secrets Manager, or GCP Secret Manager).
+
+### Zoom API Error : 400 Bad Request
+
+`{"reason":"Bad Request","error":"invalid_request"}`
+
+Causes:
+  - extra chars in Account ID; or incorrect Account ID

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -955,14 +955,14 @@ EOT
         {
           name : "CLIENT_ID"
           writable : false
-          sensitive : false
+          sensitive : false # zoom renders in clear in console
           value_managed_by_tf : false
           description : "Client ID of the Zoom 'Server-to-Server' OAuth App used by the Connector to retrieve Zoom data. Value should be obtained from your Zoom admin."
         },
         {
           name : "ACCOUNT_ID"
           writable : false
-          sensitive : false
+          sensitive : false # zoom renders in clear in console
           value_managed_by_tf : false
           description : "Account ID of the Zoom tenant from which the Connector will retrieve Zoom data. Value should be obtained from your Zoom admin."
         },

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -446,13 +446,6 @@ EOT
           writable : false
           sensitive : true
           value_managed_by_tf : false
-        },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
         }
       ],
       environment_variables : {
@@ -547,13 +540,6 @@ EOT
           name : "REFRESH_TOKEN"
           writable : true
           sensitive : true
-          value_managed_by_tf : false
-        },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true   # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
-          sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
           value_managed_by_tf : false
         },
         {
@@ -677,13 +663,6 @@ EOT
           writable : false
           sensitive : true
           value_managed_by_tf : false
-        },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
         }
       ],
       environment_variables : {
@@ -781,13 +760,6 @@ EOT
         {
           name : "CLIENT_ID"
           writable : false
-          sensitive : true
-          value_managed_by_tf : false
-        },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
           sensitive : true
           value_managed_by_tf : false
         },
@@ -972,8 +944,7 @@ EOT
           sensitive : true
           value_managed_by_tf : false
           description : "Short-lived Oauth access_token used by connector to retrieve Zoom data. Filled by Proxy instance."
-        },
-        # used to have OAUTH_REFRESH_TOKEN; but as of Sept 2024, seeing that it's not being used
+        }
       ],
       reserved_concurrent_executions : null # 1
       example_api_calls_user_to_impersonate : null
@@ -1193,13 +1164,6 @@ EOT
           name : "REFRESH_TOKEN"
           writable : true
           sensitive : true
-          value_managed_by_tf : false
-        },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true   # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
-          sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
           value_managed_by_tf : false
         },
         {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -962,7 +962,7 @@ EOT
         {
           name : "ACCOUNT_ID"
           writable : false
-          sensitive : true
+          sensitive : false
           value_managed_by_tf : false
           description : "Account ID of the Zoom tenant from which the Connector will retrieve Zoom data. Value should be obtained from your Zoom admin."
         },

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -973,13 +973,7 @@ EOT
           value_managed_by_tf : false
           description : "Short-lived Oauth access_token used by connector to retrieve Zoom data. Filled by Proxy instance."
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
-        }, # q: needed? per logic as of 9 June 2023, would be created
+        # used to have OAUTH_REFRESH_TOKEN; but as of Sept 2024, seeing that it's not being used
       ],
       reserved_concurrent_executions : null # 1
       example_api_calls_user_to_impersonate : null

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/AccountCredentialsGrantTokenRequestBuilder.java
@@ -8,6 +8,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.UrlEncodedContent;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import java.nio.charset.StandardCharsets;
@@ -60,23 +61,26 @@ public class AccountCredentialsGrantTokenRequestBuilder implements OAuthRefreshT
 
     @Override
     public HttpContent buildPayload() {
+
+        //trim to avoid copy-paste errors
+        //q : check for non-printable chars or anything like that
+        String accountId = StringUtils.trim(config.getConfigPropertyAsOptional(ConfigProperty.ACCOUNT_ID)
+            .orElseGet(() -> secretStore.getConfigPropertyOrError(ConfigProperty.ACCOUNT_ID)));
+
         // The documentation doesn't say anything to use POST data, but passes everything in the URL
         // Tested manually and, for the moment, it is accepted as POST data
         Map<String, String> data = new TreeMap<>();
         data.put(PARAM_GRANT_TYPE, getGrantType());
-        //q: move to config? cost-benefit, mainly
-        data.put(PARAM_ACCOUNT_ID,
-            config.getConfigPropertyAsOptional(ConfigProperty.ACCOUNT_ID)
-            .orElseGet(() -> secretStore.getConfigPropertyOrError(ConfigProperty.ACCOUNT_ID)));
+        data.put(PARAM_ACCOUNT_ID, accountId);
         return new UrlEncodedContent(data);
     }
 
     @Override
     public void addHeaders(HttpHeaders httpHeaders) {
-        String clientId = config.getConfigPropertyAsOptional(ConfigProperty.CLIENT_ID)
-            .orElseGet(() -> secretStore.getConfigPropertyOrError(ConfigProperty.CLIENT_ID));
+        String clientId = StringUtils.trim(config.getConfigPropertyAsOptional(ConfigProperty.CLIENT_ID)
+            .orElseGet(() -> secretStore.getConfigPropertyOrError(ConfigProperty.CLIENT_ID)));
 
-        String clientSecret = secretStore.getConfigPropertyOrError(ConfigProperty.CLIENT_SECRET);
+        String clientSecret = StringUtils.trim(secretStore.getConfigPropertyOrError(ConfigProperty.CLIENT_SECRET));
         String token = Base64.getEncoder()
             .encodeToString(String.join(":", clientId, clientSecret).getBytes(StandardCharsets.UTF_8));
         httpHeaders.setAuthorization("Basic " + token);

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/RefreshTokenTokenRequestBuilder.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/RefreshTokenTokenRequestBuilder.java
@@ -38,7 +38,6 @@ public class RefreshTokenTokenRequestBuilder
     public enum ConfigProperty implements ConfigService.ConfigProperty {
         REFRESH_TOKEN, //NOTE: you should configure this as a secret in Secret Manager
         CLIENT_SECRET, //NOTE: you should configure this as a secret in Secret Manager
-
     }
 
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -120,7 +120,7 @@ public class ParameterStoreConfigService implements SecretStore, LockService {
 
             Optional<T> r;
             if (Objects.equals(parameterResponse.parameter().value(), PLACEHOLDER_VALUE)) {
-                log.warning("Found placeholder value for " + paramName + "; this is either a misconfiguration, or a value that proxy itself should later fill.");
+                log.info("Found placeholder value for " + paramName + "; this is either a misconfiguration, or a value that proxy itself should later fill.");
                 r = Optional.empty();
             } else {
                 if (envVarsConfig.isDevelopment()) {


### PR DESCRIPTION
recovery of #819, which got messy with some additional changes; and had conflicts.

### Features
 - remove OAUTH_REFRESH_TOKEN parameters? unused? (no!! - see https://github.com/Worklytics/psoxy/blob/c1bbe8b62c5a4f8a683f80a49ed1d45df48b131e/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java#L212



### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **yes**