### PR TITLE
S203 : csv extra columns

### DIFF
--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/BulkDataSanitizerImplTest.java
@@ -277,6 +277,39 @@ public class BulkDataSanitizerImplTest {
         }
     }
 
+    /**
+     * test case for CSV that includes a column without a name (eg, a column with empty/blank string in the header)
+     *
+     * such cases are not strictly invalid CSV, so we will not blow up; but we will generally fail if anyone really attempts to do anything with them.
+     * so the only supported use case is to just preserve the column as-is, and not apply any rules to it.
+     */
+    @Test
+    @SneakyThrows
+    void defaultRules_anonColumn() {
+        final String TEST_EXAMPLE_FILE = "/csv/hris-default-rules_anon-column.csv";
+        final String EXPECTED = "EMPLOYEE_ID,,employee_EMAIL,MANAGER_id,Manager_Email,JOIN_DATE,ROLE\n" +
+            "\"{\"\"hash\"\":\"\"0zPKqEd-CtbCLB1ZSwX6Zo7uAWUvkpfHGzv9-cuYwZc\"\"}\",anon1,\"{\"\"domain\"\":\"\"worklytics.co\"\",\"\"hash\"\":\"\"Qf4dLJ4jfqZLn9ef4VirvYjvOnRaVI5tf5oLnM65YOA\"\"}\",\"{\"\"hash\"\":\"\"-hN_i1M1DeMAicDVp6LhFgW9lH7r3_LbOpTlXYWpXVI\"\"}\",\"{\"\"domain\"\":\"\"worklytics.co\"\",\"\"hash\"\":\"\"TtDWXFAQxNE8O2w7DuMtEKzTSZXERuUVLCjmd9r6KQ4\"\"}\",2021-01-01,Accounting Manager\n" +
+            "\"{\"\"hash\"\":\"\"-hN_i1M1DeMAicDVp6LhFgW9lH7r3_LbOpTlXYWpXVI\"\"}\",anon2,\"{\"\"domain\"\":\"\"worklytics.co\"\",\"\"hash\"\":\"\"TtDWXFAQxNE8O2w7DuMtEKzTSZXERuUVLCjmd9r6KQ4\"\"}\",,,2020-01-01,CEO\n";
+
+        //padded case (eg, 001 instead of 1 for employee_id), should result in different hashes
+        assertNotEquals(EXPECTED, EXPECTED_HRIS_DEFAULT_RULES);
+
+        ConfigService config = MockModules.provideMock(ConfigService.class);
+        when(config.getConfigPropertyAsOptional(eq(ProxyConfigProperty.RULES)))
+            .thenReturn(Optional.of(Base64.encodeBase64String(TestUtils.getData("sources/hris/csv.yaml"))));
+
+        ColumnarRules rules = (ColumnarRules) rulesUtils.getRulesFromConfig(config, new EnvVarsConfigService()).orElseThrow();
+
+        File inputFile = new File(getClass().getResource(TEST_EXAMPLE_FILE).getFile());
+        columnarFileSanitizerImpl.setRules(rules);
+
+        try (FileReader in = new FileReader(inputFile);
+             StringWriter out = new StringWriter()) {
+            columnarFileSanitizerImpl.sanitize(in, out, pseudonymizer);
+            assertEquals(EXPECTED, out.toString());
+        }
+    }
+
 
     @Test
     @SneakyThrows

--- a/java/core/src/test/resources/csv/hris-default-rules_anon-column.csv
+++ b/java/core/src/test/resources/csv/hris-default-rules_anon-column.csv
@@ -1,0 +1,3 @@
+EMPLOYEE_ID,, employee_EMAIL  ,  MANAGER_id  ,  Manager_Email,JOIN_DATE,ROLE
+1,anon1,alice@worklytics.co,2,karen@worklytics.co,2021-01-01,Accounting Manager
+2,anon2,karen@worklytics.co,,,2020-01-01,CEO

--- a/java/core/src/test/resources/csv/hris-default-rules_trailing-commas.csv
+++ b/java/core/src/test/resources/csv/hris-default-rules_trailing-commas.csv
@@ -1,0 +1,3 @@
+EMPLOYEE_ID, employee_EMAIL  ,  MANAGER_id  ,  Manager_Email,JOIN_DATE,ROLE,
+1  ,alice@worklytics.co  ,2,  karen@worklytics.co,2021-01-01,Accounting Manager,
+  2,  karen@worklytics.co,,,2020-01-01,CEO,


### PR DESCRIPTION
### Fixes
  - proxy currently fails on CSVs with trailing `,` in the header, with `IllegalArgumentException : missing column name`; as such is not *strictly* invalid CSV, this PR alters the behavior to process such files

With this fix, behavior will be that unnamed columns (eg, with blank/empty value in the header row), will be preserved as-is. This is the ONLY supported behavior for such columns; they CANNOT be used/referenced by any transforms/rules to alter their values or rename them in any way.



### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no breaking changes; proxy will not longer fail on CSVs with missing column names, but no one should have been depending on such behavior***