### PR TITLE
more robust bulk file processing

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/StorageEventResponse.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/StorageEventResponse.java
@@ -27,4 +27,10 @@ public class StorageEventResponse {
      */
     @NonNull
     String destinationObjectPath;
+
+    /**
+     * how many records errored during processing
+     */
+    @Builder.Default
+    Integer errorCount = 0;
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/BulkDataSanitizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/BulkDataSanitizer.java
@@ -20,9 +20,10 @@ public interface BulkDataSanitizer {
      *                      implicit in records
      * @param writer        The stream writer to which sanitized content should be written.
      * @param pseudonymizer The pseudonymizer to use
-     * @throws IOException  IO problem reading or writing
+     * @return records in data which could not be processed due to errors
+     * @throws IOException IO problem reading or writing
      */
-    void sanitize(BufferedReader reader,
-                  Writer writer,
-                  Pseudonymizer pseudonymizer) throws IOException;
+    int sanitize(BufferedReader reader,
+                 Writer writer,
+                 Pseudonymizer pseudonymizer) throws IOException;
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/BulkDataSanitizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/BulkDataSanitizer.java
@@ -2,8 +2,8 @@ package co.worklytics.psoxy.storage;
 
 import co.worklytics.psoxy.Pseudonymizer;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.io.Writer;
 
 /**
@@ -22,7 +22,7 @@ public interface BulkDataSanitizer {
      * @param pseudonymizer The pseudonymizer to use
      * @throws IOException  IO problem reading or writing
      */
-    void sanitize(Reader reader,
+    void sanitize(BufferedReader reader,
                   Writer writer,
                   Pseudonymizer pseudonymizer) throws IOException;
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -379,7 +379,7 @@ public class StorageHandler {
 
         try (
             InputStream inputStream = readInputStream(request, bufferSize, inputStreamSupplier);
-            Reader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8), bufferSize);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8), bufferSize);
             OutputStream outputStream = writeOutputStream(request, bufferSize, outputStreamSupplier);
             OutputStreamWriter writer = new OutputStreamWriter(outputStream)
         ) {

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImpl.java
@@ -311,9 +311,8 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
      * @param columnTransformsToApply to apply to each column in the record
      * @param recordsToProcess to process; should be a CSVParser with headers
      * @param outputBuffer to write the processed records to
-     * @return set of transforms that were defined, but the applicable column was NOT found in the records
      */
-    Set<String> processRecords(
+    void processRecords(
                                 List<String> columnNamesForOutput,
                                 Map<String, Pair<String, List<Function<String, Optional<String>>>>> columnTransformsToApply,
                                 CSVParser recordsToProcess,
@@ -370,7 +369,6 @@ public class ColumnarBulkDataSanitizerImpl implements BulkDataSanitizer {
                 log.log(Level.WARNING, "Failed to process record", e);
             }
         }
-        return transformsWithoutMappings;
     }
 
 

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/impl/RecordBulkDataSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/impl/RecordBulkDataSanitizerImpl.java
@@ -58,7 +58,7 @@ public class RecordBulkDataSanitizerImpl implements BulkDataSanitizer {
 
 
     @Override
-    public void sanitize(@NonNull Reader reader,
+    public void sanitize(BufferedReader reader,
                          @NonNull Writer writer,
                          @NonNull Pseudonymizer pseudonymizer) throws IOException {
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.File;
-import java.io.FileReader;
-import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -124,14 +124,15 @@ public class BulkDataSanitizerImplTest {
             .columnToPseudonymize("EMPLOYEE_EMAIL")
             .build();
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
         columnarFileSanitizerImpl.setRules(rules);
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
         }
     }
+
+
 
     @ParameterizedTest
     @ValueSource(strings = {"EMPLOYEE_EMAIL", "employee_email", "Employee_Email"})
@@ -148,9 +149,8 @@ public class BulkDataSanitizerImplTest {
             .columnToPseudonymizeIfPresent("EXTRA_EMAIL") //unlike 'columnToPseudonymize', this doesn't throw error
             .build();
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
         columnarFileSanitizerImpl.setRules(rules);
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -171,10 +171,9 @@ public class BulkDataSanitizerImplTest {
             .columnToRedact("DEPARTMENT")
             .build();
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
         columnarFileSanitizerImpl.setRules(rules);
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -191,10 +190,9 @@ public class BulkDataSanitizerImplTest {
             .columnToPseudonymize("EMPLOYEE_ID")
             .columnToPseudonymize("AN EMAIL").build();
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example-headers-w-spaces.csv").getFile());
         columnarFileSanitizerImpl.setRules(rules);
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example-headers-w-spaces.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -211,10 +209,9 @@ public class BulkDataSanitizerImplTest {
             .columnToPseudonymize("EMPLOYEE_ID")
             .columnToPseudonymize("EMAIL")
             .build();
-        File inputFile = new File(getClass().getResource("/csv/hris-example-quotes.csv").getFile());
         columnarFileSanitizerImpl.setRules(rules);
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example-quotes.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -242,10 +239,9 @@ public class BulkDataSanitizerImplTest {
 
         ColumnarRules rules = (ColumnarRules) rulesUtils.getRulesFromConfig(config, new EnvVarsConfigService()).orElseThrow();
 
-        File inputFile = new File(getClass().getResource(exampleFile).getFile());
         columnarFileSanitizerImpl.setRules(rules);
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile(exampleFile);
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -269,10 +265,9 @@ public class BulkDataSanitizerImplTest {
 
         ColumnarRules rules = (ColumnarRules) rulesUtils.getRulesFromConfig(config, new EnvVarsConfigService()).orElseThrow();
 
-        File inputFile = new File(getClass().getResource("/csv/hris-default-rules_padded-employee-id.csv").getFile());
         columnarFileSanitizerImpl.setRules(rules);
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-default-rules_padded-employee-id.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -290,10 +285,7 @@ public class BulkDataSanitizerImplTest {
             .columnToPseudonymize(" an EMAIL ")
             .build();
         columnarFileSanitizerImpl.setRules(rules);
-
-        File inputFile = new File(getClass().getResource("/csv/hris-example-headers-w-spaces.csv").getFile());
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example-headers-w-spaces.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -312,9 +304,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example-quotes.csv").getFile());
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example-quotes.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -346,9 +336,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, defaultPseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -385,9 +373,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, defaultPseudonymizer);
             String output = out.toString();
@@ -420,9 +406,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, defaultPseudonymizer);
             String output = out.toString();
@@ -456,11 +440,7 @@ public class BulkDataSanitizerImplTest {
             pseudonymizerImplFactory.create(Pseudonymizer.ConfigurationOptions.builder()
                 .build());
 
-
-        File inputFile = new File(getClass().getResource("/csv/example_acme_20220901.csv").getFile());
-
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/example_acme_20220901.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, defaultPseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -478,9 +458,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example-quotes.csv").getFile());
-
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example-quotes.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -502,15 +480,11 @@ public class BulkDataSanitizerImplTest {
             .columnToPseudonymize("EMPLOYEE_EMAIL")
             .build();
         columnarFileSanitizerImpl.setRules(rules);
-
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
-
-
         // replace shuffler implementation with one that reverses the list, so deterministic
         columnarFileSanitizerImpl.setRecordShuffleChunkSize(2);
         columnarFileSanitizerImpl.makeShuffleDeterministic();
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -570,14 +544,12 @@ public class BulkDataSanitizerImplTest {
                 .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
-
         // replace shuffler implementation with one that reverses the list, so deterministic
         columnarFileSanitizerImpl.setRecordShuffleChunkSize(2);
         columnarFileSanitizerImpl.makeShuffleDeterministic();
 
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -637,7 +609,7 @@ public class BulkDataSanitizerImplTest {
 
 
         String resultString;
-        try (StringReader in = new StringReader(INITIAL);
+        try (BufferedReader in = new BufferedReader(new StringReader(INITIAL));
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
 
@@ -669,15 +641,13 @@ public class BulkDataSanitizerImplTest {
             "\"{\"\"hash\"\":\"\"4_hashed\"\"}\",\"{\"\"hash\"\":\"\"dave@worklytics.co_hashed\"\"}\",Engineering,2023-01-06,\"{\"\"hash\"\":\"\"1_hashed\"\"}\",2018-06-03,,\"{\"\"hash\"\":\"\"dave_hashed\"\"}\",\"{\"\"hash\"\":\"\"dave_alternate_hashed\"\"}\",dave\n" +
             "\"{\"\"hash\"\":\"\"3_hashed\"\"}\",\"{\"\"hash\"\":\"\"charles.clark@workltycis.co_hashed\"\"}\",Engineering,2023-01-06,\"{\"\"hash\"\":\"\"1_hashed\"\"}\",2019-10-06,2022-12-08,\"{\"\"hash\"\":\"\"charles_clark_hashed\"\"}\",\"{\"\"hash\"\":\"\"charles_clark_alternate_hashed\"\"}\",charles_clark\n";
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example-split-email-usernames.csv").getFile());
-
         columnarFileSanitizerImpl.setRecordShuffleChunkSize(2);
         columnarFileSanitizerImpl.makeShuffleDeterministic();
 
         // use stub for easy check on values
         Pseudonymizer pseudonymizer = new StubPseudonymizer();
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example-split-email-usernames.csv");
             StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -709,14 +679,14 @@ public class BulkDataSanitizerImplTest {
             "\"{\"\"hash\"\":\"\"1_hashed\"\"}\",\"{\"\"hash\"\":\"\"alice@worklytics.co_hashed\"\"}\",Engineering,2023-01-06,,2019-11-11,,\"{\"\"hash\"\":\"\"alice_acme_hashed\"\"}\"\n" +
             "\"{\"\"hash\"\":\"\"4_hashed\"\"}\",,Engineering,2023-01-06,\"{\"\"hash\"\":\"\"1_hashed\"\"}\",2018-06-03,,\n" +
             "\"{\"\"hash\"\":\"\"3_hashed\"\"}\",\"{\"\"hash\"\":\"\"charles@workltycis.co_hashed\"\"}\",Engineering,2023-01-06,\"{\"\"hash\"\":\"\"1_hashed\"\"}\",2019-10-06,2022-12-08,\"{\"\"hash\"\":\"\"charles_acme_hashed\"\"}\"\n";
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
+
 
         columnarFileSanitizerImpl.setRecordShuffleChunkSize(2);
         columnarFileSanitizerImpl.makeShuffleDeterministic();
 
         Pseudonymizer pseudonymizer = new StubPseudonymizer();
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in = forFile("/csv/hris-example.csv");
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -747,9 +717,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        File inputFile = new File(getClass().getResource("/csv/hris-example.csv").getFile());
-
-        try (StringReader in = new StringReader(SOURCE);
+        try (BufferedReader in = new BufferedReader(new StringReader(SOURCE));
              StringWriter out = new StringWriter()) {
             columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
             assertEquals(EXPECTED, out.toString());
@@ -769,7 +737,7 @@ public class BulkDataSanitizerImplTest {
             .build();
         columnarFileSanitizerImpl.setRules(rules);
 
-        try (StringReader in = new StringReader(SOURCE);
+        try (BufferedReader in = new BufferedReader(new StringReader(SOURCE));
              StringWriter out = new StringWriter()) {
             assertThrows(IllegalArgumentException.class, () -> columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer), "Non-ASCII characters found in headers, inspect file with cat -v for control characters");
         }
@@ -797,5 +765,14 @@ public class BulkDataSanitizerImplTest {
             return ConfigurationOptions.builder().build();
         }
 
+    }
+
+    BufferedReader forFile(String file) {
+        File inputFile = new File(getClass().getResource(file).getFile());
+        try {
+            return Files.newBufferedReader(Paths.get(inputFile.toURI()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + file, e);
+        }
     }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImplTest.java
@@ -1,10 +1,23 @@
 package co.worklytics.psoxy.storage.impl;
 
+import co.worklytics.psoxy.utils.ProcessingBuffer;
 import com.avaulta.gateway.rules.ColumnarRules;
+import lombok.SneakyThrows;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -24,8 +37,66 @@ class ColumnarBulkDataSanitizerImplTest {
         assertEmpty(columnarBulkDataSanitizer.determineMissingColumnsToPseudonymize(Set.of("EMPLOYEE_ID"), Set.of("employee_id")));
         assertEmpty(columnarBulkDataSanitizer.determineMissingColumnsToPseudonymize(Set.of("employee_Id"), Set.of("employee_id", "employee_name")));
         assertEmpty(columnarBulkDataSanitizer.determineMissingColumnsToPseudonymize(Set.of("employee_id"), Set.of("employee_name", "EMPLOYEE_ID")));
+    }
+
+
+
+
+    @ParameterizedTest
+    @MethodSource("headerLinesAndEndings")
+    void firstLine(String headerLine, String expectedEndOfLine) {
+        ColumnarBulkDataSanitizerImpl columnarBulkDataSanitizer = new ColumnarBulkDataSanitizerImpl(mock(ColumnarRules.class));
+        BufferedReader reader = new BufferedReader(new StringReader(headerLine));
+        ColumnarBulkDataSanitizerImpl.ParsedFirstLine parsedFirstLine = columnarBulkDataSanitizer.parseFirstLine(reader);
+        assertEquals(expectedEndOfLine, parsedFirstLine.getEndOfLine());
+    }
+
+    static Stream<Arguments> headerLinesAndEndings() {
+        return Stream.of(
+            Arguments.of("employee_id,employee_name\n", "\n"),
+            Arguments.of("employee_id,employee_name \n", "\n"),
+            Arguments.of("employee_id,employee_name\r\n", "\r\n"),
+            Arguments.of("employee_id,employee_name \r\n", "\r\n"),
+            Arguments.of("employee_id,employee_name\r", "\r"),
+            Arguments.of("employee_id,employee_name \r", "\r")
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    void proccessingSkipsMalformedRows() {
+        ColumnarBulkDataSanitizerImpl columnarBulkDataSanitizer = new ColumnarBulkDataSanitizerImpl(ColumnarRules.builder()
+            .columnToPseudonymize("employee_id")
+            .build());
+
+        String MALFORMED_CSV = "employee_id,employee_name\n" +
+            "12345,John Doe\n" +
+            "malformed_row_without_comma,\"missing_employee_name\n" +
+            "67890,Jane Doe\n";
+
+
+        CSVFormat csvFormat = CSVFormat.DEFAULT.builder()
+            .setHeader("employee_id", "employee_name")
+            .setSkipHeaderRecord(false)
+            .build();
+
+        List<ColumnarBulkDataSanitizerImpl.ProcessedRecord> processedRecords = new ArrayList<>();
+        ;
+
+        BufferedReader reader = new BufferedReader(new StringReader(MALFORMED_CSV));
+        reader.readLine(); // skip header
+
+        columnarBulkDataSanitizer.processRecords(List.of("employee_id,employee_name"),
+            csvFormat,
+            Collections.emptyMap(),
+            reader,
+            new ProcessingBuffer<>(1, r -> processedRecords.addAll(r)) {}
+        );
+
+        assertEquals(2, processedRecords.size());
 
     }
+
 
     void assertEmpty(Set<String> list) {
         assertTrue(list.isEmpty(), "Not empty list");

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImplTest.java
@@ -81,8 +81,6 @@ class ColumnarBulkDataSanitizerImplTest {
             .build();
 
         List<ColumnarBulkDataSanitizerImpl.ProcessedRecord> processedRecords = new ArrayList<>();
-        ;
-
         BufferedReader reader = new BufferedReader(new StringReader(MALFORMED_CSV));
         reader.readLine(); // skip header
 

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/ColumnarBulkDataSanitizerImplTest.java
@@ -64,7 +64,7 @@ class ColumnarBulkDataSanitizerImplTest {
 
     @SneakyThrows
     @Test
-    void proccessingSkipsMalformedRows() {
+    void processingSkipsMalformedRows() {
         ColumnarBulkDataSanitizerImpl columnarBulkDataSanitizer = new ColumnarBulkDataSanitizerImpl(ColumnarRules.builder()
             .columnToPseudonymize("employee_id")
             .build());

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
@@ -120,9 +120,9 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
                 Optional.ofNullable(sourceMetadata.getContentEncoding())
                     .ifPresent(destinationMetadata::setContentEncoding);
             }
-
-            destinationMetadata.setUserMetadata(storageHandler.buildObjectMetadata(importBucket, sourceKey, transform));
-
+            Map<String, String> metadata = new HashMap<>(storageHandler.buildObjectMetadata(importBucket, sourceKey, transform));
+            metadata.put(StorageHandler.BulkMetaData.ERROR_COUNT.getMetaDataKey(), String.valueOf(storageEventResponse.getErrorCount()));
+            destinationMetadata.setUserMetadata(metadata);
 
             s3Client.putObject(storageEventResponse.getDestinationBucketName(),
                 storageEventResponse.getDestinationObjectPath(),

--- a/java/impl/cmd-line/src/main/java/co/worklytics/psoxy/Handler.java
+++ b/java/impl/cmd-line/src/main/java/co/worklytics/psoxy/Handler.java
@@ -52,7 +52,7 @@ public class Handler {
         Pseudonymizer pseudonymizer = pseudonymizerImplFactory.create(options.build());
         BulkDataSanitizer sanitizer = fileHandlerStrategy.get(rules);
 
-        try (FileReader in = new FileReader(inputFile);
+        try (BufferedReader in =  new BufferedReader(new FileReader(inputFile));
              Writer writer = new AppendableWriter(out)) {
             sanitizer.sanitize(in, writer, pseudonymizer);
         }


### PR DESCRIPTION

### Fixes
 - syntactic-sugar loop `for (CSVRecord record : records)` can throw `UncheckedIOException` if individual line is malformed. This avoids that to some extent, by parsing line-by-line.


### Change implications

 - dependencies added/changed? **no**

While arguably good to avoid failing a huge file due to a couple malformed lines, may lead to encoding issues being too subtle to be discovered ... so perhaps we don't want this.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210453538185821