### PR TITLE
S201 fix nodejs tests

### DIFF
--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -6,7 +6,8 @@ import {
   request,
   resolveHTTPMethod,
   resolveAWSRegion,
-  signAWSRequestURL
+  signAWSRequestURL,
+  signJwtWithKMS,
 } from './utils.js';
 import {
   S3Client,
@@ -21,10 +22,6 @@ import {
   DescribeLogStreamsCommand,
   GetLogEventsCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
-import {
-   KMSClient,
-   SignCommand
-} from '@aws-sdk/client-kms';
 
 import fs from 'fs';
 import getLogger from './logger.js';
@@ -55,34 +52,6 @@ function base64url(input) {
     .replace(/\//g, '_');
 }
 
-async function signJwtWithKMS(claims, keyId, credentials, region) {
-  const client = new KMSClient({
-    region: region,
-    credentials: credentials,
-  });
-
-  const encodedHeader = base64url(Buffer.from(JSON.stringify({
-    "alg": "RS256",
-    "typ": "JWT",
-  })));
-  const encodedPayload = base64url(Buffer.from(JSON.stringify(claims)));
-  const signingInput = `${encodedHeader}.${encodedPayload}`;
-
-  const hash = crypto.createHash('sha256').update(signingInput).digest();
-
-  const command = new SignCommand({
-    KeyId: keyId,
-    SigningAlgorithm: 'RSASSA_PKCS1_V1_5_SHA_256',
-    Message: hash,
-    MessageType: 'DIGEST' // 🟢 explicitly indicate pre-hashed input
-  });
-
-  const response = await client.send(command);
-
-  const signature = base64url(Buffer.from(response.Signature));
-  return `${signingInput}.${signature}`;
-}
-
 /**
  * Psoxy test
  *
@@ -104,13 +73,13 @@ async function call(options = {}) {
 
   const signed = signAWSRequestURL(url, method, options.body, credentials,
      options.region);
+
   const headers = {
     ...getCommonHTTPHeaders(options),
     ...signed.headers,
   };
 
   if (options.signingKey) {
-
     let signature;
     let claims = {
       iss: options.signingKey, // silly?
@@ -124,9 +93,7 @@ async function call(options = {}) {
     }
 
     headers['x-psoxy-authorization'] = signature;
-    console.log(signature);
   }
-
 
   logger.info(`Calling Psoxy and waiting response: ${options.url.toString()}`);
   logger.verbose('Request Options:', { additional: options });
@@ -426,4 +393,3 @@ export default {
   parseLogEvents,
   upload,
 }
-

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -16,6 +16,8 @@ import isgzipBuffer from '@stdlib/assert-is-gzip-buffer';
 import path from 'path';
 import spec from '../data-sources/spec.js';
 import zlib from 'node:zlib';
+import {KMSClient, SignCommand} from '@aws-sdk/client-kms';
+import crypto from 'node:crypto';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // In case Psoxy is slow to respond (Lambda can take up to 20s+ to bootstrap),
@@ -178,7 +180,7 @@ function requestWrapper(url, method = 'GET', headers, body = {}) {
  * @param {URL} url
  * @param {String} method
  * @param {Object} body
- * @param {Object} credentials
+ * @param {Credentials} credentials
  * @param {String} region
  * @return {Object}
  */
@@ -456,6 +458,41 @@ async function getAWSCredentials(role, region) {
 }
 
 /**
+ * @param {object} claims - the usual JWT ones, iss, sub, etc. will be stringified
+ * @param {string} keyId
+ * @param {Credentials} credentials
+ * @param {string} region
+ * @returns {Promise<string>}
+ */
+async function signJwtWithKMS(claims, keyId, credentials, region) {
+  const client = new KMSClient({
+    region: region,
+    credentials: credentials,
+  });
+
+  const encodedHeader = base64url(Buffer.from(JSON.stringify({
+    "alg": "RS256",
+    "typ": "JWT",
+  })));
+  const encodedPayload = base64url(Buffer.from(JSON.stringify(claims)));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const hash = crypto.createHash('sha256').update(signingInput).digest();
+
+  const command = new SignCommand({
+    KeyId: keyId,
+    SigningAlgorithm: 'RSASSA_PKCS1_V1_5_SHA_256',
+    Message: hash,
+    MessageType: 'DIGEST' // 🟢 explicitly indicate pre-hashed input
+  });
+
+  const response = await client.send(command);
+
+  const signature = base64url(Buffer.from(response.Signature));
+  return `${signingInput}.${signature}`;
+}
+
+/**
  * Append suffix to filename (before extension)
  * @param {string} filename
  * @param {string} suffix
@@ -510,5 +547,6 @@ export {
   resolveHTTPMethod,
   saveToFile,
   signAWSRequestURL,
+  signJwtWithKMS,
   transformSpecWithResponse,
 };

--- a/tools/psoxy-test/package.json
+++ b/tools/psoxy-test/package.json
@@ -38,8 +38,7 @@
   },
   "ava": {
     "files": [
-      "test/psoxy-test-call.test.js",
-      "test/utils.test.js"
+      "test/*.js"
     ]
   }
 }

--- a/tools/psoxy-test/test/gcp.test.js
+++ b/tools/psoxy-test/test/gcp.test.js
@@ -33,8 +33,14 @@ test('Get logs link based on cloud function URL', (t) => {
   const gcp = t.context.subject;
 
   t.is(undefined, gcp.getLogsURL('foo'));
-  t.is('https://console.cloud.google.com/functions/details/us-central1/psoxy-function?project=psoxy-project&tab=logs',
+
+  t.is('https://console.cloud.google.com/run/detail/us-central1/psoxy-function/logs?project=psoxy-project',
     gcp.getLogsURL('https://us-central1-psoxy-project.cloudfunctions.net/psoxy-function'))
+
+  t.is('https://console.cloud.google.com/run/detail/us-central1/psoxy-dev-gcal/logs',
+    gcp.getLogsURL('https://psoxy-dev-gcal-boff2f476q-uc.a.run.app'))
+
+  t.is('https://console.cloud.google.com', gcp.getLogsURL('https://foo76q-ux.a.run.app/'));
 })
 
 test('Psoxy Logs: parse log entries', (t) => {


### PR DESCRIPTION
### Fixes
 - GCP `getLogsURL` failing for cloud functions gen1 (tests were disabled)

### Features
 - Test new `signJwtWithKMS` method (Webhooks use-case)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**