### PR TITLE
doc updates

### DIFF
--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -32,8 +32,10 @@ jobs:
     with:
       java-version: '23'
 
-  # Java 24 - released 18 March 2025, supported until Sept 2025
-  ci_java24:
-    uses: ./.github/workflows/build-java.yaml
-    with:
-      java-version: '24'
+# Java 24 disabled, pending Maven releasing 3.9.10 or 4.x version that supports Java 24
+# specific issue is https://issues.apache.org/jira/browse/MNG-8248
+#  # Java 24 - released 18 March 2025, supported until Sept 2025
+#  ci_java24:
+#    uses: ./.github/workflows/build-java.yaml
+#    with:
+#      java-version: '24'

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -31,3 +31,9 @@ jobs:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '23'
+
+  # Java 24 - released 18 March 2025, supported until Sept 2025
+  ci_java24:
+    uses: ./.github/workflows/build-java.yaml
+    with:
+      java-version: '24'

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,21 +207,21 @@ administrator AFTER you have deployed Psoxy.
 
 #### Required Software and Permissions
 
-As of Feb 2023, Psoxy is implemented with Java 11 and built via Maven. The proxy infrastructure is
+As of April 2025, Psoxy is implemented with Java 17 and built via Maven. The proxy infrastructure is
 provisioned and the Psoxy code deployed using Terraform, relying on Azure, Google Cloud, and/or AWS
 command line tools.
 
 You will need all the following in your deployment environment (eg, your laptop):
 
