### PR TITLE
S189 : cleanup oauth refresh lock

### DIFF
--- a/.github/workflows/ci-terraform-modules.yaml
+++ b/.github/workflows/ci-terraform-modules.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         terraform_version: [ '~1.6.0', '~1.7.0', '~1.8.0', '~1.9.0', '~1.10.0', 'latest' ]
+        # TODO: we should matrix this over modules eventually too
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -26,3 +27,10 @@ jobs:
         run: |
           terraform init -reconfigure
           terraform validate
+
+      # also test here ...
+      - name: "Terraform - test modules/worklytics-connector-specs"
+        working-directory: infra/modules/worklytics-connector-specs
+        run: |
+          terraform init -reconfigure
+          terraform test

--- a/infra/modules/worklytics-connector-specs/.gitignore
+++ b/infra/modules/worklytics-connector-specs/.gitignore
@@ -1,0 +1,3 @@
+# NOTE: bc this has tests, we're going to init the module but DON'T want to commit terraform files that result
+.terraform.lock.hcl
+.terraform

--- a/infra/modules/worklytics-connector-specs/auth_config.tftest.hcl
+++ b/infra/modules/worklytics-connector-specs/auth_config.tftest.hcl
@@ -1,0 +1,28 @@
+variables {
+  enabled_connectors = []
+}
+
+
+
+// NOTE: terraform test output can sometimes give red-herring feedback on failures; namely info about variable value types, (X is object with 10 attributes),
+/// which may not be the problem at all
+
+run "oauth_refresh_token_locks" {
+  command = apply
+
+  assert {
+    error_message = "6 oauth connectors expected to USE_SHARED_TOKEN"
+    condition = 6 == length([ for k, v in output.available_oauth_data_source_connectors :
+      v if try(lower(v.environment_variables.USE_SHARED_TOKEN), "false") == "true"])
+  }
+
+  assert {
+    # filter this
+    error_message = "All oauth connectors with USE_SHARED_TOKEN set to TRUE must have OAUTH_REFRESH_TOKEN secured variable"
+    condition = alltrue([
+      for k, v in output.available_oauth_data_source_connectors :
+      try(lower(v.environment_variables.USE_SHARED_TOKEN), "false") == "false" || anytrue([
+      for var in v.secured_variables : var.name == "OAUTH_REFRESH_TOKEN"])
+      ])
+  }
+}

--- a/infra/modules/worklytics-connector-specs/auth_config.tftest.hcl
+++ b/infra/modules/worklytics-connector-specs/auth_config.tftest.hcl
@@ -7,6 +7,11 @@ variables {
 // NOTE: terraform test output can sometimes give red-herring feedback on failures; namely info about variable value types, (X is object with 10 attributes),
 /// which may not be the problem at all
 
+// also don't love that these tests are very hard to debug and validate expectations/preconditions simply. conditions end up being very complex/hard-to-read,
+// or highly repetitive
+
+// and terraform conditions don't seem to short-circuit, so need to add try()s in successive steps, which can mask other errors
+
 run "oauth_refresh_token_locks" {
   command = apply
 
@@ -25,4 +30,35 @@ run "oauth_refresh_token_locks" {
       for var in v.secured_variables : var.name == "OAUTH_REFRESH_TOKEN"])
       ])
   }
+}
+
+
+run "oauth_refresh_token_access_tokens" {
+
+  assert {
+    error_message = "all oauth connectors use ACCESS_TOKEN (all except dropbox??)"
+    condition = 10 == length([ for k, v in output.available_oauth_data_source_connectors :
+      v if anytrue([for var in v.secured_variables : var.name == "ACCESS_TOKEN"])
+      ])
+  }
+
+  assert {
+    error_message = "all oauth connectors with source_auth_strategy == oauth2_refresh_token have REFRESH_TOKEN secured variable"
+    condition = alltrue([
+      for k, v in output.available_oauth_data_source_connectors :
+        v.source_auth_strategy != "oauth2_refresh_token" ||
+         try(v.environment_variables.GRANT_TYPE, "access_token") != "refresh_token" ||  # implicitly, unspecified grant type is an ACCESS_TOKEN or something else long-lived that needn't be refreshed
+         anytrue([ for var in v.secured_variables : var.name == "REFRESH_TOKEN"])
+      ])
+  }
+
+  assert {
+    error_message = "all oauth connectors with source_auth_strategy == oauth2_refresh_token must have writable ACCESS_TOKEN secured variable"
+    condition = alltrue([
+      for k, v in output.available_oauth_data_source_connectors :
+      v.source_auth_strategy != "oauth2_refresh_token" ||
+    anytrue([ for var in v.secured_variables : var.name == "ACCESS_TOKEN" && var.writable])
+      ])
+  }
+
 }

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -763,7 +763,7 @@ EOT
         CREDENTIALS_FLOW : "client_secret"
         REFRESH_ENDPOINT : "https://${var.salesforce_domain}/services/oauth2/token"
         ACCESS_TOKEN_CACHEABLE : "true",
