### PR TITLE
webhook collector CORS

### DIFF
--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -344,8 +344,8 @@ variable "webhook_collectors" {
       rotation_days = optional(number, null)       # null means no rotation; if > 0, will rotate every N days
       key_spec      = optional(string, "RSA_2048") # RSA_2048, RSA_3072, or RSA_4096; defaults to RSA_2048, which should be sufficient this use-case
     }), null)
-    auth_public_keys = optional(list(string), []) # list of public keys to use for verifying webhook signatures; if empty AND no auth keys provision, no app-level auth will be done
-    allow_origins = optional(list(string), [ "*" ]) # list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)
+    auth_public_keys = optional(list(string), [])    # list of public keys to use for verifying webhook signatures; if empty AND no auth keys provision, no app-level auth will be done
+    allow_origins    = optional(list(string), ["*"]) # list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)
   }))
 
   default = {}

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -345,6 +345,7 @@ variable "webhook_collectors" {
       key_spec      = optional(string, "RSA_2048") # RSA_2048, RSA_3072, or RSA_4096; defaults to RSA_2048, which should be sufficient this use-case
     }), null)
     auth_public_keys = optional(list(string), []) # list of public keys to use for verifying webhook signatures; if empty AND no auth keys provision, no app-level auth will be done
+    allow_origins = optional(list(string), [ "*" ]) # list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)
   }))
 
   default = {}

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -308,6 +308,8 @@ variable "webhook_collectors" {
       key_spec      = optional(string, "RSA_2048") # RSA_2048, RSA_3072, or RSA_4096; defaults to RSA_2048, which should be sufficient this use-case
     }), null)
     auth_public_keys = optional(list(string), []) # list of public keys to use for verifying webhook signatures; if empty AND no auth keys provision, no app-level auth will be done
+    allow_origins = optional(list(string), [ "*" ]) # list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)
+    }
   }))
 
   default = {}

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -307,10 +307,10 @@ variable "webhook_collectors" {
       rotation_days = optional(number, null)       # null means no rotation; if > 0, will rotate every N days
       key_spec      = optional(string, "RSA_2048") # RSA_2048, RSA_3072, or RSA_4096; defaults to RSA_2048, which should be sufficient this use-case
     }), null)
-    auth_public_keys = optional(list(string), []) # list of public keys to use for verifying webhook signatures; if empty AND no auth keys provision, no app-level auth will be done
-    allow_origins = optional(list(string), [ "*" ]) # list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)
+    auth_public_keys = optional(list(string), [])    # list of public keys to use for verifying webhook signatures; if empty AND no auth keys provision, no app-level auth will be done
+    allow_origins    = optional(list(string), ["*"]) # list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)
     }
-  }))
+  ))
 
   default = {}
 

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -27,7 +27,7 @@ locals {
   # helper to clarify conditionals throughout
   use_api_gateway = var.api_gateway_v2 != null
 
-  authorization_type = "NONE"                                # TODO: make this configurable, if auth BEYOND function-level checks of Authorization header is desired
+  authorization_type = "IAM"
   http_methods       = var.http_methods                      # Use http_methods directly without adding OPTIONS
 }
 
