### PR TITLE
jars as release artifacts

### DIFF
--- a/.github/workflows/ci-bundles.yaml
+++ b/.github/workflows/ci-bundles.yaml
@@ -36,3 +36,31 @@ jobs:
           mvn package install -f "gateway-core/pom.xml" -Dmaven.test.skip=true
           mvn package install -f "core/pom.xml" -Dmaven.test.skip=true
           mvn package -f "impl/${{ matrix.implementation }}/pom.xml"
+      - name: Verify license artifacts are in the uber jar
+        working-directory: java/impl/${{ matrix.implementation }}
+        run: |
+          JAR_FILE=$(find target -name "*.jar" | head -n1)
+
+          echo "Inspecting $JAR_FILE for required license files"
+
+          unzip -l "$JAR_FILE" | tee jar-contents.txt
+
+          # Check summary file
+          grep -q 'THIRD-PARTY-LICENSE-LIST.txt' jar-contents.txt || {
+            echo "::error::Missing THIRD-PARTY-LICENSE-LIST.txt in $JAR_FILE"
+            exit 1
+          }
+
+          # Check for at least one LICENSE or NOTICE file at root
+#          grep -Eq '/(LICENSE|NOTICE)$' jar-contents.txt || {
+#            echo "::error::Missing LICENSE or NOTICE at root of $JAR_FILE"
+#            exit 1
+#          }
+
+          # Check for license texts from dependencies (in licenses/)
+          grep -q '^ *[0-9].*licenses/' jar-contents.txt || {
+            echo "::error::No license texts from dependencies found in licenses/ folder"
+            exit 1
+          }
+
+          echo "✅ License artifacts verified in $JAR_FILE"

--- a/.github/workflows/ci-bundles.yaml
+++ b/.github/workflows/ci-bundles.yaml
@@ -35,7 +35,7 @@ jobs:
           mvn clean -f pom.xml
           mvn package install -f "gateway-core/pom.xml" -Dmaven.test.skip=true
           mvn package install -f "core/pom.xml" -Dmaven.test.skip=true
-          mvn package -f "impl/${{ matrix.implementation }}/pom.xml"
+          mvn package -f "impl/${{ matrix.implementation }}/pom.xml" -Pdistribution 
       - name: Verify license artifacts are in the uber jar
         working-directory: java/impl/${{ matrix.implementation }}
         run: |

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/SanitizerUtils.java
@@ -269,9 +269,28 @@ public class SanitizerUtils {
         };
     }
 
