### PR TITLE
GCP from Cloud Functions gen1 to Cloud Run Functions gen2

### DIFF
--- a/docs/gcp/getting-started.md
+++ b/docs/gcp/getting-started.md
@@ -28,6 +28,8 @@ Service Account Keys and activate Google Workspace APIs.
 
   - [Cloud Functions Admin](https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin) -
     proxy instances are deployed as GCP cloud functions
+  - [Cloud Run Developer](https://cloud.google.com/iam/docs/understanding-roles#cloudrun.developer) - cloud
+    function deployment requires Cloud Run Developer role
   - [Cloud Storage Admin](https://cloud.google.com/iam/docs/understanding-roles#storage.admin) -
     processing of bulk data (such as HRIS exports) uses GCS buckets
   - [IAM Role Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.roles.admin) - create
@@ -53,16 +55,22 @@ Service Account Keys and activate Google Workspace APIs.
   _attempt_ to enable these, but as there is sometimes a few minutes delay in activation and in some
   cases they are required to read your existing infra prior to apply, you may experience errors. To
   pre-empt those, we suggest ensuring the following are enabled:
-  - [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com)
-    (`compute.googleapis.com`)
-  - [Cloud Build API](https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com)
-    (`cloudbuild.googleapis.com`)
+   - [Artifact Registry API](https://console.cloud.google.com/apis/library/artifactregistry.googleapis.com)
+    (`artifactregistry.googleapis.com`)
+   - [Cloud Build API](https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com)
+     (`cloudbuild.googleapis.com`)
   - [Cloud Functions API](https://console.cloud.google.com/apis/library/cloudfunctions.googleapis.com)
     (`cloudfunctions.googleapis.com`)
   - [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
     (`cloudresourcemanager.googleapis.com`)
+  - [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com)
+    (`compute.googleapis.com`)
+  - [Eventarc API](https://console.cloud.google.com/apis/library/eventarc.googleapis.com)
+    (`eventarc.googleapis.com`)
   - [IAM API](https://console.cloud.google.com/apis/library/iam.googleapis.com)
     (`iam.googleapis.com`)
+  - [Pub/Sub API](https://console.cloud.google.com/apis/library/pubsub.googleapis.com)
+    (`pubsub.googleapis.com`)
   - [Secret Manager API](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com)
     (`secretmanager.googleapis.com`)
   - [Storage API](https://console.cloud.google.com/apis/library/storage-api.googleapis.com)

--- a/docs/gcp/getting-started.md
+++ b/docs/gcp/getting-started.md
@@ -26,7 +26,7 @@ Service Account Keys and activate Google Workspace APIs.
 - a GCP (Google) user or Service Account with permissions to provision Service Accounts, Secrets,
   Storage Buckets, Cloud Functions, and enable APIs within that project. eg:
 
-  - [Cloud Functions Admin](https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin) -
+  - [Cloud Functions Developer](https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.developer) -
     proxy instances are deployed as GCP cloud functions
   - [Cloud Run Developer](https://cloud.google.com/iam/docs/understanding-roles#cloudrun.developer) - cloud
     function deployment requires Cloud Run Developer role

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -136,7 +136,7 @@ resource "google_cloudfunctions2_function" "function" {
   location    = var.region
 
   build_config {
-    runtime     = "java17"
+    runtime     = "java21"
     entry_point = "co.worklytics.psoxy.GCSFileEvent"
 
     docker_repository = var.artifact_repository_id

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -108,8 +108,6 @@ resource "google_storage_bucket_iam_member" "grant_testers_admin_on_processed_bu
   member = each.value
 }
 
-
-
 resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret" {
   for_each = var.secret_bindings
 
@@ -119,61 +117,78 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret"
   role      = "roles/secretmanager.secretAccessor"
 }
 
+# to provision Cloud Function, TF must be able to act as the service account that the function will
+# run as
 module "tf_runner" {
   source = "../../modules/gcp-tf-runner"
 }
 
-# to provision Cloud Function, TF must be able to act as the service account that the function will
-# run as
 resource "google_service_account_iam_member" "act_as" {
   member             = module.tf_runner.iam_principal
   role               = "roles/iam.serviceAccountUser"
   service_account_id = google_service_account.service_account.id
 }
 
-resource "google_cloudfunctions_function" "function" {
+resource "google_cloudfunctions2_function" "function" {
   name        = local.function_name
   description = "Psoxy instance to process ${var.source_kind} files"
-  runtime     = "java17"
   project     = var.project_id
-  region      = var.region
+  location    = var.region
 
-  available_memory_mb   = coalesce(var.available_memory_mb, 1024)
-  source_archive_bucket = var.artifacts_bucket_name
-  source_archive_object = var.deployment_bundle_object_name
-  entry_point           = "co.worklytics.psoxy.GCSFileEvent"
-  service_account_email = google_service_account.service_account.email
-  timeout               = 540 # 9 minutes, which is gen1 max allowed
-  labels                = var.default_labels
-  docker_registry       = "ARTIFACT_REGISTRY"
-  docker_repository     = var.artifact_repository_id
+  build_config {
+    runtime     = "java17"
+    entry_point = "co.worklytics.psoxy.GCSFileEvent"
 
-  environment_variables = merge(tomap({
-    INPUT_BUCKET  = google_storage_bucket.input_bucket.name,
-    OUTPUT_BUCKET = module.output_bucket.bucket_name,
-    }),
-    var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
-    var.environment_variables,
-    var.config_parameter_prefix == null ? {} : { PATH_TO_SHARED_CONFIG = var.config_parameter_prefix },
-    var.config_parameter_prefix == null ? {} : { PATH_TO_INSTANCE_CONFIG = "${var.config_parameter_prefix}${replace(upper(var.instance_id), "-", "_")}_" },
-  )
+    docker_repository = var.artifact_repository_id
 
-  dynamic "secret_environment_variables" {
-    for_each = var.secret_bindings
-    iterator = secret_environment_variable
+    source {
+      storage_source {
+        bucket = var.artifacts_bucket_name
+        object = var.deployment_bundle_object_name
+      }
+    }
+  }
 
-    content {
-      key        = secret_environment_variable.key
-      project_id = data.google_project.project.number
-      secret     = secret_environment_variable.value.secret_id
-      version    = secret_environment_variable.value.version_number
+  service_config {
+    available_memory      = "${coalesce(var.available_memory_mb, 1024)}M"
+    service_account_email = google_service_account.service_account.email
+    timeout_seconds       = 540 # 9 minutes
+
+    environment_variables = merge(tomap({
+      INPUT_BUCKET  = google_storage_bucket.input_bucket.name,
+      OUTPUT_BUCKET = module.output_bucket.bucket_name,
+      }),
+      var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
+      var.environment_variables,
+      var.config_parameter_prefix == null ? {} : { PATH_TO_SHARED_CONFIG = var.config_parameter_prefix },
+      var.config_parameter_prefix == null ? {} : { PATH_TO_INSTANCE_CONFIG = "${var.config_parameter_prefix}${replace(upper(var.instance_id), "-", "_")}_" },
+    )
+
+    dynamic "secret_environment_variables" {
+      for_each = var.secret_bindings
+      iterator = secret_environment_variable
+
+      content {
+        key        = secret_environment_variable.key
+        project_id = data.google_project.project.number
+        secret     = secret_environment_variable.value.secret_id
+        version    = secret_environment_variable.value.version_number
+      }
     }
   }
 
   event_trigger {
-    event_type = "google.storage.object.finalize"
-    resource   = google_storage_bucket.input_bucket.name
+    event_type = "google.cloud.storage.object.v1.finalized"
+
+    # retry_policy = "RETRY_POLICY_RETRY" # what do we want??
+
+    event_filters {
+      attribute = "bucket"
+      value     = google_storage_bucket.input_bucket.name
+    }
   }
+
+  labels = var.default_labels
 
   lifecycle {
     ignore_changes = [
@@ -216,7 +231,7 @@ EOT
 
 Review the deployed Cloud function in GCP console:
 
-[Function in GCP Console](https://console.cloud.google.com/functions/details/${var.region}/${google_cloudfunctions_function.function.name}?project=${var.project_id})
+[Function in GCP Console](https://console.cloud.google.com/functions/details/${var.region}/${google_cloudfunctions2_function.function.name}?project=${var.project_id})
 
 We provide some Node.js scripts to easily validate the deployment. To be able
 to run the test commands below, you need Node.js (>=16) and npm (v >=8)

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -54,7 +54,7 @@ resource "google_cloudfunctions2_function" "function" {
   location = var.region
 
   build_config {
-    runtime           = "java17"
+    runtime           = "java21"
     docker_repository = var.artifact_repository_id
     entry_point       = "co.worklytics.psoxy.Route"
 

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -46,43 +46,53 @@ resource "google_service_account_iam_member" "act_as" {
 }
 
 
-resource "google_cloudfunctions_function" "function" {
+resource "google_cloudfunctions2_function" "function" {
   name        = "${var.environment_id_prefix}${var.instance_id}"
   description = "Psoxy Connector - ${var.source_kind}"
-  runtime     = "java17"
-  project     = var.project_id
-  region      = var.region
 
-  trigger_http                 = true
-  https_trigger_security_level = "SECURE_ALWAYS"
-  available_memory_mb          = var.available_memory_mb
-  source_archive_bucket        = var.artifacts_bucket_name
-  source_archive_object        = var.deployment_bundle_object_name
-  entry_point                  = "co.worklytics.psoxy.Route"
-  service_account_email        = var.service_account_email
-  labels                       = var.default_labels
-  docker_registry              = "ARTIFACT_REGISTRY"
-  docker_repository            = var.artifact_repository_id
+  project  = var.project_id
+  location = var.region
 
-  environment_variables = merge(
-    local.required_env_vars,
-    var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
-    var.environment_variables,
-    var.config_parameter_prefix == null ? {} : { PATH_TO_SHARED_CONFIG = var.config_parameter_prefix },
-    var.config_parameter_prefix == null ? {} : { PATH_TO_INSTANCE_CONFIG = "${var.config_parameter_prefix}${replace(upper(var.instance_id), "-", "_")}_" },
-  )
+  build_config {
+    runtime           = "java17"
+    docker_repository = var.artifact_repository_id
+    entry_point       = "co.worklytics.psoxy.Route"
 
-  dynamic "secret_environment_variables" {
-    for_each = var.secret_bindings
-    iterator = secret_environment_variable
-
-    content {
-      key        = secret_environment_variable.key
-      project_id = data.google_project.project.number
-      secret     = secret_environment_variable.value.secret_id
-      version    = secret_environment_variable.value.version_number
+    source {
+      storage_source {
+        bucket = var.artifacts_bucket_name
+        object = var.deployment_bundle_object_name
+      }
     }
   }
+
+  service_config {
+    service_account_email = var.service_account_email
+    available_memory      = "${var.available_memory_mb}M"
+    ingress_settings      = "ALLOW_ALL"
+
+    environment_variables = merge(
+      local.required_env_vars,
+      var.path_to_config == null ? {} : yamldecode(file(var.path_to_config)),
+      var.environment_variables,
+      var.config_parameter_prefix == null ? {} : { PATH_TO_SHARED_CONFIG = var.config_parameter_prefix },
+      var.config_parameter_prefix == null ? {} : { PATH_TO_INSTANCE_CONFIG = "${var.config_parameter_prefix}${replace(upper(var.instance_id), "-", "_")}_" },
+    )
+
+    dynamic "secret_environment_variables" {
+      for_each = var.secret_bindings
+      iterator = secret_environment_variable
+
+      content {
+        key        = secret_environment_variable.key
+        project_id = data.google_project.project.number
+        secret     = secret_environment_variable.value.secret_id
+        version    = secret_environment_variable.value.version_number
+      }
+    }
+  }
+
+  labels = var.default_labels
 
   lifecycle {
     ignore_changes = [
@@ -96,40 +106,40 @@ resource "google_cloudfunctions_function" "function" {
   ]
 }
 
-resource "google_cloudfunctions_function_iam_member" "invokers" {
+resource "google_cloudfunctions2_function_iam_member" "invokers" {
   for_each = toset(var.invoker_sa_emails)
 
-  cloud_function = google_cloudfunctions_function.function.id
+  cloud_function = google_cloudfunctions2_function.function.id
   member         = "serviceAccount:${each.value}"
   role           = "roles/cloudfunctions.invoker"
 }
 
-resource "google_cloudfunctions_function_iam_member" "testers" {
+resource "google_cloudfunctions2_function_iam_member" "testers" {
   for_each = toset(var.gcp_principals_authorized_to_test)
 
-  cloud_function = google_cloudfunctions_function.function.id
+  cloud_function = google_cloudfunctions2_function.function.id
   member         = each.value
   role           = "roles/cloudfunctions.invoker"
 }
 
 locals {
-  proxy_endpoint_url  = "https://${google_cloudfunctions_function.function.region}-${google_cloudfunctions_function.function.project}.cloudfunctions.net/${google_cloudfunctions_function.function.name}"
+  proxy_endpoint_url  = google_cloudfunctions2_function.function.service_config[0].uri
   impersonation_param = var.example_api_calls_user_to_impersonate == null ? "" : " -i \"${var.example_api_calls_user_to_impersonate}\""
   command_npm_install = "npm --prefix ${var.path_to_repo_root}tools/psoxy-test install"
   command_cli_call    = "node ${var.path_to_repo_root}tools/psoxy-test/cli-call.js"
   command_test_calls = [for path in var.example_api_calls :
     "${local.command_cli_call} -u \"${local.proxy_endpoint_url}${path}\"${local.impersonation_param}"
   ]
-  command_test_logs = "node ${var.path_to_repo_root}tools/psoxy-test/cli-logs.js -p \"${google_cloudfunctions_function.function.project}\" -f \"${google_cloudfunctions_function.function.name}\""
+  command_test_logs = "node ${var.path_to_repo_root}tools/psoxy-test/cli-logs.js -p \"${google_cloudfunctions2_function.function.project}\" -f \"${google_cloudfunctions2_function.function.name}\""
 }
 
 locals {
   todo_content = <<EOT
-## Testing ${google_cloudfunctions_function.function.name}
+## Testing ${google_cloudfunctions2_function.function.name}
 
 Review the deployed Cloud function in GCP console:
 
-[Function in GCP Console](https://console.cloud.google.com/functions/details/${google_cloudfunctions_function.function.region}/${google_cloudfunctions_function.function.name}?project=${google_cloudfunctions_function.function.project})
+[Function in GCP Console](https://console.cloud.google.com/functions/details/${google_cloudfunctions2_function.function.location}/${google_cloudfunctions2_function.function.name}?project=${google_cloudfunctions2_function.function.project})
 
 We provide some Node.js scripts to easily validate the deployment. To be able
 to run the test commands below, you need Node.js (>=16) and npm (v >=8)
@@ -191,7 +201,7 @@ resource "local_file" "test_script" {
 resource "local_file" "review" {
   count = var.todos_as_local_files ? 1 : 0
 
-  filename = "TODO ${var.todo_step} - test ${google_cloudfunctions_function.function.name}.md"
+  filename = "TODO ${var.todo_step} - test ${google_cloudfunctions2_function.function.name}.md"
   content  = local.todo_content
 }
 
@@ -200,11 +210,11 @@ output "instance_id" {
 }
 
 output "service_account_email" {
-  value = google_cloudfunctions_function.function.service_account_email
+  value = google_cloudfunctions2_function.function.service_config[0].service_account_email
 }
 
 output "cloud_function_name" {
-  value = google_cloudfunctions_function.function.name
+  value = google_cloudfunctions2_function.function.name
 }
 
 output "cloud_function_url" {

--- a/infra/modules/gcp/variables.tf
+++ b/infra/modules/gcp/variables.tf
@@ -77,3 +77,9 @@ variable "default_labels" {
   description = "*Alpha* in v0.4, only respected for new resources. Labels to apply to all resources created by this configuration. Intended to be analogous to AWS providers `default_tags`."
   default     = {}
 }
+
+variable "support_bulk_mode" {
+  type        = bool
+  description = "whether to enable/provision components required for 'bulk mode' instances"
+  default     = true
+}

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -460,10 +460,16 @@ locals {
       display_name    = "Service Usage Admin",
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#serviceusage.serviceUsageAdmin"
     },
-    "roles/cloudfunctions.admin" = {
+    "roles/cloudfunctions.admin" = { # q: can we replace this with Cloud Run Developer ??
       display_name    = "Cloud Functions Admin",
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin"
     },
+    "roles/cloudrun.developer" = {
+      display_name    = "Cloud Run Developer",
+      description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudrun.developer"
+    }
+  }
+
   }
   # TODO: add list of permissions, which customer could use to create custom role as alternative
 

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -460,9 +460,9 @@ locals {
       display_name    = "Service Usage Admin",
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#serviceusage.serviceUsageAdmin"
     },
-    "roles/cloudfunctions.admin" = { # q: can we replace this with Cloud Run Developer ??
-      display_name    = "Cloud Functions Admin",
-      description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.admin"
+    "roles/cloudfunctions.developer" = {
+      display_name    = "Cloud Functions Developer",
+      description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudfunctions.developer"
     },
     "roles/cloudrun.developer" = {
       display_name    = "Cloud Run Developer",

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -469,7 +469,7 @@ locals {
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudrun.developer"
     }
   }
-  
+
   # TODO: add list of permissions, which customer could use to create custom role as alternative
 
 

--- a/infra/modules/psoxy-constants/main.tf
+++ b/infra/modules/psoxy-constants/main.tf
@@ -469,8 +469,7 @@ locals {
       description_url = "https://cloud.google.com/iam/docs/understanding-roles#cloudrun.developer"
     }
   }
-
-  }
+  
   # TODO: add list of permissions, which customer could use to create custom role as alternative
 
 

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -11,6 +11,10 @@ import { Storage } from '@google-cloud/storage';
 import getLogger from './logger.js';
 import _ from 'lodash';
 
+
+const GCP_CLOUD_FUNCTION_GEN1_DOMAIN='cloudfunctions.net';
+const GCP_CLOUD_FUNCTION_GEN2_DOMAIN='run.app';
+
 /**
  * Helper: check url deploy type
  *
@@ -21,7 +25,7 @@ function isValidURL(url) {
   if (typeof url === 'string') {
     url = new URL(url);
   }
-  return url.hostname.endsWith('cloudfunctions.net');
+  return url.hostname.endsWith(GCP_CLOUD_FUNCTION_GEN1_DOMAIN) || url.hostname.endsWith(GCP_CLOUD_FUNCTION_GEN2_DOMAIN)
 }
 
 /**


### PR DESCRIPTION
### Features
  - migrate GCP to Cloud Run Gen2, as this now seem *strongly* preferred by GCP and has various advantages


### Change implications

 - dependencies added/changed? **yes - depends on having some additional perms (CLoud Run Developer); will also require enabling some APIs, but our terraform modules will handle that internally**
 - something important to note in future release notes? **yes - add the role, prob wait for v0.6 with this, as it's technically breaking**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206108944334925