### PR TITLE
fix node build

### DIFF
--- a/.github/workflows/ci-tools.yaml
+++ b/.github/workflows/ci-tools.yaml
@@ -14,9 +14,8 @@ jobs:
         # 16 is min version recommended to users; but unmaintained since 2023-10
         # 18 released 2022-04-19 - maintained until June 2025
         # 20 maintained until June 2026
-        # 21 released Oct 2023; superseded in May 2024
-        # latest is the 22 as of May 2024; 23 coming in Oct 2024
-        node-version: [ 18, 20, 21, latest]
+        # latest is the 24 as of May 2025; 23 maintained until June 2025 or so
+        node-version: [ 18, 20, 22, 23, latest ]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/tools/psoxy-test/package-lock.json
+++ b/tools/psoxy-test/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-cloudwatch-logs": "^3.350.0",
         "@aws-sdk/client-s3": "^3.350.0",
         "@aws-sdk/credential-providers": "^3.351.0",
-        "@google-cloud/logging": "^11.0.0",
+        "@google-cloud/logging": "^11.2.0",
         "@google-cloud/storage": "^7.12.1",
         "@stdlib/assert-is-gzip-buffer": "^0.1.1",
         "aws4": "^1.11.0",
@@ -1086,14 +1086,16 @@
       }
     },
     "node_modules/@google-cloud/logging": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.0.0.tgz",
-      "integrity": "sha512-uQeReiVICoV5yt9J/cczNxHxqzTkLLG7yGHXCMAk/wQNVZGevT4Bi7CBWpt0aXxm044a76Aj6V08cCAlBj7UZw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.0.tgz",
+      "integrity": "sha512-Ma94jvuoMpbgNniwtelOt8w82hxK62FuOXZonEv0Hyk3B+/YVuLG/SWNyY9yMso/RXnPEc1fP2qo9kDrjf/b2w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/common": "^5.0.0",
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
         "@google-cloud/promisify": "^4.0.0",
+        "@opentelemetry/api": "^1.7.0",
         "arrify": "^2.0.1",
         "dot-prop": "^6.0.0",
         "eventid": "^2.0.0",
@@ -1246,6 +1248,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6306,14 +6317,15 @@
       }
     },
     "@google-cloud/logging": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.0.0.tgz",
-      "integrity": "sha512-uQeReiVICoV5yt9J/cczNxHxqzTkLLG7yGHXCMAk/wQNVZGevT4Bi7CBWpt0aXxm044a76Aj6V08cCAlBj7UZw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.0.tgz",
+      "integrity": "sha512-Ma94jvuoMpbgNniwtelOt8w82hxK62FuOXZonEv0Hyk3B+/YVuLG/SWNyY9yMso/RXnPEc1fP2qo9kDrjf/b2w==",
       "requires": {
         "@google-cloud/common": "^5.0.0",
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
         "@google-cloud/promisify": "^4.0.0",
+        "@opentelemetry/api": "^1.7.0",
         "arrify": "^2.0.1",
         "dot-prop": "^6.0.0",
         "eventid": "^2.0.0",
@@ -6425,6 +6437,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.350.0",
     "@aws-sdk/client-s3": "^3.350.0",
     "@aws-sdk/credential-providers": "^3.351.0",
-    "@google-cloud/logging": "^11.0.0",
+    "@google-cloud/logging": "^11.2.0",
     "@google-cloud/storage": "^7.12.1",
     "@stdlib/assert-is-gzip-buffer": "^0.1.1",
     "aws4": "^1.11.0",


### PR DESCRIPTION
### Fixes
 - try to fix nodejs24 incompatibility

### Change implications

 - dependencies added/changed? **yes**
   - The version of Google Cloud Logging has been updated to address compatibility issues with Node.js 24.
 - something important to note in future release notes?
   - No additional notes are necessary.
 - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
   - There are no breaking changes; this is a straightforward dependency bump to fix compatibility issues.
