### PR TITLE
Slack AI Snapshot docs usage

### DIFF
--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -4,42 +4,43 @@ This section describes many of the pre-configured data sources that can be conne
 via Psoxy.
 
 The table below enumerates the available connectors, provided via the `worklytics-connector-specs`
-Terraform module (see [infra/modules/worklytics-connector-specs](infra/modules/worklytics-connector-specs)).
+Terraform module (
+see [infra/modules/worklytics-connector-specs](infra/modules/worklytics-connector-specs)).
 
 To add a source, add its Connector ID to the `enabled_connectors` list in your `terraform.tfvars`
 file.
 
-| Connector ID               | Data Source                          | Type | Availability |
-|----------------------------|--------------------------------------|------|--------------|
-| `asana`                    | Asana                                | API  | GA           |
-| `azure-ad`                 | Azure Active Directory               | API  | DEPRECATED   |
-| `badge`                    | Badge                                | Bulk | GA           |
-| `dropbox-business`         | Dropbox Business                     | API  | DEPRECATED   |
-| `gcal`                     | Google Calendar                      | API  | GA           |
-| `gdrive`                   | Google Drive                         | API  | GA           |
-| `gdirectory`               | Google Directory                     | API  | GA           |
-| `gemini-usage`            | Gemini Usage                         | Bulk | BETA         |
-| `msft-copilot`            | Microsot 365 Copilot                 | API | ALPHA        |
-| `github`                   | GitHub                               | API  | GA           |
-| `github-copilot`           | GitHub                               | API  | ALPHA        |
-| `github-enterprise-server` | GitHub Enterprise Server             | API  | GA           |
-| `github-non-enterprise`    | GitHub Non-Enterprise                | API  | GA           |
-| `gmail`                    | Gmail                                | API  | GA           |
-| `google-chat`              | Google Chat                          | API  | GA           |
-| `google-meet`              | Google Meet                          | API  | GA           |
-| `hris`                     | HR Information System (eg, Workday)  | Bulk | GA           |
-| `jira-cloud`               | Jira Cloud                           | API  | GA           |
-| `jira-server`              | Jira Server                          | API  | GA           |
-| `outlook-cal`              | Outlook Calendar                     | API  | GA           |
-| `outlook-mail`             | Outlook Mail                         | API  | GA           |
-| `msft-teams`               | Microsoft Teams                      | API  | BETA         |
-| `msft-entra-id`            | Microsoft Entra ID                   | API  | GA           |
-| `qualtrics`                | Qualtrics (survey)                   | API  | GA           |
-| `salesforce`               | Salesforce                           | API  | GA           |
-| `slack-discovery-api`      | Slack Discovery API                  | API  | GA           |
-| `slack-ai-snapshot`      | Slack AI Snapshot                    | API  | ALPHA        |
-| `survey`                   | Survey                               | Bulk | GA           |
-| `zoom`                     | Zoom                                 | API  | GA           |
+| Connector ID               | Data Source                         | Type | Availability |
+|----------------------------|-------------------------------------|------|--------------|
+| `asana`                    | Asana                               | API  | GA           |
+| `azure-ad`                 | Azure Active Directory              | API  | DEPRECATED   |
+| `badge`                    | Badge                               | Bulk | GA           |
+| `dropbox-business`         | Dropbox Business                    | API  | DEPRECATED   |
+| `gcal`                     | Google Calendar                     | API  | GA           |
+| `gdrive`                   | Google Drive                        | API  | GA           |
+| `gdirectory`               | Google Directory                    | API  | GA           |
+| `gemini-usage`             | Gemini Usage                        | Bulk | BETA         |
+| `msft-copilot`             | Microsot 365 Copilot                | API  | ALPHA        |
+| `github`                   | GitHub                              | API  | GA           |
+| `github-copilot`           | GitHub                              | API  | ALPHA        |
+| `github-enterprise-server` | GitHub Enterprise Server            | API  | GA           |
+| `github-non-enterprise`    | GitHub Non-Enterprise               | API  | GA           |
+| `gmail`                    | Gmail                               | API  | GA           |
+| `google-chat`              | Google Chat                         | API  | GA           |
+| `google-meet`              | Google Meet                         | API  | GA           |
+| `hris`                     | HR Information System (eg, Workday) | Bulk | GA           |
+| `jira-cloud`               | Jira Cloud                          | API  | GA           |
+| `jira-server`              | Jira Server                         | API  | GA           |
+| `outlook-cal`              | Outlook Calendar                    | API  | GA           |
+| `outlook-mail`             | Outlook Mail                        | API  | GA           |
+| `msft-teams`               | Microsoft Teams                     | API  | BETA         |
+| `msft-entra-id`            | Microsoft Entra ID                  | API  | GA           |
+| `qualtrics`                | Qualtrics (survey)                  | API  | GA           |
+| `salesforce`               | Salesforce                          | API  | GA           |
+| `slack-discovery-api`      | Slack Discovery API                 | API  | GA           |
+| `slack-ai-snapshot`        | Slack AI Snapshot                   | Bulk | ALPHA        |
+| `survey`                   | Survey                              | Bulk | GA           |
+| `zoom`                     | Zoom                                | API  | GA           |
 
 From v0.4.58, you can confirm the availability of a connector by running the following command from
 the root of one of our examples:
