### PR TITLE
S193 : remove deprected methods

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/Pseudonymizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/Pseudonymizer.java
@@ -17,15 +17,6 @@ public interface Pseudonymizer {
 
         private static final long serialVersionUID = 5L;
 
-        /**
-         * salt used to generate pseudonyms
-         * <p>
-         * q: split this out? it's per-customer, not per-source API (although it *could* be the
-         * later, if you don't need to match with it)
-         */
-        @Deprecated //used ONLY in LEGACY case ; otherwise behavior determined by tokenization strategies
-        String pseudonymizationSalt;
-
         @Builder.Default
         PseudonymImplementation pseudonymImplementation = PseudonymImplementation.DEFAULT;
 

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
@@ -5,7 +5,6 @@ import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.transforms.Transform;
 import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
-import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
 import com.google.common.base.Preconditions;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedInject;
@@ -77,16 +76,6 @@ public class PseudonymizerImpl implements Pseudonymizer {
     public PseudonymizedIdentity pseudonymize(Object value, Transform.PseudonymizationTransform transformOptions) {
         if (value == null) {
             return null;
-        }
-
-        if (this.getOptions().getPseudonymizationSalt() != null &&
-                this.deterministicTokenizationStrategy instanceof Sha256DeterministicTokenizationStrategy) {
-
-            if (!Objects.equals(((Sha256DeterministicTokenizationStrategy) this.deterministicTokenizationStrategy).getSalt(),
-                    this.options.getPseudonymizationSalt())) {
-                //shouldn't happen in real life, but just in case
-                throw new RuntimeException("Salt mismatch between pseudonymizer and tokenization strategy");
-            }
         }
 
         Preconditions.checkArgument(value instanceof String || value instanceof Number,

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImplFactory.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImplFactory.java
@@ -15,9 +15,7 @@ public interface PseudonymizerImplFactory {
 
     default Pseudonymizer.ConfigurationOptions buildOptions(ConfigService config,
                                                             SecretStore secretStore) {
-        Pseudonymizer.ConfigurationOptions.ConfigurationOptionsBuilder builder = Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt(secretStore.getConfigPropertyAsOptional(ProxyConfigProperty.PSOXY_SALT)
-                .orElseThrow(() -> new Error("Must configure value for SALT to generate pseudonyms")));
+        Pseudonymizer.ConfigurationOptions.ConfigurationOptionsBuilder builder = Pseudonymizer.ConfigurationOptions.builder();
 
         Optional<PseudonymImplementation> pseudonymImplementation = config.getConfigPropertyAsOptional(ProxyConfigProperty.PSEUDONYM_IMPLEMENTATION)
             .map(PseudonymImplementation::parseConfigPropertyValue);

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -448,10 +448,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
             } else if (transformOptions.getEncoding() == PseudonymEncoder.Implementations.URL_SAFE_TOKEN) {
                 if (pseudonymizedIdentity.getReversible() != null
                     && getPseudonymizer().getOptions().getPseudonymImplementation() == PseudonymImplementation.LEGACY) {
-                    // can't URL_SAFE_TOKEN encode reversible portion of pseudonym if LEGACY mode, bc
-                    // URL_SAFE_TOKEN depends on 'hash' being encoded as prefix of the reversible;
-                    // and reverisbles need the non-legacy
-                    return configuration.jsonProvider().toJson(pseudonymizedIdentity);
+                    throw new IllegalArgumentException("LEGACY pseudonymization is no longer supported with v0.5+");
                 }
                 //exploit that already reversibly encoded, including prefix
                 return ObjectUtils.firstNonNull(pseudonymizedIdentity.getReversible(), pseudonymizedIdentity.getHash());
@@ -485,9 +482,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
                 String pseudonymizedString;
                 if (pseudonymizedIdentity.getReversible() != null) {
                     if (getPseudonymizer().getOptions().getPseudonymImplementation() == PseudonymImplementation.LEGACY) {
-                        //exploits that already reversibly encoded, including prefix
-                        log.warning("Using transform PseudonymizeRegexMatches, with reversible==true; this is NOT supported for LEGACY pseudonym implementation, so non-reversible pseudonym encoded");
-                        pseudonymizedString = UrlSafeTokenPseudonymEncoder.TOKEN_PREFIX + pseudonymizedIdentity.getHash();
+                        throw new IllegalArgumentException("LEGACY pseudonymization is no longer supported with v0.5+");
                     } else {
                         pseudonymizedString = pseudonymizedIdentity.getReversible();
                     }

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizedIdentityTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizedIdentityTest.java
@@ -61,7 +61,6 @@ class PseudonymizedIdentityTest {
     @Test
     void asPseudonym() {
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .pseudonymImplementation(PseudonymImplementation.DEFAULT)
                 .build());
 
@@ -81,7 +80,6 @@ class PseudonymizedIdentityTest {
     })
     void asPseudonym_should_return_null_if_null_or_empty(String identifier) {
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .pseudonymImplementation(PseudonymImplementation.DEFAULT)
                 .build());
 
@@ -93,7 +91,6 @@ class PseudonymizedIdentityTest {
     @Test
     void asPseudonym_reversible() {
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .pseudonymImplementation(PseudonymImplementation.DEFAULT)
                 .build());
 

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizerImplTest.java
@@ -54,7 +54,6 @@ class PseudonymizerImplTest {
         container.inject(this);
 
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .pseudonymImplementation(PseudonymImplementation.DEFAULT)
             .build());
 
@@ -100,7 +99,6 @@ class PseudonymizerImplTest {
     @ParameterizedTest
     void emailCanonicalEquivalents_IgnoreDots(String mailHeaderValue) {
          pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .pseudonymImplementation(PseudonymImplementation.DEFAULT)
             .emailCanonicalization(EmailCanonicalization.IGNORE_DOTS)
             .build());

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CommonRequestHandlerTest.java
@@ -165,13 +165,13 @@ class CommonRequestHandlerTest {
         //prep mock request
         HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
         when(request.getHeader(ControlHeader.PSEUDONYM_IMPLEMENTATION.getHttpHeader()))
-                .thenReturn(Optional.of(PseudonymImplementation.LEGACY.getHttpHeaderValue()));
+                .thenReturn(Optional.of(PseudonymImplementation.DEFAULT.getHttpHeaderValue()));
 
         //test parsing options from request
         Optional<PseudonymImplementation> impl = handler.parsePseudonymImplementation(request);
 
         //verify options were parsed correctly
-        assertEquals(PseudonymImplementation.LEGACY, impl.orElseThrow());
+        assertEquals(PseudonymImplementation.DEFAULT, impl.orElseThrow());
     }
 
     @Test
@@ -341,9 +341,9 @@ class CommonRequestHandlerTest {
         //prep mock request
         HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
         when(request.getHeader(ControlHeader.PSEUDONYM_IMPLEMENTATION.getHttpHeader()))
-                .thenReturn(Optional.of(PseudonymImplementation.LEGACY.getHttpHeaderValue()));
+                .thenReturn(Optional.of(PseudonymImplementation.DEFAULT.getHttpHeaderValue()));
 
-        assertEquals(PseudonymImplementation.LEGACY,
+        assertEquals(PseudonymImplementation.DEFAULT,
                 handler.getSanitizerForRequest(request).getPseudonymizer().getOptions().getPseudonymImplementation());
 
         assertEquals(PseudonymImplementation.DEFAULT,
@@ -426,8 +426,7 @@ class CommonRequestHandlerTest {
     private RESTApiSanitizer buildSanitizer(RESTRules rules) {
         Pseudonymizer defaultPseudonymizer =
                 pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                        .pseudonymizationSalt("salt")
-                        .pseudonymImplementation(PseudonymImplementation.LEGACY)
+                        .pseudonymImplementation(PseudonymImplementation.DEFAULT)
                         .build());
 
         return sanitizerFactory.create(rules, defaultPseudonymizer);

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -103,7 +103,6 @@ class RESTApiSanitizerImplTest {
         container.inject(this);
 
         Pseudonymizer pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .build());
 
         sanitizer = sanitizerFactory.create(PrebuiltSanitizerRules.DEFAULTS.get("gmail"), pseudonymizer);
@@ -481,7 +480,6 @@ class RESTApiSanitizerImplTest {
     public void getPseudonymize_URL_SAFE_TOKEN(PseudonymImplementation implementation, String value, Boolean includeReversible, String encoding, String expected) {
 
         Pseudonymizer pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .pseudonymImplementation(implementation)
             .build());
 
@@ -576,7 +574,6 @@ class RESTApiSanitizerImplTest {
     void pseudonymizeWithRegexMatches(String input) {
 
         Pseudonymizer pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .pseudonymImplementation(PseudonymImplementation.DEFAULT)
             .build());
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -104,7 +104,6 @@ public class BulkDataSanitizerImplTest {
         container.inject(this);
 
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .build());
 
         //make it deterministic
@@ -327,7 +326,6 @@ public class BulkDataSanitizerImplTest {
     void handle_duplicates() {
         Pseudonymizer defaultPseudonymizer =
             pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .build());
 
 
@@ -363,7 +361,6 @@ public class BulkDataSanitizerImplTest {
     void handle_duplicates_lookup_table_via_transforms() {
         Pseudonymizer defaultPseudonymizer =
             pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .build());
 
 
@@ -403,7 +400,6 @@ public class BulkDataSanitizerImplTest {
     void handle_duplicates_lookup_table_pre_0_4_48() {
         Pseudonymizer defaultPseudonymizer =
             pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .build());
 
 
@@ -458,7 +454,6 @@ public class BulkDataSanitizerImplTest {
 
         Pseudonymizer defaultPseudonymizer =
             pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt("salt")
                 .build());
 
 
@@ -529,7 +524,6 @@ public class BulkDataSanitizerImplTest {
     @ParameterizedTest
     void pre_v0_4_30_bulk_pseudonym_URL_SAFE_TOKEN_ENCODING(String identifier) {
         pseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-            .pseudonymizationSalt("salt")
             .pseudonymImplementation(PseudonymImplementation.DEFAULT)
             .build());
 
@@ -593,7 +587,6 @@ public class BulkDataSanitizerImplTest {
             assertEquals(EXPECTED, resultString);
 
             PseudonymizerImpl githubPseudonymizer = pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
-                .pseudonymizationSalt(pseudonymizer.getOptions().getPseudonymizationSalt())
                 .build());
 
             //validate has _enterprise appended pre-pseudonymization


### PR DESCRIPTION
### Fixes
 - remove pseudonymization salt option; not used anymore as config option
 - drop LEGACY pseudonyms tests
 
  

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
