### PR TITLE
fix hybrid pseudonym deserialization

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/PseudonymizedIdentity.java
@@ -40,6 +40,19 @@ public class PseudonymizedIdentity {
      */
     String hash;
 
+    /**
+     * future-use. 0.4 hash for pseudonym, if `hash` is NOT 0.4.
+     *
+     * in the future, will be filled for LEGACY (0.3) cases; but for now, will be null (and always
+     * absent from JSON-serialized form)
+     *
+     * this will give both DEFAULT and LEGACY hashes for pseudonyms, allowing for eventual migration
+     * of LEGACY customers to DEFAULT (0.4)
+     *
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String h_4;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String original;
 

--- a/java/core/src/test/java/co/worklytics/psoxy/PseudonymizedIdentityTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/PseudonymizedIdentityTest.java
@@ -136,4 +136,15 @@ class PseudonymizedIdentityTest {
 
     }
 
+    @SneakyThrows
+    @Test
+    void jsonWithH4Works() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        PseudonymizedIdentity identity = objectMapper.readerFor(PseudonymizedIdentity.class)
+            .readValue("{\"domain\":\"worklytics.co\",\"hash\":\"wGt4TmRdTGdvKJT_H8AXKLbC4XoxCDKRyyAQtKJQbHE\",\"h_4\":\"wGt4TmRdTGdvKJT_H8AXKLbC4XoxCDKRyyAQtKJQbHE\"}");
+
+        assertEquals(identity.getDomain(), "worklytics.co");
+        assertEquals(identity.getHash(), "wGt4TmRdTGdvKJT_H8AXKLbC4XoxCDKRyyAQtKJQbHE");
+    }
+
 }


### PR DESCRIPTION
Case is customers legacy pseudonyms, but with a version that ALSO sends the new pseudonyms scheme to facilitate migration.

### Fixes
 - pseudonyms configured with legacy scheme, then serialized with proxy versions that actually fill the `h_4` proerpty with the new scheme (sometime after 0.4.39), aren't readable with v0.5.x libraries


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **anything consuming pseudonyms that might be legacy scheme, but serialized with verions 0.4.40 - 0.4.62, should upgrade to this**
