### PR TITLE
Drop invalid syntax for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,8 +67,6 @@ jobs:
                   # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
                   # queries: security-extended,security-and-quality
 
-            -
-
             # If the analyze step fails for one of the languages you are analyzing with
             # "We were unable to automatically build your code", modify the matrix above
             # to set the build mode to "manual" for that language. Then modify this step


### PR DESCRIPTION
Workflow is failing due an invalid step.

### Fixes
> paste links to issues/tasks in project management
[Invalid psoxy workflow](https://app.asana.com/0/1209129432638434/1209173071906011)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
