### PR TITLE
fix gcp gen2 invoke perms

### DIFF
--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -180,7 +180,10 @@ resource "google_cloudfunctions2_function" "function" {
   event_trigger {
     event_type = "google.cloud.storage.object.v1.finalized"
 
-    # retry_policy = "RETRY_POLICY_RETRY" # what do we want??
+    # no retries for now, consistent with legacy behavior
+    # can configure this to retry on errors, and will do so with exponential backoff. but concern is that
+    # we have no control of that - eg no way to cap it at 3 or 5 retries, as far as can see atm
+    retry_policy = "RETRY_POLICY_DO_NOT_RETRY"
 
     event_filters {
       attribute = "bucket"

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -111,7 +111,7 @@ resource "google_cloudfunctions2_function_iam_member" "invokers" {
 
   cloud_function = google_cloudfunctions2_function.function.id
   member         = "serviceAccount:${each.value}"
-  role           = "roles/cloudfunctions.invoker"
+  role           = "roles/run.invoker"
 }
 
 resource "google_cloudfunctions2_function_iam_member" "testers" {
@@ -119,7 +119,7 @@ resource "google_cloudfunctions2_function_iam_member" "testers" {
 
   cloud_function = google_cloudfunctions2_function.function.id
   member         = each.value
-  role           = "roles/cloudfunctions.invoker"
+  role           = "roles/run.invoker"
 }
 
 locals {

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -106,11 +106,14 @@ resource "google_cloudfunctions2_function" "function" {
   ]
 }
 
-resource "google_cloudfunctions2_function_iam_binding" "invokers" {
-  project        = google_cloudfunctions2_function.function.project
-  location       = google_cloudfunctions2_function.function.location
-  cloud_function = google_cloudfunctions2_function.function.name
-  role           = "roles/run.invoker"
+# bizarrely, `google_cloudfunctions2_function_iam_binding` doesn't work for this; wtf?
+resource "google_cloud_run_service_iam_binding" "invokers" {
+  project  = google_cloudfunctions2_function.function.project
+  location = google_cloudfunctions2_function.function.location
+  service  = google_cloudfunctions2_function.function.name
+
+  role = "roles/run.invoker"
+
   members = concat(
     [for email in var.invoker_sa_emails : "serviceAccount:${email}"],
     var.gcp_principals_authorized_to_test

--- a/infra/modules/gcp-psoxy-rest/main.tf
+++ b/infra/modules/gcp-psoxy-rest/main.tf
@@ -106,20 +106,15 @@ resource "google_cloudfunctions2_function" "function" {
   ]
 }
 
-resource "google_cloudfunctions2_function_iam_member" "invokers" {
-  for_each = toset(var.invoker_sa_emails)
-
-  cloud_function = google_cloudfunctions2_function.function.id
-  member         = "serviceAccount:${each.value}"
+resource "google_cloudfunctions2_function_iam_binding" "invokers" {
+  project        = google_cloudfunctions2_function.function.project
+  location       = google_cloudfunctions2_function.function.location
+  cloud_function = google_cloudfunctions2_function.function.name
   role           = "roles/run.invoker"
-}
-
-resource "google_cloudfunctions2_function_iam_member" "testers" {
-  for_each = toset(var.gcp_principals_authorized_to_test)
-
-  cloud_function = google_cloudfunctions2_function.function.id
-  member         = each.value
-  role           = "roles/run.invoker"
+  members = concat(
+    [for email in var.invoker_sa_emails : "serviceAccount:${email}"],
+    var.gcp_principals_authorized_to_test
+  )
 }
 
 locals {


### PR DESCRIPTION


### Fixes
 - IAM role required for invocation of gen2 is different than gen1; test scripts likely working bc devs 

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210084585333421