-        USE_SHARED_TOKEN : "true"
+        USE_SHARED_TOKEN : "TRUE"
       }
       secured_variables : [
         {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -956,7 +956,7 @@ EOT
         },
         {
           name : "ACCESS_TOKEN"
-          writable : true
+          writable : true  # access token
           sensitive : true
           value_managed_by_tf : false
           description : "Short-lived oauth access_token. Filled by Proxy instance."
@@ -1058,6 +1058,13 @@ EOT
           writable : false
           sensitive : true
           value_managed_by_tf : false
+        },
+        {
+          name : "ACCESS_TOKEN"
+          writable : true  # access token
+          sensitive : true
+          value_managed_by_tf : false
+          description : "Short-lived oauth access_token. Filled by Proxy instance."
         },
       ],
       environment_variables : {

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -19,6 +19,18 @@ locals {
   google_workspace_example_user  = coalesce(var.google_workspace_example_user, "REPLACE_WITH_EXAMPLE_USER@YOUR_COMPANY.COM")
   google_workspace_example_admin = coalesce(var.google_workspace_example_admin, var.google_workspace_example_user, "REPLACE_WITH_EXAMPLE_ADMIN@YOUR_COMPANY.COM")
 
+  standard_config_values = {
+    oauth_refresh_token_lock = {
+      # NOTE: in GCP case, this is NEVER actually filled with a value; lock is done by labeling the secret
+      name : "OAUTH_REFRESH_TOKEN"
+      writable : true
+      lockable : true   # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
+      sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
+      value_managed_by_tf : false
+      description: "Used to 'lock' the token refresh flow, so multiple processes don't refresh tokens concurrently.  Filled by Proxy instance."
+    }
+  }
+
   google_workspace_sources = {
     # GDirectory connections are a PRE-REQ for gmail, gdrive, and gcal connections. remove only
     # if you plan to directly connect Directory to worklytics (without proxy). such a scenario is
@@ -447,13 +459,7 @@ EOT
           sensitive : true
           value_managed_by_tf : false
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
-        }
+        local.standard_config_values.oauth_refresh_token_lock,
       ],
       environment_variables : {
         GRANT_TYPE : "certificate_credentials"
@@ -549,13 +555,7 @@ EOT
           sensitive : true
           value_managed_by_tf : false
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true   # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
-          sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
-          value_managed_by_tf : false
-        },
+        local.standard_config_values.oauth_refresh_token_lock,
         {
           name : "CLIENT_ID"
           writable : false
@@ -678,13 +678,7 @@ EOT
           sensitive : true
           value_managed_by_tf : false
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
-        }
+        local.standard_config_values.oauth_refresh_token_lock
       ],
       environment_variables : {
         GRANT_TYPE : "certificate_credentials"
@@ -784,13 +778,7 @@ EOT
           sensitive : true
           value_managed_by_tf : false
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
-        },
+        local.standard_config_values.oauth_refresh_token_lock,
         {
           name : "ACCESS_TOKEN"
           writable : true
@@ -971,15 +959,9 @@ EOT
           writable : true
           sensitive : true
           value_managed_by_tf : false
-          description : "Short-lived Oauth access_token used by connector to retrieve Zoom data. Filled by Proxy instance."
+          description : "Short-lived oauth access_token. Filled by Proxy instance."
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true
-          sensitive : true
-          value_managed_by_tf : false
-        }, # q: needed? per logic as of 9 June 2023, would be created
+        local.standard_config_values.oauth_refresh_token_lock,
       ],
       reserved_concurrent_executions : null # 1
       example_api_calls_user_to_impersonate : null
@@ -1201,13 +1183,7 @@ EOT
           sensitive : true
           value_managed_by_tf : false
         },
-        {
-          name : "OAUTH_REFRESH_TOKEN"
-          writable : true
-          lockable : true   # nonsensical; this parameter/secret IS the lock. it's really the tokens that should have lockable:true
-          sensitive : false # not sensitive; this just represents lock of the refresh of the token, not hold token value itself
-          value_managed_by_tf : false
-        },
+        local.standard_config_values.oauth_refresh_token_lock,
         {
           name : "CLIENT_ID"
           writable : false

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -209,7 +209,9 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
 
         // not high; better to fail fast and leave it to the caller (Worklytics) to retry than hold
         // open a lambda waiting for a lock
-        private static final String TOKEN_REFRESH_LOCK_ID = "oauth_refresh_token";
+        //NOTE: this is OAUTH_REFRESH_TOKEN secret / parameter that we expect to exist (created by Terraform modules in usual case)
+        private static final String TOKEN_REFRESH_LOCK_ID = "OAUTH_REFRESH_TOKEN";
+
         private static final int MAX_TOKEN_REFRESH_ATTEMPTS = 3;
 
         /**

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/SecretManagerConfigService.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/SecretManagerConfigService.java
@@ -189,8 +189,8 @@ public class SecretManagerConfigService implements WritableConfigService, LockSe
             try {
                 lockSecret = client.getSecret(lockSecretName);
             } catch (com.google.api.gax.rpc.NotFoundException e) {
-                // It should not happen, as the secret has been created by Terraform
-                throw new RuntimeException(String.format("Secret %s must exist as it should be created by Terraform", lockSecretName));
+                // It should not happen, as the secret should have been created by Terraform
+                throw new RuntimeException(String.format("Secret %s does not exist, but should have be created by Terraform", lockSecretName));
             }
 
             Instant lockedAt = Optional.ofNullable(lockSecret.getLabelsMap().get(LOCK_LABEL))


### PR DESCRIPTION
### Features
  - warn in logs if lock secret is missing
  - add explicit tests of `worklytics-connector-specs` module; ensure it's consistently.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**