### PR TITLE
add hash of SALT to healthcheck, for change detection

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,9 +7,8 @@
         <option value="$PROJECT_DIR$/java/pom.xml" />
       </list>
     </option>
-    <option name="workspaceImportForciblyTurnedOn" value="true" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="19" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/java/target" />
   </component>
 </project>

--- a/java/core/src/main/java/co/worklytics/psoxy/HealthCheckResult.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/HealthCheckResult.java
@@ -70,6 +70,14 @@ public class HealthCheckResult {
 
     String callerIp;
 
+    /**
+     *  A SHA-256 hash of the salt, to aid in detecting changes to the salt value.
+     *
+     *  If salt changes, client needs to know; as all subsequent pseudonyms produced by proxy instance from that point
+     *  will be inconsistent with the prior ones.
+     */
+    String saltSha256Hash;
+
     public boolean passed() {
         return getConfiguredSource() != null
             && getNonDefaultSalt()

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
@@ -44,7 +44,7 @@ public class HealthCheckRequestHandler {
      *
      *  do NOT change this value. if you do, we won't be able to detect that proxy-side salts of changed.
      */
-    static final String SALT_FOR_SALT = "f33c366c-ae91-4819-b221-f9794ebb8145";
+    private static final String SALT_FOR_SALT = "f33c366c-ae91-4819-b221-f9794ebb8145";
 
     @Inject
     EnvVarsConfigService envVarsConfigService;

--- a/java/core/src/test/java/co/worklytics/psoxy/HealthCheckResultTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/HealthCheckResultTest.java
@@ -30,6 +30,7 @@ class HealthCheckResultTest {
             "  \"nonDefaultSalt\" : true,\n" +
             "  \"pseudonymImplementation\" : null,\n" +
             "  \"pseudonymizeAppIds\" : null,\n" +
+            "  \"saltSha256Hash\" : null,\n" +
             "  \"sourceAuthGrantType\" : null,\n" +
             "  \"sourceAuthStrategy\" : null,\n" +
             "  \"version\" : \"rc-v0.1.15\"\n" +


### PR DESCRIPTION
### Features
 - add hash of SALT to health check, for change detection

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
 - security risk that somehow reveals something about the SALT; but see comments; should be very safe in practice due to sufficiently large and random potential set of SALTs; but salted SALT for some extra protection


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209205689107063