@@ -128,7 +128,7 @@ resource "aws_lambda_function_url" "lambda_url" {
     allow_credentials = true
     allow_headers     = ["*"]
     allow_methods     = [for m in local.http_methods : m if !(m == "OPTIONS")]
-    allow_origins     = ["*"] # q: support configuration of this??
+    allow_origins     = var.allow_origins
     expose_headers    = ["*"]
   }
 

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -122,11 +122,13 @@ resource "aws_lambda_function_url" "lambda_url" {
   function_name      = module.gate_instance.function_name
   authorization_type = local.authorization_type
 
+  # NOTE: CORS doesn't require that we include 'OPTIONS' method, as it is added automatically
+  # message is You can use GET, PUT, POST, DELETE, HEAD, PATCH, and the wildcard character (*).",
   cors {
     allow_credentials = true
     allow_headers     = ["*"]
-    allow_methods     = [for m in local.http_methods : !(m == "OPTIONS")] # OPTIONS is added automatically? if include, get error on apply "Value '[POST, GET, OPTIONS]' at 'cors.allowMethods' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 6," --> OPTIONS has 7 chars, so seems not allowed??
-    allow_origins     = ["*"]                                             # q: support configuration of this??
+    allow_methods     = [for m in local.http_methods : m if !(m == "OPTIONS")]
+    allow_origins     = ["*"] # q: support configuration of this??
     expose_headers    = ["*"]
   }
 

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -111,6 +111,7 @@ module "gate_instance" {
     },
     length(local.accepted_auth_keys) > 0 ? {
       ACCEPTED_AUTH_KEYS = join(",", local.accepted_auth_keys)
+      ALLOW_ORIGINS      = join(",", var.allow_origins)
     } : {}
   )
 }

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -27,7 +27,7 @@ locals {
   # helper to clarify conditionals throughout
   use_api_gateway = var.api_gateway_v2 != null
 
-  authorization_type = "IAM"
+  authorization_type = "AWS_IAM"
   http_methods       = var.http_methods # Use http_methods directly without adding OPTIONS
 }
 

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -28,7 +28,7 @@ locals {
   use_api_gateway = var.api_gateway_v2 != null
 
   authorization_type = "NONE"                                # TODO: make this configurable, if auth BEYOND function-level checks of Authorization header is desired
-  http_methods       = concat(var.http_methods, ["OPTIONS"]) # always add OPTIONS, as required by CORS
+  http_methods       = var.http_methods                      # Use http_methods directly without adding OPTIONS
 }
 
 module "env_id" {

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -27,8 +27,8 @@ locals {
   # helper to clarify conditionals throughout
   use_api_gateway = var.api_gateway_v2 != null
 
-  # TODO: convert this to 'NONE', once we do JWT auth in the lambda itself
-  authorization_type = "AWS_IAM"
+  authorization_type = "NONE"                                # TODO: make this configurable, if auth BEYOND function-level checks of Authorization header is desired
+  http_methods       = concat(var.http_methods, ["OPTIONS"]) # always add OPTIONS, as required by CORS
 }
 
 module "env_id" {
@@ -122,6 +122,14 @@ resource "aws_lambda_function_url" "lambda_url" {
   function_name      = module.gate_instance.function_name
   authorization_type = local.authorization_type
 
+  cors {
+    allow_credentials = true
+    allow_headers     = ["*"]
+    allow_methods     = local.http_methods
+    allow_origins     = ["*"] # q: support configuration of this??
+    expose_headers    = ["*"]
+  }
+
   depends_on = [
     module.gate_instance
   ]
@@ -141,7 +149,7 @@ resource "aws_apigatewayv2_integration" "map" {
 }
 
 resource "aws_apigatewayv2_route" "methods" {
-  for_each = toset(local.use_api_gateway ? var.http_methods : [])
+  for_each = toset(local.use_api_gateway ? local.http_methods : [])
 
   api_id             = var.api_gateway_v2.id
   route_key          = "${each.key} /${module.gate_instance.function_name}/{proxy+}"
@@ -160,7 +168,7 @@ resource "aws_lambda_permission" "api_gateway" {
 
   # The /*/*/ part allows invocation from any stage, method and resource path
   # within API Gateway REST API.
-  # TODO: limit by http method here too?
+  # TODO: limit by http method here too?  for webhooks, would need POST, OPTIONS at min
   source_arn = "${var.api_gateway_v2.execution_arn}/*/*/${module.gate_instance.function_name}/{proxy+}"
 }
 

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -125,8 +125,8 @@ resource "aws_lambda_function_url" "lambda_url" {
   cors {
     allow_credentials = true
     allow_headers     = ["*"]
-    allow_methods     = local.http_methods
-    allow_origins     = ["*"] # q: support configuration of this??
+    allow_methods     = [for m in local.http_methods : !(m == "OPTIONS")] # OPTIONS is added automatically? if include, get error on apply "Value '[POST, GET, OPTIONS]' at 'cors.allowMethods' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 6," --> OPTIONS has 7 chars, so seems not allowed??
+    allow_origins     = ["*"]                                             # q: support configuration of this??
     expose_headers    = ["*"]
   }
 

--- a/infra/modules/aws-webhook-collector/main.tf
+++ b/infra/modules/aws-webhook-collector/main.tf
@@ -28,7 +28,7 @@ locals {
   use_api_gateway = var.api_gateway_v2 != null
 
   authorization_type = "IAM"
-  http_methods       = var.http_methods                      # Use http_methods directly without adding OPTIONS
+  http_methods       = var.http_methods # Use http_methods directly without adding OPTIONS
 }
 
 module "env_id" {

--- a/infra/modules/aws-webhook-collector/variables.tf
+++ b/infra/modules/aws-webhook-collector/variables.tf
@@ -216,7 +216,7 @@ variable "secrets_store_implementation" {
 variable "allow_origins" {
   type        = list(string)
   description = "list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)"
-  default = [ "*" ]
+  default     = ["*"]
 }
 
 variable "test_caller_role_arn" {

--- a/infra/modules/aws-webhook-collector/variables.tf
+++ b/infra/modules/aws-webhook-collector/variables.tf
@@ -163,8 +163,8 @@ variable "api_gateway_v2" {
 
 variable "http_methods" {
   type        = list(string)
-  description = "HTTP methods to expose; has no effect unless api_gateway is also provided"
-  default     = ["HEAD", "GET", "POST"]
+  description = "HTTP methods to expose; NOTE: 'OPTIONS' is always added to this list, so you don't need to include it; if you want to allow all methods, use ['*']"
+  default     = ["GET", "POST"]
 }
 
 # examples:

--- a/infra/modules/aws-webhook-collector/variables.tf
+++ b/infra/modules/aws-webhook-collector/variables.tf
@@ -213,6 +213,12 @@ variable "secrets_store_implementation" {
   default     = "aws_ssm_parameter_store"
 }
 
+variable "allow_origins" {
+  type        = list(string)
+  description = "list of origins to allow for CORS, eg 'https://my-app.com'; if you want to allow all origins, use ['*'] (the default)"
+  default = [ "*" ]
+}
+
 variable "test_caller_role_arn" {
   type        = string
   description = "optional ARN of an AWS role to assume when making test calls, if any; leave `null` for none"

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/WebhookCollectorModeConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/WebhookCollectorModeConfigProperty.java
@@ -26,6 +26,13 @@ public enum WebhookCollectorModeConfigProperty implements ConfigService.ConfigPr
     ACCEPTED_AUTH_KEYS,
 
     /**
+     * a CSV of origins that are allowed to send webhooks to this collector. aligned with CORS standards
+     *
+     *default to "*", meaning all origins are allowed.
+     */
+    ALLOW_ORIGINS,
+
+    /**
      * if false, proxy will not require or validate any Authorization header(s) sent with webhooks.
      *
      * false does NOT mean there is no authentication/authorization of webhook collection; simply that it is not done within


### PR DESCRIPTION
### Fixes
 - add CORS support to webhook collectors, so those can work from browser-based JS

Big doubt is whether to allow configuration of allowed origins ...

Curiously, while I added underneath in the handler (app-level), AWS seems to handle these OPTIONS requests at API Gateway/Function URL level, via settings; so I've done them via terraform.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210561492262910