@@ -48,7 +49,9 @@ the root of one of our examples:
 ./available-connectors
 ```
 
-If your using v0.4.58+ of our terraform modules, but don't have the above script in your example, try
+If your using v0.4.58+ of our terraform modules, but don't have the above script in your example,
+try
+
 ```shell
 cp .terraform/modules/psoxy/tools/available-connectors.sh available-connectors
 chmod +x available-connectors

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -37,6 +37,7 @@ file.
 | `qualtrics`                | Qualtrics (survey)                   | API  | GA           |
 | `salesforce`               | Salesforce                           | API  | GA           |
 | `slack-discovery-api`      | Slack Discovery API                  | API  | GA           |
+| `slack-ai-snapshot`      | Slack AI Snapshot                    | API  | ALPHA        |
 | `survey`                   | Survey                               | Bulk | GA           |
 | `zoom`                     | Zoom                                 | API  | GA           |
 

--- a/docs/sources/slack/README.md
+++ b/docs/sources/slack/README.md
@@ -75,6 +75,7 @@ Use this steps if you intend to install in just one workspace within your org.
 
 ## Bulk Data Flow
 
+### Slack Discovery
 **_beta_** As an alternative to connecting Worklytics to the Slack Discovery API via the proxy, it
 is possible to use the bulk-mode of the proxy to sanitize an export of Slack Discovery data and
 ingest the resulting sanitized data to Worklytics. Example data of this is given in the
@@ -85,3 +86,30 @@ This data can be processing using custom multi-file type rules in the proxy, of 
 
 For clarity, example files are NOT compressed, so don't have `.gz` extension; but rules expect
 `.gz`.
+
+### Slack AI Snapshot
+
+Psoxy can pseudonymize Slack AI Snapshot data for ingestion into Worklytics.
+
+See [https://docs.worklytics.co/knowledge-base/connectors/bulk-data/slack-ai-snapshot](https://docs.worklytics.co/knowledge-base/connectors/bulk-data/slack-ai-snapshot)
+
+The default proxy rules for `slack-ai-snapshot` will pseudonymize `user_email`. If your data set does not match
+the schema expected by Worklytics, you can adapt it by specifying some custom transforms within
+the proxy itself:
+
+```hcl
+custom_bulk_connector_rules = {
+   "slack-ai-bulk" = {
+        source_kind               = "slack-ai",
+        worklytics_connector_id   = "bulk-import-psoxy"
+        worklytics_connector_name = "Bulk Import - Psoxy"
+        display_name              = "Slack Bulk"
+        rules = {
+          columnsToPseudonymize = ["user_email"]
+          }
+        settings_to_provide = {
+           "Parser" = "slack-ai-bulk"
+          }
+  }
+}
+```


### PR DESCRIPTION
Adding docs about how to setup bulk connector for Slack AI Snapshot data. 

Related to https://github.com/Worklytics/evalengin/pull/7505

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Prepare bulk proxy](https://app.asana.com/0/0/1210126519152708)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
