### PR TITLE
MSFT Copilot bot pass-through

### DIFF
--- a/docs/sources/microsoft-365/msft-copilot/example-api-responses/sanitized_no-userIds/response_beta.json
+++ b/docs/sources/microsoft-365/msft-copilot/example-api-responses/sanitized_no-userIds/response_beta.json
@@ -16,7 +16,7 @@
         "device":null,
         "user":null,
         "application":{
-          "id":"{\"hash\":\"PtknPBuvPc6KzesKdOr8My9yeOsKY_7nWRbuJsIn2CU\"}",
+          "id":"fb8d773d-7ef8-4ec0-a117-179f88add510",
           "applicationIdentityType":"bot"
         }
       },

--- a/docs/sources/microsoft-365/msft-copilot/example-api-responses/sanitized_no-userIds/response_with_team_meeting_beta.json
+++ b/docs/sources/microsoft-365/msft-copilot/example-api-responses/sanitized_no-userIds/response_with_team_meeting_beta.json
@@ -20,7 +20,7 @@
         "device":null,
         "user":null,
         "application":{
-          "id":"{\"hash\":\"PtknPBuvPc6KzesKdOr8My9yeOsKY_7nWRbuJsIn2CU\"}",
+          "id":"fb8d773d-7ef8-4ec0-a117-179f88add510",
           "applicationIdentityType":"bot"
         }
       },

--- a/docs/sources/microsoft-365/msft-copilot/msft-copilot_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-copilot/msft-copilot_no-userIds.yaml
@@ -17,8 +17,8 @@ endpoints:
         regex: "^https://graph.microsoft.com/beta/copilot/users/([a-zA-Z0-9_-]+)/.*$"
       - !<pseudonymize>
         jsonPaths:
-          - "$..from..id"
-          - "$..mentions[*]..id"
+          - "$..from..[?(@.applicationIdentityType != \"bot\")].id"
+          - "$..mentions[*][?(@.applicationIdentityType != \"bot\")].id"
         encoding: "JSON"
       - !<textDigest>
         jsonPaths:

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -753,8 +753,8 @@ public class PrebuiltSanitizerRules {
                     .regex("^https://graph.microsoft.com/beta/copilot/users/([a-zA-Z0-9_-]+)/.*$")
                     .build(),
                 Transform.Pseudonymize.builder()
-                    .jsonPath("$..from..id")
-                    .jsonPath("$..mentions[*]..id")
+                    .jsonPath("$..from..[?(@.applicationIdentityType != \"bot\")].id")
+                    .jsonPath("$..mentions[*][?(@.applicationIdentityType != \"bot\")].id")
                     .build(),
                 MS_COPILOT_TEXT_DIGEST_ATTACHMENT,
                 MS_COPILOT_TEXT_DIGEST_BODY,

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/CopilotNoUserIdsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/CopilotNoUserIdsTests.java
@@ -53,7 +53,8 @@ public class CopilotNoUserIdsTests extends JavaRulesTestBaseCase {
 
         assertPseudonymized(sanitized, "4db02e4b-d144-400e-b194-53253a34c5be");
 
-        // Bot is not sanitized
+        // Bot IDs are not sanitized because they are not considered sensitive user data 
+        // and are required for system functionality, such as identifying automated processes.
         assertNotSanitized(sanitized, "fb8d773d-7ef8-4ec0-a117-179f88add510");
 
         assertReversibleUrlTokenized(sanitized, List.of("19:YzBP1kUdkNjFtJnketPYT8kQdQ3A08Y51rDTxE_ENIk1@thread.v2")

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/CopilotNoUserIdsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/CopilotNoUserIdsTests.java
@@ -51,8 +51,10 @@ public class CopilotNoUserIdsTests extends JavaRulesTestBaseCase {
                 "What should be on my radar from emails last week?"
         );
 
-        assertPseudonymized(sanitized, "4db02e4b-d144-400e-b194-53253a34c5be",
-            "fb8d773d-7ef8-4ec0-a117-179f88add510");
+        assertPseudonymized(sanitized, "4db02e4b-d144-400e-b194-53253a34c5be");
+
+        // Bot is not sanitized
+        assertNotSanitized(sanitized, "fb8d773d-7ef8-4ec0-a117-179f88add510");
 
         assertReversibleUrlTokenized(sanitized, List.of("19:YzBP1kUdkNjFtJnketPYT8kQdQ3A08Y51rDTxE_ENIk1@thread.v2")
         );


### PR DESCRIPTION
Supporting passing-through the id of the application when is a bot for MSFT Copilot.

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Pass-through when bot is a user](https://app.asana.com/0/1210085394292999/1210137761207242)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