-| Tool                                            | Version               | Test Command          |
-|-------------------------------------------------|-----------------------|-----------------------|
-| [git](https://git-scm.com/)                     | 2.17+                 | `git --version`       |
-| [Maven](https://maven.apache.org/)              | 3.6+                  | `mvn -v`              |
-| [Java JDK 11+](https://openjdk.org/install/) | 17, 21 (see notes) | `mvn -v \| grep Java` |
-| [Terraform](https://www.terraform.io/)          | 1.6+, < 2.0           | `terraform version`   |
+| Tool                                         | Version                | Test Command          |
+|----------------------------------------------|------------------------|-----------------------|
+| [git](https://git-scm.com/)                  | 2.17+                  | `git --version`       |
+| [Maven](https://maven.apache.org/)           | 3.6+                   | `mvn -v`              |
+| [Java JDK 17+](https://openjdk.org/install/) | 17, 21, 24 (see notes) | `mvn -v \| grep Java` |
+| [Terraform](https://www.terraform.io/)       | 1.6+, < 2.0            | `terraform version`   |
 
 NOTE: we will support Java versions for duration of official support windows, in particular the
-LTS versions. Minor versions, such as 18-20, which are out of official support, may work but are not
+LTS versions. Minor versions, such as 18-20, 22-23 which are out of official support, may work but are not
 routinely tested.
 
 NOTE: Using `terraform` is not strictly necessary, but it is the only supported method. You may

--- a/docs/README.md
+++ b/docs/README.md
@@ -220,7 +220,7 @@ You will need all the following in your deployment environment (eg, your laptop)
 | [Java JDK 17+](https://openjdk.org/install/) | 17, 21 (see notes) | `mvn -v \| grep Java` |
 | [Terraform](https://www.terraform.io/)       | 1.6+, < 2.0          | `terraform version`   |
 
-NOTE: as of Apr 8, 2024, although Java 24 has been release Maven 3.9.9 is not compatible with it. Maven
+NOTE: as of Apr 8, 2024, although Java 24 has been released Maven 3.9.9 is not compatible with it. Maven
 has fixed this, but has yet to release a version 3.9.10 or 4.0.x with the fix. Until then, we don't officially
 support Java 24.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -419,8 +419,7 @@ Subsystem for Linux (WSL) platforms.
 | Java                     | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-java.yaml)                            |
 | Terraform Examples       | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-terraform-examples.yaml)              |
 | Tools                    | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-tools.yaml)                           |
- | Terraform Security Scan | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-terraform-sec-analysis-examples.yaml) |
-
+| Terraform Security Scan | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-terraform-sec-analysis-examples.yaml) |
 
 Review [release notes in GitHub](https://github.com/Worklytics/psoxy/releases).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -213,12 +213,16 @@ command line tools.
 
 You will need all the following in your deployment environment (eg, your laptop):
 
-| Tool                                         | Version                | Test Command          |
-|----------------------------------------------|------------------------|-----------------------|
-| [git](https://git-scm.com/)                  | 2.17+                  | `git --version`       |
-| [Maven](https://maven.apache.org/)           | 3.6+                   | `mvn -v`              |
-| [Java JDK 17+](https://openjdk.org/install/) | 17, 21, 24 (see notes) | `mvn -v \| grep Java` |
-| [Terraform](https://www.terraform.io/)       | 1.6+, < 2.0            | `terraform version`   |
+| Tool                                         | Version              | Test Command          |
+|----------------------------------------------|----------------------|-----------------------|
+| [git](https://git-scm.com/)                  | 2.17+                | `git --version`       |
+| [Maven](https://maven.apache.org/)           | 3.6+                 | `mvn -v`              |
+| [Java JDK 17+](https://openjdk.org/install/) | 17, 21 (see notes) | `mvn -v \| grep Java` |
+| [Terraform](https://www.terraform.io/)       | 1.6+, < 2.0          | `terraform version`   |
+
+NOTE: as of Apr 8, 2024, although Java 24 has been release Maven 3.9.9 is not compatible with it. Maven
+has fixed this, but has yet to release a version 3.9.10 or 4.0.x with the fix. Until then, we don't officially
+support Java 24.
 
 NOTE: we will support Java versions for duration of official support windows, in particular the
 LTS versions. Minor versions, such as 18-20, 22-23 which are out of official support, may work but are not

--- a/docs/README.md
+++ b/docs/README.md
@@ -410,11 +410,12 @@ Subsystem for Linux (WSL) platforms.
 
 ## Component Status
 
-| Component                | Status                                                                                                                       |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| Java                     | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-java.yaml)               |
-| Terraform Examples       | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-terraform.yaml)          |
-| Tools                    | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-tools.yaml)              |
+| Component                | Status                                                                                                                                    |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| Java                     | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-java.yaml)                            |
+| Terraform Examples       | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-terraform-examples.yaml)              |
+| Tools                    | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-tools.yaml)                           |
+ | Terraform Security Scan | ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Worklytics/psoxy/ci-terraform-sec-analysis-examples.yaml) |
 
 
 Review [release notes in GitHub](https://github.com/Worklytics/psoxy/releases).

--- a/docs/configuration/api-data-sanitization.md
+++ b/docs/configuration/api-data-sanitization.md
@@ -34,7 +34,7 @@ which do not match a endpoint in this list will be rejected with a `403` respons
 based on OpenAPI Spec v3.0.0 Path Template syntax. Variable path segments are enclosed in curly
 braces (`{}`) and are matched by any value that does not contain an `/` character.
 
-See: https://swagger.io/docs/specification/paths-and-operations/
+See: [https://swagger.io/docs/specification/paths-and-operations/](https://swagger.io/docs/specification/paths-and-operations/)
 
 ### Allowed Methods
 
@@ -201,7 +201,7 @@ able to copy the JSON Schema for an API endpoint from its
 `responseSchema` value in your rule set. Similarly, there are tools that can generate JSON Schema
 from example JSON content, as well as from data models in various languages, that may be useful.
 
-See: https://json-schema.org/implementations.html#schema-generators
+See: [https://json-schema.org/implementations.html#schema-generators](https://json-schema.org/implementations.html#schema-generators)
 
 If a `responseSchema` attribute is specified for an `endpoint`, the response content will be
 _filtered_ (rather than validated) against that schema. Eg, fields NOT specified in the schema, or
@@ -227,7 +227,7 @@ not of expected type, will be removed from the response.
 Example:
 
 The following is for a User from the GitHub API, via graphql. See:
-https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint
+[https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint)
 
 ```yaml
 - pathTemplate: "/graphql"

--- a/docs/configuration/api-data-sanitization.md
+++ b/docs/configuration/api-data-sanitization.md
@@ -224,6 +224,10 @@ not of expected type, will be removed from the response.
 - `definitions` - a map of schema names to schemas of type `JsonSchemaFilter`; only supported at
   root schema of endpoint.
 
+Omitting all of the above, (eg, just `{ }`), is interpreted as a schema that matches any valid leaf node.
+
+
+
 Example:
 
 The following is for a User from the GitHub API, via graphql. See:

--- a/docs/configuration/json-filter.md
+++ b/docs/configuration/json-filter.md
@@ -6,6 +6,8 @@ filter schema are removed, rather than the whole document failing validation.
 
 The goal of JsonFilter is that only data elements specified in the filter pass through.
 
+These are used for [API Data Sanitization policies](api-data-sanitization.md).
+
 Some differences:
 
 - `required` properties are ignored. While in JSON schema, an object that was missing a "required"

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -18,6 +18,7 @@ file.
 | `gcal`                     | Google Calendar                      | API  | GA           |
 | `gdrive`                   | Google Drive                         | API  | GA           |
 | `gdirectory`               | Google Directory                     | API  | GA           |
+| `gemini-usage`            | Gemini Usage                         | Bulk | BETA         |
 | `github`                   | GitHub                               | API  | GA           |
 | `github-enterprise-server` | GitHub Enterprise Server             | API  | GA           |
 | `github-non-enterprise`    | GitHub Non-Enterprise                | API  | GA           |

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -19,6 +19,7 @@ file.
 | `gdrive`                   | Google Drive                         | API  | GA           |
 | `gdirectory`               | Google Directory                     | API  | GA           |
 | `gemini-usage`            | Gemini Usage                         | Bulk | BETA         |
+| `msft-copilot`            |  Microsot 365 Copilot                         | API | ALPHA         |
 | `github`                   | GitHub                               | API  | GA           |
 | `github-enterprise-server` | GitHub Enterprise Server             | API  | GA           |
 | `github-non-enterprise`    | GitHub Non-Enterprise                | API  | GA           |

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -38,7 +38,7 @@ file.
 | `zoom`                     | Zoom                                 | API  | GA           |
 
 From v0.4.58, you can confirm the availability of a connector by running the following command from
-the root of on of our examples:
+the root of one of our examples:
 
 ```shell
 ./available-connectors

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
         <dependency.jackson.version>2.18.3</dependency.jackson.version>
         <dependency.apache-commons-lang3.version>3.13.0</dependency.apache-commons-lang3.version> <!-- July 2023 release, doesn't actually have constants for java after 17 yet -->
         <dependency.apache-commons-csv.version>1.10.0</dependency.apache-commons-csv.version>
-        <dependency.guava.version>32.0.1-jre</dependency.guava.version>
+        <dependency.guava.version>33.4.7-jre</dependency.guava.version>
         <dependency.commons-io.version>2.13.0</dependency.commons-io.version>
         <dependency.apache-httpcore.version>5.2.2</dependency.apache-httpcore.version>
         <dependency.google-cloud-bom.version>26.42.0</dependency.google-cloud-bom.version>

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -50,8 +50,8 @@ JAVA_VERSION_MAJOR=$(echo $JAVA_VERSION | sed -n 's/^Java version: \([0-9]*\).*/
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
 
-if [[  "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21  && "$JAVA_VERSION_MAJOR" != 23  && "$JAVA_VERSION_MAJOR" != 24 ]]; then
-  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires an Oracle-supported version of Java 17 or later;  as of April 2025, this includes Java 17, 21, or 23. See https://maven.apache.org/install.html\n"
+if [[  "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21  && "$JAVA_VERSION_MAJOR" != 23  ]]; then
+  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires an Oracle-supported version of Java 17 or later;  as of April 2025, this includes Java 17 or 21. See https://maven.apache.org/install.html\n"
   if $HOMEBREW_AVAILABLE; then printf "or as you have Homebrew available, run ${BLUE}brew install openjdk@17${NC}\n"; fi
   printf "If you have an alternative JDK installed, then you must update your ${BLUE}JAVA_HOME${NC} environment variable to point to it.\n"
 fi

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -50,8 +50,8 @@ JAVA_VERSION_MAJOR=$(echo $JAVA_VERSION | sed -n 's/^Java version: \([0-9]*\).*/
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
 
-if [[ "$JAVA_VERSION_MAJOR" != 11 && "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21 ]]; then
-  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires a supported version of Java 11 or later; as of Nov 2023, this includes Java 11, 17, or 21. See https://maven.apache.org/install.html\n"
+if [[  "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21  && "$JAVA_VERSION_MAJOR" != 23  && "$JAVA_VERSION_MAJOR" != 24 ]]; then
+  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires an Oracle-supported version of Java 17 or later;  as of April 2025, this includes Java 17, 21, or 23. See https://maven.apache.org/install.html\n"
   if $HOMEBREW_AVAILABLE; then printf "or as you have Homebrew available, run ${BLUE}brew install openjdk@17${NC}\n"; fi
   printf "If you have an alternative JDK installed, then you must update your ${BLUE}JAVA_HOME${NC} environment variable to point to it.\n"
 fi


### PR DESCRIPTION
### Fixes
- Fix github action badge rendering 
- Typos in docs

### Features
- Add `gemini-usage` to the source list
- ~~Add test of Java 24~~ doc that java 24 won't work until Maven supports it

### Change implications

- dependencies added/changed? **Yes** bumped guava to latest version of 333
- breaking changes? **no**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209671615752425