### PR TITLE
workflow to auth aws, push uber-jar to bucket

### DIFF
--- a/.github/workflows/ci-bundles.yaml
+++ b/.github/workflows/ci-bundles.yaml
@@ -80,7 +80,7 @@ jobs:
           S3_BUCKET: psoxy-public-artifacts
         run: |
           # uber-jar should be something like: psoxy-aws-{VERSION}.jar
-          JAR_FILE=$(find target -name "*.jar" | head -n1) 
+          JAR_FILE=$(find . -name "*.jar" | head -n1) 
           echo "Uploading $JAR_FILE to s3://$S3_BUCKET/"
 
           aws s3 cp "$JAR_FILE" "s3://$S3_BUCKET/" --region "$AWS_REGION"

--- a/.github/workflows/ci-bundles.yaml
+++ b/.github/workflows/ci-bundles.yaml
@@ -11,7 +11,8 @@ on:
     branches:
       - 'main'
       - 'rc-*'
-
+  workflow_dispatch:
+  
 jobs:
   bundle:
     runs-on: ubuntu-latest
@@ -35,10 +36,11 @@ jobs:
           mvn clean -f pom.xml
           mvn package install -f "gateway-core/pom.xml" -Dmaven.test.skip=true
           mvn package install -f "core/pom.xml" -Dmaven.test.skip=true
-          mvn package -f "impl/${{ matrix.implementation }}/pom.xml" -Pdistribution 
+          mvn package   -Pdistribution -f "impl/${{ matrix.implementation }}/pom.xml"
       - name: Verify license artifacts are in the uber jar
-        working-directory: java/impl/${{ matrix.implementation }}
+        working-directory: java/impl/
         run: |
+           cd ${{ matrix.implementation }}
           JAR_FILE=$(find target -name "*.jar" | head -n1)
 
           echo "Inspecting $JAR_FILE for required license files"

--- a/.github/workflows/ci-bundles.yaml
+++ b/.github/workflows/ci-bundles.yaml
@@ -12,7 +12,7 @@ on:
       - 'main'
       - 'rc-*'
   workflow_dispatch:
-  
+
 jobs:
   bundle:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
       - name: Verify license artifacts are in the uber jar
         working-directory: java/impl/
         run: |
-           cd ${{ matrix.implementation }}
+          cd ${{ matrix.implementation }}
           JAR_FILE=$(find target -name "*.jar" | head -n1)
 
           echo "Inspecting $JAR_FILE for required license files"
@@ -66,3 +66,21 @@ jobs:
           }
 
           echo "✅ License artifacts verified in $JAR_FILE"
+      - name: Configure AWS credentials via OIDC
+        if: matrix.implementation == 'aws'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::908404960471:role/GithubActionCIAgent
+          aws-region: us-west-2
+      - name: Upload uber-jar to S3
+        if: matrix.implementation == 'aws'
+        working-directory: java/impl/aws/target/
+        env:
+          AWS_REGION: us-west-2
+          S3_BUCKET: psoxy-public-artifacts
+        run: |
+          # uber-jar should be something like: psoxy-aws-{VERSION}.jar
+          JAR_FILE=$(find target -name "*.jar" | head -n1) 
+          echo "Uploading $JAR_FILE to s3://$S3_BUCKET/"
+
+          aws s3 cp "$JAR_FILE" "s3://$S3_BUCKET/" --region "$AWS_REGION"

--- a/.github/workflows/ci-bundles.yaml
+++ b/.github/workflows/ci-bundles.yaml
@@ -38,9 +38,8 @@ jobs:
           mvn package install -f "core/pom.xml" -Dmaven.test.skip=true
           mvn package   -Pdistribution -f "impl/${{ matrix.implementation }}/pom.xml"
       - name: Verify license artifacts are in the uber jar
-        working-directory: java/impl/
+        working-directory: java/impl/${{ matrix.implementation }}
         run: |
-          cd ${{ matrix.implementation }}
           JAR_FILE=$(find target -name "*.jar" | head -n1)
 
           echo "Inspecting $JAR_FILE for required license files"


### PR DESCRIPTION
### Features
 - adds workflow step to auth aws, push JAR to s3

After this, referencing the artifact in s3 (as `s3://psoxy-public-artifacts/psoxy-aws-0.5.3.jar` as the value of `deployment_bundle` in examples should use that, rather than build from scratch. This should eliminate maven + java as dependencies entirely (this functionality previously existed to support terraform cloud use-case, by pre-building JAR locally and uploading to S3, where terraform cloud could find it - as otherwise terraform cloud lacks maven/java too)

### Change implications

 - dependencies added/changed? **yes - `configure-aws-credentials` action; s3 tooling must be installed.
