### PR TITLE
support terraform 1.11

### DIFF
--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3, < 1.11"
+  required_version = ">= 1.3, < 2.0"
 
   required_providers {
     # for the infra that will host Psoxy instances

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3, < 1.11"
+  required_version = ">= 1.3, < 2.0"
 
   required_providers {
     google = {

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3, < 1.11"
+  required_version = ">= 1.3, < 2.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Features
 - relax terraform version constraints, so 1.11 (latest, released 27 Feb 2025, will work)

NOTE: this fixes `latest` CI builds, which currently failing on the rc

### Change implications

 - dependencies added/changed? **yes** allow terraform 1.11 