### PR TITLE
Fix slack loader

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/rules/Rules2.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/Rules2.java
@@ -117,22 +117,4 @@ public class Rules2 implements RESTRules {
             .build();
         return clone;
     }
-
-    //TODO: fix YAML serialization with something like
-    // https://stackoverflow.com/questions/55878770/how-to-use-jsonsubtypes-for-polymorphic-type-handling-with-jackson-yaml-mapper
-
-    static ObjectMapper mapper = new YAMLMapper();
-
-    public static synchronized Rules2 load(String path) {
-        try {
-            URL url = PrebuiltSanitizerRules.class.getClassLoader().getResource(path);
-            if (url == null) {
-                throw new IllegalArgumentException("No such file: " + path);
-            }
-            return mapper.readerFor(Rules2.class).readValue(Files.readAllBytes(Paths.get(url.toURI())));
-        } catch (IOException | URISyntaxException e) {
-            throw new Error(e);
-        }
-    }
-
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/slack/PrebuiltSanitizerRules.java
@@ -7,6 +7,7 @@ import co.worklytics.psoxy.rules.Rules2;
 import com.avaulta.gateway.rules.JsonSchemaFilter;
 import com.avaulta.gateway.rules.transforms.Transform;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
@@ -22,10 +23,23 @@ import java.util.Map;
 public class PrebuiltSanitizerRules {
 
 
-    static final RESTRules SLACK = Rules2.load("sources/slack/discovery.yaml");
+    static final YAMLMapper YAML_MAPPER = new YAMLMapper();
+
+    static final RESTRules SLACK;
+
+    static {
+        try {
+            SLACK = YAML_MAPPER.readValue(
+                co.worklytics.psoxy.rules.google.PrebuiltSanitizerRules.class.getClassLoader().getResourceAsStream("sources/slack/discovery.yaml"),
+                Rules2.class
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     static public final Map<String, RESTRules> SLACK_DEFAULT_RULES_MAP =
-            ImmutableMap.<String, RESTRules>builder()
-                    .put("slack", SLACK)
-                    .build();
+        ImmutableMap.<String, RESTRules>builder()
+            .put("slack", SLACK)
+            .build();
 }


### PR DESCRIPTION
Slack was being loaded as a file path and not as a resource

### Fixes
[500s in gcp-hosted asana, others](https://app.asana.com/1/27145998307022/project/1201039336231823/task/1210246445501431)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