+
+    // Matches valid IPv4 addresses
+    private static final Pattern IPV4_PATTERN = Pattern.compile(
+        "^([0-9]{1,3}\\.){3}[0-9]{1,3}$"
+    );
+
+    // Matches unbracketed IPv6 addresses
+    private static final Pattern IPV6_PATTERN = Pattern.compile(
+        "^[0-9a-fA-F:.]+$"  // q: too permissive? this is what's rec'd by
+    );
+
+
     String canonicalizeIp(String ip) {
         try {
-            //TODO: force to textual IP address, and never permit hostnames?
+            boolean maybeIpv4 = IPV4_PATTERN.matcher(ip).matches();
+            boolean maybeIpv6 = IPV6_PATTERN.matcher(ip).matches();
+
+            if (!maybeIpv4 && !maybeIpv6) {
+                //not a valid IP address
+                log.warning("value matched by HashIP transform not a valid IP address: " + ip);
+                return null;
+            }
             InetAddress address = InetAddress.getByName(ip);
             return address.getHostAddress();
         } catch (UnknownHostException e) {

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -698,8 +698,14 @@ class RESTApiSanitizerImplTest {
     @CsvSource(value = {
         "123.234.252.12,t~7USliSM4GiS0Xfk1DXIAH-4nK-UkLJlSAA_5ZqQh_CI",
         "10.0.0.1,t~3BU4goNN07w3ofq8v5ig2enxSWj9xnAnPOThel4mHTk",
-        ",",
-        "not an ip," // redact
+        //some IPv6 cases
+        "2001:0db8::1,t~njBikXo6n6-7z6JEg8zs_E89aJQ0lje1vW3O9EkS__8", //compressed zeros
+        "2001:db8:0:0:0:0:2:1,t~I8-OlnbGQkV5ClnMrM_O79TR_r8JroRmUbd056Hs2x4", //uncompressed zeros
+        "0:0:0:0:0:ffff:c000:0280,t~SUZ6xYqAE2gCw90EnrhS7ait6lh2xPKj2-SSQVm8o9A", //IPv4-mapped IPv6 address
+        "::ffff:192.0.2.128,t~SUZ6xYqAE2gCw90EnrhS7ait6lh2xPKj2-SSQVm8o9A", //IPv4-mapped IPv6 address
+        "not an ip,", // redact
+        "notanip,", // redact
+        //"aaaa,aaaa", // permits hex strings that *may* be IPv6 ....
     })
     @ParameterizedTest
     public void hashIp(String input, String expected) {

--- a/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/impl/RESTApiSanitizerImplTest.java
@@ -705,7 +705,7 @@ class RESTApiSanitizerImplTest {
         "::ffff:192.0.2.128,t~SUZ6xYqAE2gCw90EnrhS7ait6lh2xPKj2-SSQVm8o9A", //IPv4-mapped IPv6 address
         "not an ip,", // redact
         "notanip,", // redact
-        //"aaaa,aaaa", // permits hex strings that *may* be IPv6 ....
+// Line removed as the test case is no longer needed.
     })
     @ParameterizedTest
     public void hashIp(String input, String expected) {

--- a/java/impl/aws/pom.xml
+++ b/java/impl/aws/pom.xml
@@ -257,11 +257,43 @@
             <!-- add license plugin -->
             <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
                  dependencies, to facilitate eventual distribution of built JAR -->
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.5.0</version>
+                <executions>
+                    <execution>
+                        <id>download-dependency-licenses</id>
+                        <goals><goal>download-licenses</goal></goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
+                            <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <includeOptional>false</includeOptional>
+                            <licensesConfigFile>${project.basedir}/src/license-mapping.xml</licensesConfigFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-third-party-license</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
+                            <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <excludedScopes>test,provided</excludedScopes>
+                            <!--<failIfWarning>true</failIfWarning>-->
+                            <licenseMerges>${project.basedir}/license-mapping.xml</licenseMerges>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
+
+
         </plugins>
     </build>
 </project>

--- a/java/impl/aws/pom.xml
+++ b/java/impl/aws/pom.xml
@@ -252,47 +252,55 @@
                     </execution>
                 </executions>
             </plugin>
-
-
-            <!-- add license plugin -->
-            <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
-                 dependencies, to facilitate eventual distribution of built JAR -->
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <id>download-dependency-licenses</id>
-                        <goals><goal>download-licenses</goal></goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
-                            <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
-                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
-                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                            <excludedScopes>test,provided</excludedScopes>
-                            <failOnMissing>true</failOnMissing>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>generate-third-party-license</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>add-third-party</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
-                            <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
-                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
-                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                            <excludedScopes>test,provided</excludedScopes>
-                            <failOnMissing>true</failOnMissing>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>distribution</id>
+            <build>
+                <plugins>
+
+                    <!-- add license plugin -->
+                    <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
+                         dependencies, to facilitate eventual distribution of built JAR -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>2.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>download-dependency-licenses</id>
+                                <goals><goal>download-licenses</goal></goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
+                                    <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
+                                    <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
+                                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                                    <excludedScopes>test,provided</excludedScopes>
+                                    <failOnMissing>true</failOnMissing>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>generate-third-party-license</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>add-third-party</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
+                                    <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
+                                    <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
+                                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                                    <excludedScopes>test,provided</excludedScopes>
+                                    <failOnMissing>true</failOnMissing>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/java/impl/aws/pom.xml
+++ b/java/impl/aws/pom.xml
@@ -270,9 +270,10 @@
                         <configuration>
                             <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
                             <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
+                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
                             <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                            <includeOptional>false</includeOptional>
-                            <licensesConfigFile>${project.basedir}/src/license-mapping.xml</licensesConfigFile>
+                            <excludedScopes>test,provided</excludedScopes>
+                            <failOnMissing>true</failOnMissing>
                         </configuration>
                     </execution>
                     <execution>
@@ -284,16 +285,14 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
                             <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
+                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
                             <includeTransitiveDependencies>true</includeTransitiveDependencies>
                             <excludedScopes>test,provided</excludedScopes>
-                            <!--<failIfWarning>true</failIfWarning>-->
-                            <licenseMerges>${project.basedir}/license-mapping.xml</licenseMerges>
+                            <failOnMissing>true</failOnMissing>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
-
         </plugins>
     </build>
 </project>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -254,10 +254,40 @@
             <!-- add license plugin -->
             <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
                  dependencies, to facilitate eventual distribution of built JAR -->
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.5.0</version>
+                <executions>
+                    <execution>
+                        <id>download-dependency-licenses</id>
+                        <goals><goal>download-licenses</goal></goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
+                            <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <includeOptional>false</includeOptional>
+                            <licensesConfigFile>${project.basedir}/src/license-mapping.xml</licensesConfigFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-third-party-license</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
+                            <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <excludedScopes>test,provided</excludedScopes>
+                            <!--<failIfWarning>true</failIfWarning>-->
+                            <licenseMerges>${project.basedir}/license-mapping.xml</licenseMerges>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -267,9 +267,10 @@
                         <configuration>
                             <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
                             <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
+                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
                             <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                            <includeOptional>false</includeOptional>
-                            <licensesConfigFile>${project.basedir}/src/license-mapping.xml</licensesConfigFile>
+                            <excludedScopes>test,provided</excludedScopes>
+                            <failOnMissing>true</failOnMissing>
                         </configuration>
                     </execution>
                     <execution>
@@ -281,10 +282,10 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
                             <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
+                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
                             <includeTransitiveDependencies>true</includeTransitiveDependencies>
                             <excludedScopes>test,provided</excludedScopes>
-                            <!--<failIfWarning>true</failIfWarning>-->
-                            <licenseMerges>${project.basedir}/license-mapping.xml</licenseMerges>
+                            <failOnMissing>true</failOnMissing>
                         </configuration>
                     </execution>
                 </executions>

--- a/java/impl/gcp/pom.xml
+++ b/java/impl/gcp/pom.xml
@@ -251,45 +251,58 @@
             </plugin>
 
 
-            <!-- add license plugin -->
-            <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
-                 dependencies, to facilitate eventual distribution of built JAR -->
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <id>download-dependency-licenses</id>
-                        <goals><goal>download-licenses</goal></goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
-                            <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
-                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
-                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                            <excludedScopes>test,provided</excludedScopes>
-                            <failOnMissing>true</failOnMissing>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>generate-third-party-license</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>add-third-party</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
-                            <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
-                            <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
-                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                            <excludedScopes>test,provided</excludedScopes>
-                            <failOnMissing>true</failOnMissing>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+
         </plugins>
     </build>
+
+
+    <profiles>
+        <profile>
+            <id>distribution</id>
+            <build>
+                <plugins>
+
+                    <!-- add license plugin -->
+                    <!-- use mvn goal license:aggregate-third-party-report to get report on licenses about
+                         dependencies, to facilitate eventual distribution of built JAR -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>2.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>download-dependency-licenses</id>
+                                <goals><goal>download-licenses</goal></goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses</licensesOutputDirectory>
+                                    <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
+                                    <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
+                                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                                    <excludedScopes>test,provided</excludedScopes>
+                                    <failOnMissing>true</failOnMissing>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>generate-third-party-license</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>add-third-party</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/generated-resources/licenses</outputDirectory>
+                                    <thirdPartyFilename>THIRD-PARTY-LICENSE-LIST.txt</thirdPartyFilename>
+                                    <licenseMerges>${project.parent.basedir}/license-mapping.xml</licenseMerges>
+                                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                                    <excludedScopes>test,provided</excludedScopes>
+                                    <failOnMissing>true</failOnMissing>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/java/impl/uber-jar.xml
+++ b/java/impl/uber-jar.xml
@@ -22,4 +22,25 @@
             <handlerName>metaInf-services</handlerName>
         </containerDescriptorHandler>
     </containerDescriptorHandlers>
+
+    <!-- include license file -->
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/generated-resources/licenses</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>THIRD-PARTY-LICENSE-LIST.txt</include>
+            </includes>
+            <filtered>false</filtered>
+        </fileSet>
+
+        <fileSet>
+            <directory>${project.build.directory}/generated-resources/dependency-licenses</directory>
+            <outputDirectory>licenses</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <filtered>false</filtered>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/java/license-mapping.xml
+++ b/java/license-mapping.xml
@@ -2,20 +2,48 @@
   <licenseMerge>
     <match>
       <groupId>co.worklytics.psoxy</groupId>
+        <artifactId>psoxy-core</artifactId>
     </match>
     <mergedLicense>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <name>Worklytics Commercial License</name>
+      <url>https://github.com/Worklytics/psoxy/blob/main/LICENSE.md</url>
     </mergedLicense>
   </licenseMerge>
 
   <licenseMerge>
     <match>
       <groupId>com.avaulta.gateway</groupId>
+        <artifactId>gateway-core</artifactId>
     </match>
     <mergedLicense>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <name>Worklytics Commercial License</name>
+      <url>https://github.com/Worklytics/psoxy/blob/main/LICENSE.md</url>
     </mergedLicense>
   </licenseMerge>
+
+    <!-- External deps with known licenses but broken/unavailable URLs -->
+
+    <!-- error-prone javac shaded -->
+    <licenseMerge>
+        <match>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>javac-shaded</artifactId>
+        </match>
+        <mergedLicense>
+            <name>GPLv2 with Classpath Exception</name>
+            <url>https://openjdk.org/legal/gplv2+ce.html</url>
+        </mergedLicense>
+    </licenseMerge>
+
+    <!-- checker-compat-qual -->
+    <licenseMerge>
+        <match>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-compat-qual</artifactId>
+        </match>
+        <mergedLicense>
+            <name>GPLv2 with Classpath Exception</name>
+            <url>https://www.gnu.org/software/classpath/license.html</url>
+        </mergedLicense>
+    </licenseMerge>
 </licenseMerges>

--- a/java/license-mapping.xml
+++ b/java/license-mapping.xml
@@ -1,0 +1,21 @@
+<licenseMerges>
+  <licenseMerge>
+    <match>
+      <groupId>co.worklytics.psoxy</groupId>
+    </match>
+    <mergedLicense>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </mergedLicense>
+  </licenseMerge>
+
+  <licenseMerge>
+    <match>
+      <groupId>com.avaulta.gateway</groupId>
+    </match>
+    <mergedLicense>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </mergedLicense>
+  </licenseMerge>
+</licenseMerges>


### PR DESCRIPTION
### Features
 - bundle licenses for deps into uber-JAR, which allows potential distribution of it

Next steps:
 - [ ] add release tooling to upload bundles as release artifacts
 - [x] maven profile to NOT run all the license plugin stuff EXCEPT in special cases (prepping a JAR for distribution)

### Change implications

- **Dependencies added/changed?** **maven-license-plugin**
- **Something important to note in future release notes?** **no**
- **Breaking changes?** **no**
