### PR TITLE
avoid email parser dependency

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -128,20 +128,6 @@
             <version>${dependency.google-auth-library-oauth2-http.version}</version>
         </dependency>
 
-
-        <!-- RFC 2822 validator -->
-        <!-- see https://github.com/bbottema/email-rfc2822-validator -->
-        <dependency>
-            <groupId>com.github.bbottema</groupId>
-            <artifactId>emailaddress-rfc2822</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency> <!-- for email validation to work in lib above; used in RESTApiSanitizerImpl, PseudonymizerImpl as of June 2023 -->
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId> <!-- CDDL + GPLv2 with classpath exception license, so ideally would remove -->
-            <version>[1.6.3,1.9.9)</version>
-        </dependency>
-
         <!-- explicit direct dep on apache HTTP Client (psoxy-core has transitive dep on it) -->
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>

--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizerImpl.java
@@ -15,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.java.Log;
 import org.apache.commons.lang3.StringUtils;
-import org.hazlewood.connor.bottema.emailaddress.EmailAddressValidator;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -152,7 +151,7 @@ public class PseudonymizerImpl implements Pseudonymizer {
     }
 
     boolean duckTypesAsEmails(Object value) {
-        return value instanceof String && EmailAddressValidator.isValid((String) value);
+        return value instanceof String && emailAddressParser.isValid((String) value);
     }
 
     /**

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/Dragons.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/Dragons.java
@@ -1,0 +1,404 @@
+package co.worklytics.psoxy.utils.email;
+
+/*
+ * Copyright (C) 2016 Benny Bottema and Casey Connor (benny@bennybottema.com and ahoy@caseyconnor.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import lombok.NonNull;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+/**
+ * MY DRAGONS WILL EAT YOUR DRAGONS
+ * <p>
+ * Regular expressions based on given list of {@link EmailAddressCriteria}. Used in both validation ({@link EmailAddressValidator}) and email data extraction
+ * ({@link EmailAddressParser}).
+ */
+final class Dragons {
+
+    /**
+     * Java regex pattern for 2822 &quot;mailbox&quot; token; Not necessarily useful, but available in case.
+     */
+    final Pattern MAILBOX_PATTERN;
+    /**
+     * Java regex pattern for 2822 &quot;addr-spec&quot; token; Not necessarily useful, but available in case.
+     */
+    final Pattern ADDR_SPEC_PATTERN;
+    /**
+     * Java regex pattern for 2822 &quot;mailbox-list&quot; token; Not necessarily useful, but available in case.
+     */
+    final Pattern MAILBOX_LIST_PATTERN;
+    //    public static final Pattern ADDRESS_LIST_PATTERN = Pattern.compile(addressList);
+    /**
+     * Java regex pattern for 2822 &quot;address&quot; token; Not necessarily useful, but available in case.
+     */
+    final Pattern ADDRESS_PATTERN;
+    /**
+     * Java regex pattern for 2822 &quot;comment&quot; token; Not necessarily useful, but available in case.
+     */
+    final Pattern COMMENT_PATTERN;
+
+    final Pattern QUOTED_STRING_WO_CFWS_PATTERN;
+    final Pattern RETURN_PATH_PATTERN;
+    final Pattern GROUP_PREFIX_PATTERN;
+
+    final Pattern ESCAPED_QUOTE_PATTERN;
+    final Pattern ESCAPED_BSLASH_PATTERN;
+
+    /**
+     * Very simply cache to avoid recreating dragons all the time.
+     */
+    private static final Map<EnumSet<EmailAddressCriteria>, Dragons> cache = new HashMap<>();
+
+    /**
+     * @return Dragons based on criteria, cached if the criteria have been used before
+     */
+    @SuppressWarnings("WeakerAccess")
+    @NonNull
+    protected static  Dragons fromCriteria(@NonNull final EnumSet<EmailAddressCriteria> criteria) {
+        if (!cache.containsKey(criteria)) {
+            cache.put(criteria, new Dragons(criteria));
+        }
+        return cache.get(criteria);
+    }
+
+    /**
+     * Hatch dragons...
+     */
+    @NonNull
+    private Dragons(@NonNull final EnumSet<EmailAddressCriteria> criteria) {
+        // RFC 2822 2.2.2 Structured Header Field Bodies
+        final String crlf = "\\r\\n";
+        final String wsp = "[ \\t]"; //space or tab
+        final String fwsp = format("(?:%s*%s)?%s+", wsp, crlf, wsp);
+
+        //RFC 2822 3.2.1 Primitive tokens
+        final String dquote = "\"";
+        //ASCII Control characters excluding white space:
+        final String noWsCtl = "\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F";
+        //all ASCII characters except CR and LF:
+        final String asciiText = "[\\x01-\\x09\\x0B\\x0C\\x0E-\\x7F]";
+
+        // RFC 2822 3.2.2 Quoted characters:
+        //single backslash followed by a text char
+        final String quotedPair = format("(?:\\\\%s)", asciiText);
+
+        // RFC 2822 3.2.3 CFWS specification
+        // note: nesting should be permitted but is not by these rules given code limitations:
+
+        // rewritten to be shorter:
+        //final String ctext = "[" + noWsCtl + "\\x21-\\x27\\x2A-\\x5B\\x5D-\\x7E]";
+        final String ctext = format("[%s!-'*-\\[\\]-~]", noWsCtl);
+        final String ccontent = format("%s|%s", ctext, quotedPair); // + "|" + comment;
+        final String comment = format("\\((?:(?:%s)?%s)*(?:%s)?\\)", fwsp, ccontent, fwsp);
+        final String cfws = format("(?:(?:%s)?%s)*(?:(?:(?:%s)?%s)|(?:%s))", fwsp, comment, fwsp, comment, fwsp);
+
+        //RFC 2822 3.2.4 Atom:
+
+        final String atext = format("[a-zA-Z0-9!#-'*+\\-/=?^-`{-~%s%s]",
+            criteria.contains(EmailAddressCriteria.ALLOW_DOT_IN_A_TEXT) ? "." : "",
+            criteria.contains(EmailAddressCriteria.ALLOW_SQUARE_BRACKETS_IN_A_TEXT) ? "\\[\\]" : "");
+        // regular atext is same as atext but has no . or [ or ] allowed, no matter the class prefs, to prevent
+        // long recursions on e.g. "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t"
+        final String regularAtext = "[a-zA-Z0-9!#-'*+\\-/=?^-`{-~]";
+
+        final String atom = format("(?:%s)?%s+(?:%s)?", cfws, atext, cfws);
+        final String dotAtomText = format("%s+(?:\\.%s+)*", regularAtext, regularAtext);
+//		final String dotAtom = format("(?:%s)?%s(?:%s)?", cfws, dotAtomText, cfws);
+        final String capDotAtomNoCFWS = format("(?:%s)?(%s)(?:%s)?", cfws, dotAtomText, cfws);
+        final String capDotAtomTrailingCFWS = format("(?:%s)?(%s)(%s)?", cfws, dotAtomText, cfws);
+
+        //RFC 2822 3.2.5 Quoted strings:
+        //noWsCtl and the rest of ASCII except the doublequote and backslash characters:
+
+        final String qtext = format("[%s!#-\\[\\]-~]", noWsCtl);
+        final String localPartqtext = format("[%s%s", noWsCtl,
+            criteria.contains(EmailAddressCriteria.ALLOW_PARENS_IN_LOCALPART) ? "!#-\\[\\]-~]" : "!#-'\\*-\\[\\]-~]");
+
+        final String qcontent = format("(?:%s|%s)", qtext, quotedPair);
+        final String localPartqcontent = format("(?>%s|%s)", localPartqtext, quotedPair);
+        final String quotedStringWOCFWS = format("%s(?>(?:%s)?%s)*(?:%s)?%s", dquote, fwsp, qcontent, fwsp, dquote);
+        final String quotedString = format("(?:%s)?%s(?:%s)?", cfws, quotedStringWOCFWS, cfws);
+        final String localPartQuotedString = format("(?:%s)?(%s(?:(?:%s)?%s)*(?:%s)?%s)(?:%s)?",
+            cfws, dquote, fwsp, localPartqcontent, fwsp, dquote, cfws);
+
+        //RFC 2822 3.2.6 Miscellaneous tokens
+        final String word = format("(?:(?:%s)|(?:%s))", atom, quotedString);
+        // by 2822: phrase = 1*word / obs-phrase
+        // implemented here as: phrase = word (FWS word)*
+        // so that aaaa can't be four words, which can cause tons of recursive backtracking
+        //final String phrase = "(?:" + word + "+?)"; //one or more words
+        final String phrase = format("%s(?:(?:%s)%s)*", word, fwsp, word);
+
+        //RFC 1035 tokens for domain names:
+        final String letter = "[a-zA-Z]";
+        final String letDig = "[a-zA-Z0-9]";
+        final String letDigHyp = "[a-zA-Z0-9-]";
+        final String rfcLabel = format("%s(?:%s{0,61}%s)?", letDig, letDigHyp, letDig);
+        final String rfc1035DomainName = format("%s(?:\\.%s)*\\.%s{2,26}", rfcLabel, rfcLabel, letter);
+
+        //RFC 2822 3.4 Address specification
+        //domain text - non white space controls and the rest of ASCII chars not
+        // including [, ], or \:
+        // rewritten to save space:
+        //final String dtext = "[" + noWsCtl + "\\x21-\\x5A\\x5E-\\x7E]";
+        final String dtext = format("[%s!-Z^-~]", noWsCtl);
+
+        final String dcontent = format("%s|%s", dtext, quotedPair);
+        final String capDomainLiteralNoCFWS =
+            format("(?:%s)?(\\[(?:(?:%s)?(?:%s)+)*(?:%s)?])(?:%s)?", cfws, fwsp, dcontent, fwsp, cfws);
+        final String capDomainLiteralTrailingCFWS =
+            format("(?:%s)?(\\[(?:(?:%s)?(?:%s)+)*(?:%s)?])(%s)?", cfws, fwsp, dcontent, fwsp, cfws);
+        final String rfc2822Domain = format("(?:%s|%s)", capDotAtomNoCFWS, capDomainLiteralNoCFWS);
+        final String capCFWSRfc2822Domain = format("(?:%s|%s)", capDotAtomTrailingCFWS, capDomainLiteralTrailingCFWS);
+
+        // Les chose to implement the more-strict 1035 instead of just relying on "dot-atom"
+        // as would be implied by 2822 without the domain-literal token. The issue is that 2822
+        // allows CFWS around the local part and the domain,
+        // strange though that may be (and you "SHOULD NOT" put it around the @). This version
+        // allows the cfws before and after.
+        // final String domain =
+        //    ALLOW_DOMAIN_LITERALS ? rfc2822Domain : rfc1035DomainName;
+        final String domain = criteria.contains(EmailAddressCriteria.ALLOW_DOMAIN_LITERALS) ? rfc2822Domain : "(?:" + cfws + ")?(" + rfc1035DomainName + ")(?:" + cfws + ")?";
+        final String capCFWSDomain = criteria.contains(EmailAddressCriteria.ALLOW_DOMAIN_LITERALS)
+            ? capCFWSRfc2822Domain
+            : format("(?:%s)?(%s)(%s)?", cfws, rfc1035DomainName, cfws);
+        final String localPart = format("(%s|%s)", capDotAtomNoCFWS, localPartQuotedString);
+        // uniqueAddrSpec exists so we can have a duplicate tree that has a capturing group
+        // instead of a non-capturing group for the trailing CFWS after the domain token
+        // that we wouldn't want if it was inside
+        // an angleAddr. The matching should be otherwise identical.
+        final String addrSpec = format("%s@%s", localPart, domain);
+        final String uniqueAddrSpec = localPart + "@" + capCFWSDomain;
+        final String angleAddr = format("(?:%s)?<%s>(%s)?", cfws, addrSpec, cfws);
+        // uses a reluctant quantifier to skip ahead and make sure there's actually an
+        // address in there somewhere... hmmm, maybe regex in java doesn't optimize that
+        // case by skipping over it at the start by default? Doesn't seem to solve the
+        // issue of recursion on long strings like [A-Za-z], but issue was solved by
+        // changing phrase definition (see above):
+        final String nameAddr = format("(%s)??(%s)", phrase, angleAddr);
+        final String mailboxName = criteria.contains(EmailAddressCriteria.ALLOW_QUOTED_IDENTIFIERS)
+            ? format("(%s)|", nameAddr) : "";
+        final String mailbox = format("%s(%s)", mailboxName, uniqueAddrSpec);
+
+        final String returnPath = format("(?:(?:%s)?<((?:%s)?|%s)>(?:%s)?)", cfws, cfws, addrSpec, cfws);
+
+        final String mailboxList = format("(?:(?:%s)(?:,(?:%s))*)", mailbox, mailbox);
+        final String groupPostfix = format("(?:%s|(?:%s))?;(?:%s)?", cfws, mailboxList, cfws);
+        final String groupPrefix = phrase + ":";
+        final String group = groupPrefix + groupPostfix;
+        final String address = format("(?:(?:%s)|(?:%s))", mailbox, group);
+        // this string is too long, so must do it FSM style in isValidAddressList:
+        // private static final String addressList = address + "(?:," + address + ")*";
+
+        // That wasn't so hard...
+
+        // Group IDs:
+
+        // Capturing groups (works with (), ()?, but not ()* if it has nested
+        // groups). Many of these are provided for your convenience. As few as one
+        // or as many as four would be needed to reconstruct the address.
+
+        // If ALLOW_QUOTED_IDENTIFIERS and ALLOW_DOMAIN_LITERALS:
+        // 1: name-addr (inlc angle-addr only)
+        //  2: phrase (personal name) of said name-addr (1)
+        //  3: angle-addr of said name-addr (1)
+        //  4: local-part of said angle-addr (3)
+        //  5: non-cfws dot-atom local-part of said angle-addr (3)
+        //  6: non-cfws quoted-string local-part of said-angle-addr(3)
+        //  7: non-cfws dot-atom domain-part of said angle-addr (3)
+        //  8: non-cfws domain-literal domain-part of said angle-addr (3)
+        //  9: any CFWS that follows said angle-address (3)
+        // 10: addr-spec only
+        //  11: local-part of said addr-spec (10)
+        //  12: non-cfws dot-atom local-part of said addr-spec (10)
+        //  13: non-cfws quoted-string local-part of said addr-spec (10)
+        //  14: non-cfws dot-atom domain-part of said addr-spec (10)
+        //  15: non-cfws domain-literal domain-part of said addr-spec (10)
+        //  16: any CFWS that follows (14) or (15)
+        // if name-addr: addr w/o CFWS is part (5|6) + "@" + (7|8), personal name is part (2|9)
+        // if addr-spec: addr w/o CFWS is part (12|13) + "@" + (14|15), personal name is part (16)
+
+        // If ALLOW_QUOTED_IDENTIFIERS and !ALLOW_DOMAIN_LITERALS:
+        // 1: name-addr (inlc angle-addr only)
+        //  2: phrase (personal name) of said name-addr (1)
+        //  3: angle-addr of said name-addr (1)
+        //  4: local-part of said angle-addr (3)
+        //  5: non-cfws dot-atom local-part of said angle-addr (3)
+        //  6: non-cfws quoted-string local-part of said-angle-addr(3)
+        //  7: non-cfws domain-part (always dot-atom) of said angle-addr (3)
+        //  8: any CFWS that follows said angle-address (3)
+        // 9: addr-spec only
+        //  10: local-part of said addr-spec (9)
+        //  11: non-cfws dot-atom local-part of said addr-spec (9)
+        //  12: non-cfws quoted-string local-part of said addr-spec (9)
+        //  13: non-cfws domain-part of said addr-spec (9)
+        //  14: any CFWS that follows (12) or (13)
+        // if name-addr: addr w/o CFWS is part (5|6) + "@" + 7, personal name is part (2|8)
+        // if addr-spec: addr w/o CFWS is part (11|12) + "@" + 13, personal name is part (14)
+
+        // If !ALLOW_QUOTED_IDENTIFIERS and !ALLOW_DOMAIN_LITERALS:
+        // 1: addr-spec only
+        //  2: local-part of said addr-spec (1)
+        //   3: non-cfws dot-atom local-part of said addr-spec (1)
+        //   4: non-cfws quoted-string local-part of said addr-spec (1)
+        //   5: non-cfws domain-part (always dot-atom) of said addr-spec (1)
+        //   6: any CFWS that follows (5)
+        // addr w/o CFWS is part (3|4) + "@" + 5, personal name is (6)
+
+        // If !ALLOW_QUOTED_IDENTIFIERS and ALLOW_DOMAIN_LITERALS:
+        // 1: addr-spec only
+        //  2: local-part of said addr-spec (1)
+        //   3: non-cfws dot-atom local-part of said addr-spec (1)
+        //   4: non-cfws quoted-string local-part of said addr-spec (1)
+        //   5: non-cfws dot-atom domain-part of said addr-spec (1)
+        //   6: non-cfws domain-literal domain-part of said addr-spec (1)
+        //   7: any CFWS that follows (5) or (6)
+        // addr w/o CFWS is part (3|4) + "@" + (5|6), personal name is part (7)
+
+        // For RETURN_PATH_PATTERN, there is one matching group at the head of the
+        // group ID tree that matches the content inside the angle brackets (including
+        // CFWS, etc.: Group 1.
+
+        // optimize: could pre-make matchers as well and use reset(s) on them?
+
+        //compile patterns for efficient re-use:
+
+		/*
+		  Java regex pattern for 2822 &quot;mailbox&quot; token; Not necessarily useful, but available in case.
+		 */
+        MAILBOX_PATTERN = Pattern.compile(mailbox);
+        /*
+         * Java regex pattern for 2822 &quot;addr-spec&quot; token; Not necessarily useful, but available in case.
+         */
+        ADDR_SPEC_PATTERN = Pattern.compile(addrSpec);
+		/*
+		  Java regex pattern for 2822 &quot;mailbox-list&quot; token; Not necessarily useful, but available in case.
+		 */
+        MAILBOX_LIST_PATTERN = Pattern.compile(mailboxList);
+        //    public static final Pattern ADDRESS_LIST_PATTERN = Pattern.compile(addressList);
+		/*
+		  Java regex pattern for 2822 &quot;address&quot; token; Not necessarily useful, but available in case.
+		 */
+        ADDRESS_PATTERN = Pattern.compile(address);
+        /*
+         * Java regex pattern for 2822 &quot;comment&quot; token; Not necessarily useful, but available in case.
+         */
+        COMMENT_PATTERN = Pattern.compile(comment);
+
+        QUOTED_STRING_WO_CFWS_PATTERN = Pattern.compile(quotedStringWOCFWS);
+        RETURN_PATH_PATTERN = Pattern.compile(returnPath);
+        GROUP_PREFIX_PATTERN = Pattern.compile(groupPrefix);
+
+        // confused yet? Try this:
+        ESCAPED_QUOTE_PATTERN = Pattern.compile("\\\\\"");
+        ESCAPED_BSLASH_PATTERN = Pattern.compile("\\\\\\\\");
+    }
+
+
+/* The current regex string for mailbox token, just for fun:
+(((?:(?:(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09
+\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x
+0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?[a-zA-Z0
+-9!#-'*+\-/=?^-`{-~.\[]]+(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~
+]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)
+?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[
+ \t]+)))?)|(?:(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x0
+1-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08
+\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?"(
+?>(?:(?:[ \t]*\r\n)?[ \t]+)?(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!#-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F])))*(?:(?:[ \t]*\r\n)?[
+\t]+)?"(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\
+x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0
+C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?))(?:(?:(
+?:[ \t]*\r\n)?[ \t]+)(?:(?:(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]
+-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]
++)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)
+?[ \t]+)))?[a-zA-Z0-9!#-'*+\-/=?^-`{-~.\[]]+(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-
+\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:
+[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|
+(?:(?:[ \t]*\r\n)?[ \t]+)))?)|(?:(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'
+*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)
+?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]
+*\r\n)?[ \t]+)))?"(?>(?:(?:[ \t]*\r\n)?[ \t]+)?(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!#-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F])))*(
+?:(?:[ \t]*\r\n)?[ \t]+)?"(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-
+~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+
+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?
+[ \t]+)))?)))*)??((?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\
+[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-
+\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+))
+)?<((?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B
+\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x
+0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?([a-zA-Z0-9!
+#-'*+\-/=?^-`{-~]+(?:\.[a-zA-Z0-9!#-'*+\-/=?^-`{-~]+)*)(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x
+0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?
+\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[
+ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?|(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F
+\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t
+]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(
+?:[ \t]*\r\n)?[ \t]+)))?("(?:(?:(?:[ \t]*\r\n)?[ \t]+)?(?>[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!#-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x
+7F])))*(?:(?:[ \t]*\r\n)?[ \t]+)?")(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!
+-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\
+n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \
+t]*\r\n)?[ \t]+)))?)@(?:(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]
+|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?
+[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[
+\t]+)))?([a-zA-Z0-9!#-'*+\-/=?^-`{-~]+(?:\.[a-zA-Z0-9!#-'*+\-/=?^-`{-~]+)*)(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?
+[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:
+[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))
+*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?|(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\
+x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \
+t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r
+\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?(\[(?:(?:(?:[ \t]*\r\n)?[ \t]+)?(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-Z^-~]|(?:\\[\x01-\
+x09\x0B\x0C\x0E-\x7F]))+)*(?:(?:[ \t]*\r\n)?[ \t]+)?])(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0
+B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\
+((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[
+\t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?)>((?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x
+7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*
+\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:
+[ \t]*\r\n)?[ \t]+)))?))|(((?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]
+-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]
++)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)
+?[ \t]+)))?([a-zA-Z0-9!#-'*+\-/=?^-`{-~]+(?:\.[a-zA-Z0-9!#-'*+\-/=?^-`{-~]+)*)(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\
+n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:
+(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F
+]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?|(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x0
+1-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?
+[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]
+*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?("(?:(?:(?:[ \t]*\r\n)?[ \t]+)?(?>[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!#-\[\]-~]|(?:\\[\
+x01-\x09\x0B\x0C\x0E-\x7F])))*(?:(?:[ \t]*\r\n)?[ \t]+)?")(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x0
+8\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]
++)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n
+)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?)@(?:(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x
+0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:
+(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\
+))|(?:(?:[ \t]*\r\n)?[ \t]+)))?([a-zA-Z0-9!#-'*+\-/=?^-`{-~]+(?:\.[a-zA-Z0-9!#-'*+\-/=?^-`{-~]+)*)((?:(?:(?:[ \t]*\r\n)?[ \t]+)?\(
+(?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \
+t]+)?\))*(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x0
+9\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?|(?:(?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*
+\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:
+(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\
+x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?(\[(?:(?:(?:[ \t]*\r\n)?[ \t]+)?(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x7
+F!-Z^-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))+)*(?:(?:[ \t]*\r\n)?[ \t]+)?])((?:(?:(?:[ \t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[
+\t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(?:(?:[ \t]*\r\n)?[ \t]+)?\))*(?:(?:(?:(?:[
+\t]*\r\n)?[ \t]+)?\((?:(?:(?:[ \t]*\r\n)?[ \t]+)?[\x01-\x08\x0B\x0C\x0E-\x1F\x7F!-'*-\[\]-~]|(?:\\[\x01-\x09\x0B\x0C\x0E-\x7F]))*(
+?:(?:[ \t]*\r\n)?[ \t]+)?\))|(?:(?:[ \t]*\r\n)?[ \t]+)))?))
+*/
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddress.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddress.java
@@ -1,0 +1,12 @@
+package co.worklytics.psoxy.utils.email;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class EmailAddress {
+    public String personalName;
+    public String localPart;
+    public String domain;
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddress.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddress.java
@@ -6,7 +6,16 @@ import lombok.Value;
 @Value
 @Builder
 public class EmailAddress {
-    public String personalName;
-    public String localPart;
-    public String domain;
+
+    String personalName;
+    String localPart;
+    String domain;
+
+    public String asFormattedString() {
+        if (personalName != null && !personalName.isEmpty()) {
+            return String.format("\"%s\" <%s@%s>", personalName, localPart, domain);
+        } else {
+            return String.format("%s@%s", localPart, domain);
+        }
+    }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressCriteria.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressCriteria.java
@@ -1,0 +1,136 @@
+
+/*
+ * Copyright (C) 2016 Benny Bottema and Casey Connor (benny@bennybottema.com and ahoy@caseyconnor.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package co.worklytics.psoxy.utils.email;
+
+import java.util.EnumSet;
+
+import static java.util.EnumSet.of;
+
+/**
+ * Defines a set of restriction flags for email address validation. To remain completely true to RFC 2822, all flags should be set to <code>true</code>.
+ * <p>
+ * There are a few basic use cases:
+ * <ol>
+ *    	 <li>
+ *    	     User wants to scrape as much data from a possibly-ugly address as they can and make a sensible address from it; these users typically allow all
+ *    	     kinds of addresses (except perhaps for single-domain addresses) because in the wild, legitimate senders often violate 2822. E.g. If your goal is to
+ *    	     parse spammy emails for analysis, you may want to allow every variation out there just so you can parse something useful.
+ * 		</li>
+ *     	<li>
+ *     	    User wants to check to see if an email address is of proper, normal syntax; e.g. checking the value entered in a form. These users typically make
+ * 			everything strict, since what most people consider a "valid" email address is a drastic subset of 2822. For users with the strictest requirements,
+ * 			this library may not be enough, since although it checks most of RFC 2822, it might still be too 'tolerant' for their needs (on the other side of
+ * 			the spectrum, most libraries use a simple blah@blah.blah.com type regex, which as we of course know is
+ * 			<a href="http://www.troyhunt.com/2013/11/dont-trust-net-web-forms-email-regex.html">rarely a good idea</a>.)
+ * 		</li>
+ * 		<li>
+ * 		    User wants to intelligently parse a possibly-ugly address with the goal being a cleaned up usable address that other software
+ * 		    (MTAs, databases, whatever) can use / parse without breaking; {@link #RECOMMENDED} tailors to this use case (with the possible exception of
+ * 		    {@link #ALLOW_DOT_IN_A_TEXT}, to taste). In our experience they allowed "real" addresses the highest percentage of the time, and the addresses they
+ * 		    failed on were almost all ridiculous.
+ * 		</li>
+ * </ol>
+ *
+ * @author Benny Bottema
+ */
+public enum EmailAddressCriteria {
+    /**
+     * This criteria changes the behavior of the domain parsing. If included, the parser will allow 2822 domains, which include single-level domains (e.g.
+     * bob@localhost) as well as domain literals, e.g.:
+     * <p>
+     * <code>someone@[192.168.1.100]</code> or<br>
+     * <code>john.doe@[23:33:A2:22:16:1F]</code> or<br>
+     * <code>me@[my computer]</code>
+     * <p>
+     * The RFC says these are valid email addresses, but most people don't like allowing them. If you don't want to allow them, and only want to allow valid
+     * domain names (<a href="http://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a>, x.y.z.com, etc), and specifically only those with at least two levels
+     * ("example.com"), then don't include this critera.
+     */
+    ALLOW_DOMAIN_LITERALS,
+
+    /**
+     * This criteria states that as per RFC 2822, quoted identifiers are allowed (using quotes and angle brackets around the raw address), e.g.:
+     * <p>
+     * <code>"John Smith" &lt;john.smith@somewhere.com&gt;</code>
+     * <p>
+     * The RFC says this is a valid mailbox.  If you don't want to allow this, because for example, you only want users to enter in a raw address
+     * (<code>john.smith@somewhere.com</code> - no quotes or angle brackets), then don't include this criteria.
+     */
+    ALLOW_QUOTED_IDENTIFIERS,
+
+    /**
+     * This criteria allows &quot;.&quot; to appear in atext (note: only atext which appears in the 2822 &quot;name-addr&quot; part of the address, not the
+     * other instances)
+     * <p>
+     * The addresses:<br>
+     * <code>Kayaks.org &lt;kayaks@kayaks.org&gt;</code><br>
+     * <code>Bob K. Smith&lt;bobksmith@bob.net&gt;</code><br>
+     * ...are not valid. They should be:<br>
+     * <code>&quot;Kayaks.org&quot; &lt;kayaks@kayaks.org&gt;</code><br>
+     * <code>&quot;Bob K. Smith&quot;
+     * &lt;bobksmith@bob.net&gt;</code>
+     * <p>
+     * If this criteria is not included, the parser will act per 2822 and will require the quotes; if included, it will allow the use of &quot;.&quot; without
+     * quotes.
+     */
+    ALLOW_DOT_IN_A_TEXT,
+
+    /**
+     * This criteria allows &quot;[&quot; or &quot;]&quot; to appear in atext. Not very useful, maybe, but there it is.
+     * <p>
+     * The address:
+     * <p>
+     * <code>[Kayaks] &lt;kayaks@kayaks.org&gt;</code> ...is not valid. It should be:
+     * <p>
+     * <code>&quot;[Kayaks]&quot; &lt;kayaks@kayaks.org&gt;</code>
+     * <p>
+     * If this criteria is not included, the parser will act per 2822 and will require the quotes; if included, it will allow them to be missing.
+     * <p>
+     * One real-world example seen:
+     * <p>
+     * Bob Smith [mailto:bsmith@gmail.com]=20
+     * <p>
+     * Use at your own risk. There may be some issue with enabling this feature in conjunction with {@link #ALLOW_DOMAIN_LITERALS}, but i haven't looked into
+     * that. If the <code>ALLOW_DOMAIN_LITERALS</code> criteria is not included, I think this should be pretty safe. Whether or not it's useful, that's up to
+     * you.
+     */
+    ALLOW_SQUARE_BRACKETS_IN_A_TEXT,
+
+    /**
+     * This criteria allows as per RFC 2822 &quot;)&quot; or &quot;(&quot; to appear in quoted versions of the localpart (they are never allowed in unquoted
+     * versions)
+     * <p>
+     * You can disallow it, but better to include this criteria. I left this hanging around (from an earlier incarnation of the code) as a random option you can
+     * switch off. No, it's not necssarily useful. Long story.
+     * <p>
+     * If this criteria is not included, it will prevent such addresses from being valid, even though they are: &quot;bob(hi)smith&quot;@test.com
+     */
+    ALLOW_PARENS_IN_LOCALPART;
+
+    /**
+     * The recommended setting is not strictly 2822 compliant. For example, it does not include the {@link #ALLOW_DOMAIN_LITERALS} criteria, which results in
+     * exclusions on single domains. Useful for cleaning up email strings that other middleware (ie. the next server) will be able to understand.
+     * <p>
+     * Included in the recommended defaults are:
+     * <ul>
+     *     <li>{@link #ALLOW_QUOTED_IDENTIFIERS}</li>
+     *     <li>{@link #ALLOW_PARENS_IN_LOCALPART}</li>
+     * </ul>.
+     */
+    public static final EnumSet<EmailAddressCriteria> RECOMMENDED = of(ALLOW_QUOTED_IDENTIFIERS, ALLOW_PARENS_IN_LOCALPART);
+
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressCriteria.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressCriteria.java
@@ -121,16 +121,5 @@ public enum EmailAddressCriteria {
      */
     ALLOW_PARENS_IN_LOCALPART;
 
-    /**
-     * The recommended setting is not strictly 2822 compliant. For example, it does not include the {@link #ALLOW_DOMAIN_LITERALS} criteria, which results in
-     * exclusions on single domains. Useful for cleaning up email strings that other middleware (ie. the next server) will be able to understand.
-     * <p>
-     * Included in the recommended defaults are:
-     * <ul>
-     *     <li>{@link #ALLOW_QUOTED_IDENTIFIERS}</li>
-     *     <li>{@link #ALLOW_PARENS_IN_LOCALPART}</li>
-     * </ul>.
-     */
-    public static final EnumSet<EmailAddressCriteria> RECOMMENDED = of(ALLOW_QUOTED_IDENTIFIERS, ALLOW_PARENS_IN_LOCALPART);
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
@@ -25,10 +25,27 @@ public class EmailAddressParser {
     final EnumSet<EmailAddressCriteria> criteria;
     final Pattern MAILBOX_PATTERN;
 
+    /**
+     * Parse an email address into its components. The email address must be valid according to the criteria.
+     * @param rawEmail to parse
+     * @return an Optional containing the parsed email address if valid, or an empty Optional if invalid
+     */
     public Optional<EmailAddress> parse(String rawEmail) {
         return Optional.ofNullable(rawEmail)
             .map(MAILBOX_PATTERN::matcher)
             .filter(Matcher::matches)
             .map(m -> EmailAddressParserRoutines.matcherToStruture(m, criteria, true));
+    }
+
+    /**
+     * whether email address is valid according to the criteria, which is a pragmatic subset of RFC stuff
+     *
+     * @see EmailAddressParserRoutines for details on precise criteria / interpretation of the RFC.
+     *
+     * @param rawEmail to validate
+     * @return true if valid, false if not
+     */
+    public boolean isValid(String rawEmail) {
+        return parse(rawEmail).isPresent();
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
@@ -1,29 +1,44 @@
 package co.worklytics.psoxy.utils.email;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
 public class EmailAddressParser {
+
 
     public EmailAddressParser(EnumSet<EmailAddressCriteria> criteria) {
         this.criteria = criteria;
-        this.MAILBOX_PATTERN = Dragons.fromCriteria(criteria).MAILBOX_PATTERN;
+
+        // prob dumb level of indirection, but minimizes coupling to 'Dragons' class
+        Dragons dragon = Dragons.fromCriteria(criteria);
+        this.MAILBOX_PATTERN = dragon.MAILBOX_PATTERN;
+        this.MAILBOX_LIST_PATTERN = dragon.MAILBOX_LIST_PATTERN;
+        this.ADDRESS_PATTERN = dragon.ADDRESS_PATTERN;
+        this.GROUP_PREFIX_PATTERN = dragon.GROUP_PREFIX_PATTERN;
+
     }
 
     @Inject
     public EmailAddressParser() {
         this(EnumSet.of(
             EmailAddressCriteria.ALLOW_QUOTED_IDENTIFIERS,
-            EmailAddressCriteria.ALLOW_PARENS_IN_LOCALPART,
-            EmailAddressCriteria.ALLOW_DOMAIN_LITERALS // logic change from < 0.5.2; this will allow emails @ IP address to work; not restrict to domain strings - OK.
+            EmailAddressCriteria.ALLOW_PARENS_IN_LOCALPART
         ));
     }
 
     final EnumSet<EmailAddressCriteria> criteria;
     final Pattern MAILBOX_PATTERN;
+    final Pattern MAILBOX_LIST_PATTERN;
+    final Pattern ADDRESS_PATTERN;
+    final Pattern GROUP_PREFIX_PATTERN;
 
     /**
      * Parse an email address into its components. The email address must be valid according to the criteria.
@@ -34,7 +49,7 @@ public class EmailAddressParser {
         return Optional.ofNullable(rawEmail)
             .map(MAILBOX_PATTERN::matcher)
             .filter(Matcher::matches)
-            .map(m -> EmailAddressParserRoutines.matcherToStruture(m, criteria, true));
+            .map(m -> EmailAddressParserRoutines.matcherToStructure(m, criteria, true));
     }
 
     /**
@@ -47,5 +62,155 @@ public class EmailAddressParser {
      */
     public boolean isValid(String rawEmail) {
         return parse(rawEmail).isPresent();
+    }
+
+    /**
+     * Copyright (C) 2016 Benny Bottema and Casey Connor (benny@bennybottema.com and ahoy@caseyconnor.org)
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *
+     *         http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     *
+     * Tells us if a header line is valid, i.e. a 2822 address-list (which could only have one address in it, or might have more.) Applicable to To, Cc, Bcc,
+     * Reply-To, Resent-To, Resent-Cc, and Resent-Bcc headers <b>only</b>.
+     * <p>
+     * This method seems quick enough so far, but I'm not totally convinced it couldn't be slow given a complicated near-miss string. You may just want to call
+     * extractHeaderAddresses() instead, unless you must confirm that the format is perfect. I think that in 99.9999% of real-world cases this method will work
+     * fine and quickly enough. Let me know what your testing reveals.
+     *
+     * @see #isValidMailboxList(String, EnumSet)
+     */
+    public boolean isValidAddressList(String value) {
+        // creating the actual ADDRESS_LIST_PATTERN string proved too large for java, but
+        // fortunately we can use this alternative FSM to check. Since the address pattern
+        // is ugreedy, it will match all CFWS up to the comma which we can then require easily.
+        final Matcher m = ADDRESS_PATTERN.matcher(value);
+        final int max = value.length();
+        while (m.lookingAt()) {
+            if (m.end() == max) {
+                return true;
+            } else if (value.charAt(m.end()) == ',') {
+                m.region(m.end() + 1, max);
+            } else {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * Copyright (C) 2016 Benny Bottema and Casey Connor (benny@bennybottema.com and ahoy@caseyconnor.org)
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *
+     *         http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     *
+     */
+    public List<EmailAddress> parseEmailAddressesFromHeader(String value) {
+        if (StringUtils.isBlank(value)) {
+            return new ArrayList<>();
+        }
+        // optimize: separate method or boolean to indicate if group should be worried about at all
+        final Matcher m =MAILBOX_PATTERN.matcher(value);
+        final Matcher gp = GROUP_PREFIX_PATTERN.matcher(value);
+        final ArrayList<EmailAddress> result = new ArrayList<>(1);
+        final int max = value.length();
+        boolean group_start = false;
+        boolean group_end = false;
+        int next_comma_index;
+        int next_semicolon_index;
+        int just_after_group_end = -1;
+        // skip past any group prefixes, gobble addresses as usual in a list but
+        // skip past the terminating semicolon
+        while (true) {
+            if (group_end) {
+                next_comma_index = value.indexOf(',', just_after_group_end);
+                if (next_comma_index < 0) {
+                    break;
+                }
+                if (next_comma_index >= max - 1) {
+                    break;
+                }
+                gp.region(next_comma_index + 1, max);
+                m.region(next_comma_index + 1, max);
+                group_end = false;
+            }
+            if (value.charAt(m.regionStart()) == ';') {
+                group_start = false;
+                m.region(m.regionStart() + 1, max);
+                // could say >= max - 1 or even max - 3 or something, but just to be
+                // proper:
+                if (m.regionStart() >= max) {
+                    break;
+                }
+                gp.region(m.regionStart(), max);
+                group_end = true;
+                just_after_group_end = m.regionStart();
+            }
+            if (m.lookingAt()) {
+                group_start = false;
+                // must test m.end() == max first with early exit
+                if (m.end() == max || value.charAt(m.end()) == ',' ||
+                    (group_end = value.charAt(m.end()) == ';')) {
+                    EmailAddress cur_addr  = EmailAddressParserRoutines.matcherToStructure(m, criteria, true);
+                    if (cur_addr != null) {
+                        result.add(cur_addr);
+                    }
+                    if (m.end() < max - 1) {
+                        if (!group_end) {
+                            // skip the comma
+                            gp.region(m.end() + 1, max);
+                            m.region(m.end() + 1, max);
+                        } else {
+                            just_after_group_end = m.end() + 1;
+                        }
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            } else if (gp.lookingAt()) {
+                if (gp.end() < max) {
+                    // the colon is included in the gp match, so nothing to skip
+                    m.region(gp.end(), max);
+                    gp.region(gp.end(), max);
+                    group_start = true;
+                } else {
+                    break;
+                }
+            } else if (group_start) {
+                next_semicolon_index = value.indexOf(';', m.regionStart());
+                if (next_semicolon_index < 0) {
+                    break;
+                } else if (next_semicolon_index >= max - 1) {
+                    break;
+                }
+                m.region(next_semicolon_index + 1, max);
+                gp.region(next_semicolon_index + 1, max);
+                group_start = false;
+                group_end = true;
+                just_after_group_end = m.regionStart();
+            } else if (!group_end) {
+                break;
+            }
+        }
+        return result;
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
@@ -1,0 +1,34 @@
+package co.worklytics.psoxy.utils.email;
+
+import javax.inject.Inject;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EmailAddressParser {
+
+    public EmailAddressParser(EnumSet<EmailAddressCriteria> criteria) {
+        this.criteria = criteria;
+        this.MAILBOX_PATTERN = Dragons.fromCriteria(criteria).MAILBOX_PATTERN;
+    }
+
+    @Inject
+    public EmailAddressParser() {
+        this(EnumSet.of(
+            EmailAddressCriteria.ALLOW_QUOTED_IDENTIFIERS,
+            EmailAddressCriteria.ALLOW_PARENS_IN_LOCALPART,
+            EmailAddressCriteria.ALLOW_DOMAIN_LITERALS // logic change from < 0.5.2; this will allow emails @ IP address to work; not restrict to domain strings - OK.
+        ));
+    }
+
+    final EnumSet<EmailAddressCriteria> criteria;
+    final Pattern MAILBOX_PATTERN;
+
+    public Optional<EmailAddress> parse(String rawEmail) {
+        return Optional.ofNullable(rawEmail)
+            .map(MAILBOX_PATTERN::matcher)
+            .filter(Matcher::matches)
+            .map(m -> EmailAddressParserRoutines.matcherToStruture(m, criteria, true));
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParser.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.utils.email;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -11,8 +12,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
+/**
+ * our version of EmailAddressParser, which parses/validates email addresses as entity identifiers
+ *
+ * this is slightly different use-case than many parsers/validators, which actually want to ensure that an email address is *deliverable*,
+ *  for example when signing up a user or something.
+ *
+ *  We just care that it syntactically looks like an email address, with personal name / mailbox / domain parts
+ */
+@Singleton
 public class EmailAddressParser {
-
 
     public EmailAddressParser(EnumSet<EmailAddressCriteria> criteria) {
         this.criteria = criteria;
@@ -23,7 +32,6 @@ public class EmailAddressParser {
         this.MAILBOX_LIST_PATTERN = dragon.MAILBOX_LIST_PATTERN;
         this.ADDRESS_PATTERN = dragon.ADDRESS_PATTERN;
         this.GROUP_PREFIX_PATTERN = dragon.GROUP_PREFIX_PATTERN;
-
     }
 
     @Inject

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParserRoutines.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParserRoutines.java
@@ -30,6 +30,7 @@ package co.worklytics.psoxy.utils.email;
 import lombok.NonNull;
 
 import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
 import java.util.EnumSet;
 import java.util.regex.Matcher;
 
@@ -75,9 +76,9 @@ class EmailAddressParserRoutines {
      */
     @SuppressWarnings("WeakerAccess")
     @NonNull
-    public static EmailAddress matcherToStruture(@NonNull Matcher m,
-                                                 @NonNull EnumSet<EmailAddressCriteria> criteria,
-                                                 boolean extractCfwsPersonalNames) {
+    public static EmailAddress matcherToStructure(@NonNull Matcher m,
+                                                  @NonNull EnumSet<EmailAddressCriteria> criteria,
+                                                  boolean extractCfwsPersonalNames) {
         String current_localpart = null;
         String current_domainpart = null;
         String local_part_da;
@@ -250,4 +251,6 @@ class EmailAddressParserRoutines {
         boolean valueStartsEndsWithSAndE = str != null && str.length() >= 2 && str.startsWith(String.valueOf(s)) && str.endsWith(String.valueOf(e));
         return valueStartsEndsWithSAndE ? str.substring(1, str.length() - 1) : str;
     }
+
+
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParserRoutines.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/email/EmailAddressParserRoutines.java
@@ -1,0 +1,253 @@
+package co.worklytics.psoxy.utils.email;
+
+/**
+ * derived from org.hazlewood.connor.bottema.emailaddress.EmailAddressParser
+ *
+ * rather than re-write a bunch of that parsing logic, re-use that and wrap with more structured/modern interface (our EmailAddressParser class)
+ *
+ * particular motivation was avoiding javax / jakarta mail dependencies, which were problematic
+ *
+ */
+
+
+/*
+ * Copyright (C) 2016 Benny Bottema and Casey Connor (benny@bennybottema.com and ahoy@caseyconnor.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+import java.util.EnumSet;
+import java.util.regex.Matcher;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A utility class to parse, clean up, and extract email addresses from messages per RFC2822 syntax. Designed to integrate with Javamail (this class will
+ * require that you have a javamail mail.jar in your classpath), but you could easily change the existing methods around to not use Javamail at all. For
+ * example, if you're changing the code, see the difference between getInternetAddress and getDomain: the latter doesn't depend on any javamail code. This is
+ * all a by-product of what this class was written for, so feel free to modify it to suit your needs.
+ * <p>
+ * <strong>Regarding the parameter <code>extractCfwsPersonalNames</code>:</strong>
+ * <p>
+ * This criteria controls the behavior of getInternetAddress and extractHeaderAddresses. If included, it allows the
+ * not-totally-kosher-but-happens-in-the-real-world practice of:
+ * <p>
+ * &lt;bob@example.com&gt; (Bob Smith)
+ * <p>
+ * In this case, &quot;Bob Smith&quot; is not techinically the personal name, just a comment. If this is included, the methods will convert this into: Bob Smith
+ * &lt;bob@example.com&gt;
+ * <p>
+ * This also happens somewhat more often and appropriately with <code>mailer-daemon@blah.com (Mail Delivery System)</code>
+ * <p>
+ * If a personal name appears to the left and CFWS appears to the right of an address, the methods will favor the personal name to the left. If the methods need
+ * to use the CFWS following the address, they will take the first comment token they find.
+ * <p>
+ * e.g.:
+ * <p>
+ * <code>"bob smith" &lt;bob@example.com&gt; (Bobby)</code> yields personal name &quot;bob smith&quot;<br>
+ * <code>&lt;bob@example.com&gt; (Bobby)</code> yields personal name &quot;Bobby&quot;<br>
+ * <code>bob@example.com (Bobby)</code> yields personal name &quot;Bobby&quot;<br>
+ * <code>bob@example.com (Bob) (Smith)</code> yields personal name &quot;Bob&quot;
+ */
+class EmailAddressParserRoutines {
+
+    private EmailAddressParserRoutines() {}
+
+    /**
+     * See {@link #pullFromGroups(Matcher, EnumSet, boolean)}.
+     *
+     * @param extractCfwsPersonalNames See {@link EmailAddressParser}
+     * @return will not return null
+     */
+    @SuppressWarnings("WeakerAccess")
+    @NonNull
+    public static EmailAddress matcherToStruture(@NonNull Matcher m,
+                                                 @NonNull EnumSet<EmailAddressCriteria> criteria,
+                                                 boolean extractCfwsPersonalNames) {
+        String current_localpart = null;
+        String current_domainpart = null;
+        String local_part_da;
+        String local_part_qs = null;
+        String domain_part_da;
+        String domain_part_dl = null;
+        String personal_string = null;
+        // see the group-ID lists in the grammar comments
+        final boolean allowDomainLiterals = criteria.contains(EmailAddressCriteria.ALLOW_DOMAIN_LITERALS);
+        if (criteria.contains(EmailAddressCriteria.ALLOW_QUOTED_IDENTIFIERS)) {
+            if (allowDomainLiterals) {
+                // yes quoted identifiers, yes domain literals
+                if (m.group(1) != null) {
+                    // name-addr form
+                    local_part_da = m.group(5);
+                    if (local_part_da == null) {
+                        local_part_qs = m.group(6);
+                    }
+                    domain_part_da = m.group(7);
+                    if (domain_part_da == null) {
+                        domain_part_dl = m.group(8);
+                    }
+                    current_localpart = local_part_da == null ? local_part_qs : local_part_da;
+                    current_domainpart = domain_part_da == null ? domain_part_dl : domain_part_da;
+                    personal_string = m.group(2);
+                    if (personal_string == null && extractCfwsPersonalNames) {
+                        personal_string = m.group(9);
+                        personal_string = removeAnyBounding('(', ')', getFirstComment(personal_string, criteria));
+                    }
+                } else if (m.group(10) != null) {
+                    // addr-spec form
+                    local_part_da = m.group(12);
+                    if (local_part_da == null) {
+                        local_part_qs = m.group(13);
+                    }
+                    domain_part_da = m.group(14);
+                    if (domain_part_da == null) {
+                        domain_part_dl = m.group(15);
+                    }
+                    current_localpart = local_part_da == null ? local_part_qs : local_part_da;
+                    current_domainpart = domain_part_da == null ? domain_part_dl : domain_part_da;
+                    if (extractCfwsPersonalNames) {
+                        personal_string = m.group(16);
+                        personal_string = removeAnyBounding('(', ')', getFirstComment(personal_string, criteria));
+                    }
+                }
+            } else {
+                // yes quoted identifiers, no domain literals
+                if (m.group(1) != null) {
+                    // name-addr form
+                    local_part_da = m.group(5);
+                    if (local_part_da == null) {
+                        local_part_qs = m.group(6);
+                    }
+                    current_localpart = local_part_da == null ? local_part_qs : local_part_da;
+                    current_domainpart = m.group(7);
+                    personal_string = m.group(2);
+                    if (personal_string == null && extractCfwsPersonalNames) {
+                        personal_string = m.group(8);
+                        personal_string = removeAnyBounding('(', ')', getFirstComment(personal_string, criteria));
+                    }
+                } else if (m.group(9) != null) {
+                    // addr-spec form
+                    local_part_da = m.group(11);
+                    if (local_part_da == null) {
+                        local_part_qs = m.group(12);
+                    }
+                    current_localpart = local_part_da == null ? local_part_qs : local_part_da;
+                    current_domainpart = m.group(13);
+                    if (extractCfwsPersonalNames) {
+                        personal_string = m.group(14);
+                        personal_string = removeAnyBounding('(', ')', getFirstComment(personal_string, criteria));
+                    }
+                }
+            }
+        } else {
+            // no quoted identifiers, yes|no domain literals
+            local_part_da = m.group(3);
+            if (local_part_da == null) {
+                local_part_qs = m.group(4);
+            }
+            domain_part_da = m.group(5);
+            if (domain_part_da == null && allowDomainLiterals) {
+                domain_part_dl = m.group(6);
+            }
+            current_localpart = local_part_da == null ? local_part_qs : local_part_da;
+            current_domainpart = domain_part_da == null ? domain_part_dl : domain_part_da;
+            if (extractCfwsPersonalNames) {
+                personal_string = m.group((allowDomainLiterals ? 1 : 0) + 6);
+                personal_string = removeAnyBounding('(', ')', getFirstComment(personal_string, criteria));
+            }
+        }
+        if (current_localpart != null) {
+            current_localpart = current_localpart.trim();
+        }
+        if (current_domainpart != null) {
+            current_domainpart = current_domainpart.trim();
+        }
+        if (personal_string != null) {
+            // trim even though calling cPS which trims, because the latter may return
+            // the same thing back without trimming
+            personal_string = personal_string.trim();
+            personal_string = cleanupPersonalString(personal_string, criteria);
+        }
+        // remove any unnecessary bounding quotes from the localpart:
+        String test_addr = removeAnyBounding('"', '"', current_localpart) +
+            "@" + current_domainpart;
+        if (Dragons.fromCriteria(criteria).ADDR_SPEC_PATTERN.matcher(test_addr).matches()) {
+            current_localpart = removeAnyBounding('"', '"', current_localpart);
+        }
+        return EmailAddress.builder()
+            .personalName(personal_string)
+            .localPart(current_localpart)
+            .domain(current_domainpart)
+            .build();
+    }
+
+    /**
+     * Given a string, extract the first matched comment token as defined in 2822, trimmed; return null on all errors or non-findings
+     * <p>
+     * This is probably not super-useful. Included just in case.
+     * <p>
+     * Note for future improvement: if COMMENT_PATTERN could handle nested comments, then this should be able to as well, but if this method were to be used to
+     * find the CFWS personal name (see boolean option) then such a nested comment would probably not be the one you were looking for?
+     */
+    @SuppressWarnings("WeakerAccess")
+    @Nullable
+    public static String getFirstComment(@Nullable String text, @NonNull EnumSet<EmailAddressCriteria> criteria) {
+        if (text == null) {
+            return null; // important
+        }
+        Matcher m = Dragons.fromCriteria(criteria).COMMENT_PATTERN.matcher(text);
+        if (!m.find()) {
+            return null;
+        }
+        return m.group().trim(); // trim important
+    }
+
+    /**
+     * Given a string, if the string is a quoted string (without CFWS around it, although it will be trimmed) then remove the bounding quotations and then
+     * unescape it. Useful when passing simple named address personal names into InternetAddress since InternetAddress always quotes the entire phrase token
+     * into one mass; in this simple (and common) case, we can strip off the quotes and de-escape, and passing to javamail will result in a cleaner quote-free
+     * result (if there are no embedded escaped characters) or the proper one-level-quoting result (if there are embedded escaped characters). If the string is
+     * anything else, this just returns it unadulterated.
+     */
+    @SuppressWarnings("WeakerAccess")
+    @Nullable
+    public static String cleanupPersonalString(@Nullable String string, @NonNull EnumSet<EmailAddressCriteria> criteria) {
+        if (string == null) {
+            return null;
+        }
+        String text = string.trim();
+        final Dragons dragons = Dragons.fromCriteria(criteria);
+        Matcher m = dragons.QUOTED_STRING_WO_CFWS_PATTERN.matcher(text);
+        if (!m.matches()) {
+            return text;
+        }
+        text = requireNonNull(removeAnyBounding('"', '"', m.group()));
+        text = dragons.ESCAPED_BSLASH_PATTERN.matcher(text).replaceAll("\\\\");
+        text = dragons.ESCAPED_QUOTE_PATTERN.matcher(text).replaceAll("\"");
+        return text.trim();
+    }
+
+    /**
+     * If the string starts and ends with s and e, remove them, otherwise return the string as it was passed in.
+     */
+    @SuppressWarnings("WeakerAccess")
+    @Nullable
+    public static String removeAnyBounding(char s, char e, @Nullable String str) {
+        boolean valueStartsEndsWithSAndE = str != null && str.length() >= 2 && str.startsWith(String.valueOf(s)) && str.endsWith(String.valueOf(e));
+        return valueStartsEndsWithSAndE ? str.substring(1, str.length() - 1) : str;
+    }
+}

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/generics/CalendarTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/generics/CalendarTest.java
@@ -1,6 +1,7 @@
 package co.worklytics.psoxy.rules.generics;
 
 import co.worklytics.psoxy.impl.RESTApiSanitizerImpl;
+import co.worklytics.psoxy.utils.email.EmailAddressParser;
 import com.jayway.jsonpath.Configuration;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CalendarTest {
 
-    RESTApiSanitizerImpl restApiSanitizer = new RESTApiSanitizerImpl(null, null);
+    RESTApiSanitizerImpl restApiSanitizer = new RESTApiSanitizerImpl(null, null, new EmailAddressParser());
 
     @CsvSource(value = {
         "OOO,OOO",

--- a/java/core/src/test/java/co/worklytics/psoxy/utils/email/EmailAddressParserTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/utils/email/EmailAddressParserTest.java
@@ -1,0 +1,81 @@
+package co.worklytics.psoxy.utils.email;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailAddressParserTest {
+
+    EmailAddressParser emailAddressParser = new EmailAddressParser();
+
+    @CsvSource({
+        "alice@worklytics.co,worklytics.co",
+        "\"Alice Smith\" <alice@worklytics.co>,worklytics.co",
+        ",",
+        "   ,",
+        "bob@example.com,example.com",
+        "\"Bob Brown\" <bob.brown@example.com>,example.com",
+        "bob.brown+sales@example.co.uk,example.co.uk",
+        "charlie@example.io,example.io",
+        "\"Charlie Chaplin\" <charlie.chaplin+test@example.io>,example.io",
+        "<dave@example.com>,example.com",
+        "\"Eve Adams\" <eve.adams@subdomain.worklytics.co>,subdomain.worklytics.co",
+        "\"Frank\" <frank@example.com>,example.com",
+        "frank@example.com,example.com",
+        "\"George R.R. Martin\" <george.r.r.martin@example.com>,example.com",
+        "invalid-email,",
+        "\"\",",
+        "<>,",
+        "\"Hannah Montana\" <hannah.montana+newsletter@worklytics.co>,worklytics.co",
+        "ian@worklytics.co,worklytics.co",
+        "jack.o'neill@example.com,example.com",
+        "\"Kate\" <kate@example.com>,example.com",
+        "\"Mary Jane\" <mary_jane@worklytics.co>,worklytics.co",
+        "nancy+hr@company.org,company.org",
+        "\"Olivia Pope\" <olivia@whitehouse.gov>,whitehouse.gov",
+        "<peter.parker@example.com>,example.com",
+        "\"Rachel Green\" <rachel.green@friends.example.com>,friends.example.com",
+        "\"\",",
+    })
+    @ParameterizedTest
+    void getDomain(String original, String expected) {
+        assertEquals(expected, emailAddressParser.parse(original).map(EmailAddress::getDomain).orElse(null));
+    }
+
+    @CsvSource({
+        "alice@worklytics.co,alice",
+        "\"Alice Smith\" <alice@worklytics.co>,alice",
+        ",",
+        "   ,",
+        "bob@example.com,bob",
+        "\"Bob Brown\" <bob.brown@example.com>,bob.brown",
+        "bob.brown+sales@example.co.uk,bob.brown+sales",
+        "charlie@example.io,charlie",
+        "\"Charlie Chaplin\" <charlie.chaplin+test@example.io>,charlie.chaplin+test",
+        "<dave@example.com>,dave",
+        "\"Eve Adams\" <eve.adams@subdomain.worklytics.co>,eve.adams",
+        "\"Frank\" <frank@example.com>,frank",
+        "frank@example.com,frank",
+        "\"George R.R. Martin\" <george.r.r.martin@example.com>,george.r.r.martin",
+        "\"invalid-email\",",
+        "\"\",",
+        "\"<>\",",
+        "\"Hannah Montana\" <hannah.montana+newsletter@worklytics.co>,hannah.montana+newsletter",
+        "ian@worklytics.co,ian",
+        "jack.o'neill@example.com,jack.o'neill",
+        "\"Kate\" <kate@example.com>,kate",
+        "luke.skywalker@[192.168.1.1],luke.skywalker",
+        "\"Mary Jane\" <mary_jane@worklytics.co>,mary_jane",
+        "nancy+hr@company.org,nancy+hr",
+        "\"Olivia Pope\" <olivia@whitehouse.gov>,olivia",
+        "<peter.parker@example.com>,peter.parker",
+        "\"Rachel Green\" <rachel.green@friends.example.com>,rachel.green",
+        "\"\",",
+        "user@[IPv6:2001:db8::1],user"
+    })
+    @ParameterizedTest
+    void getLocalPart(String original, String expected) {
+        assertEquals(expected, emailAddressParser.parse(original).map(EmailAddress::getLocalPart).orElse(null));
+    }
+}


### PR DESCRIPTION
### Features
  - replace email parser/validator lib with combination of their stuff (apache 2 license) copied over and our own cleaner/simpler wrappers

why? they have a weird jakarta/javax dep that's problematic and unhelpful.  In particular, conflicts with some deps in core worklytics codebase, requiring exclusion stuff; and generally messy to deal with

### Change implications

- dependencies added/changed? **yes**
  - The dependency on `EmailParser` has been removed. Please check the project's dependency list to ensure compatibility with the new validation changes.
- something important to note in future release notes? **no**
- breaking changes? **shouldn't be; certainly risk of minor changes to email parsing/validation**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209929312359673