### PR TITLE
REST rule (data access policy support) for validating/authorizing requests based on content of request body; cursor PoC

### DIFF
--- a/docs/sources/cursor/README.md
+++ b/docs/sources/cursor/README.md
@@ -1,0 +1,28 @@
+# Cursor
+
+**ALPHA**; may change in backwards incompatible ways and we are NOT committed to supporting it, or making it available to all customers.
+
+
+Our Cursor data connector uses the Admin API to import data about Team Members (accounts),  Daily Usage (metrics), and Usage Events (work events) to Worklytics.
+
+https://docs.cursor.com/account/teams/admin-api
+
+
+## Steps to Connect
+
+See Cursor's documentation for the latest, but as of July 10, 2025, you must create an API key and fill that as a secret in your host platform. The Proxy will then use Basic Authentication when connecting to Cursor.
+
+
+1. Navigate to https://cursor.com/dashboard → Settings tab → Cursor Admin API Keys
+
+2. Click 'Create New API Key'
+
+3. Give your key a descriptive name (e.g., “Usage Dashboard Integration”)
+
+4. Copy the generated key immediately - you won’t see it again; then paste it as the `API_KEY` value in your proxy's host platform. Likely this will be a secret / parameter named `PSOXY_CURSOR_API_KEY`, but the exact name/path may vary by environment.
+
+
+
+
+
+

--- a/docs/sources/cursor/cursor.yaml
+++ b/docs/sources/cursor/cursor.yaml
@@ -1,0 +1,212 @@
+---
+endpoints:
+  - pathTemplate: "/teams/daily-usage-data"
+    allowedQueryParams:
+      - "startDate"
+      - "endDate"
+    transforms:
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..email"
+        encoding: "URL_SAFE_TOKEN"
+      - !<redactRegexMatches>
+        jsonPaths:
+          - "$.data[*].email"
+        redactions:
+          - "(?i)password=[^&]*"
+          - "(?i)token=[^&]*"
+          - "(?i)key=[^&]*"
+    responseSchema:
+      type: "object"
+      properties:
+        data:
+          type: "array"
+          items:
+            $ref: "#/definitions/AccountUsageData"
+        period:
+          $ref: "#/definitions/DataPeriod"
+
+  - pathTemplate: "/teams/members"
+    allowedQueryParams: []
+    transforms:
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..email"
+        encoding: "URL_SAFE_TOKEN"
+      - !<redactRegexMatches>
+        jsonPaths:
+          - "$.teamMembers[*].name"
+        redactions:
+          - ".*"
+    responseSchema:
+      type: "object"
+      properties:
+        teamMembers:
+          type: "array"
+          items:
+            $ref: "#/definitions/TeamMember"
+
+  - pathTemplate: "/teams/filtered-usage-events"
+    allowedQueryParams:
+      - "startDate"
+      - "endDate"
+      - "page"
+      - "pageSize"
+      - "model"
+      - "kindLabel"
+      - "userEmail"
+    transforms:
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..userEmail"
+          - "$..email"
+        encoding: "URL_SAFE_TOKEN"
+      - !<redactRegexMatches>
+        jsonPaths:
+          - "$.usageEvents[*].userEmail"
+        redactions:
+          - "(?i)password=[^&]*"
+          - "(?i)token=[^&]*"
+          - "(?i)key=[^&]*"
+    responseSchema:
+      type: "object"
+      properties:
+        totalUsageEventsCount:
+          type: "integer"
+        pagination:
+          $ref: "#/definitions/Pagination"
+        usageEvents:
+          type: "array"
+          items:
+            $ref: "#/definitions/UsageEvent"
+        period:
+          $ref: "#/definitions/DataPeriod"
+
+definitions:
+  AccountUsageData:
+    type: "object"
+    properties:
+      date:
+        type: "integer"
+        format: "int64"
+      isActive:
+        type: "boolean"
+      totalLinesAdded:
+        type: "integer"
+      totalLinesDeleted:
+        type: "integer"
+      acceptedLinesAdded:
+        type: "integer"
+      acceptedLinesDeleted:
+        type: "integer"
+      totalApplies:
+        type: "integer"
+      totalAccepts:
+        type: "integer"
+      totalRejects:
+        type: "integer"
+      totalTabsShown:
+        type: "integer"
+      totalTabsAccepted:
+        type: "integer"
+      composerRequests:
+        type: "integer"
+      chatRequests:
+        type: "integer"
+      agentRequests:
+        type: "integer"
+      cmdkUsages:
+        type: "integer"
+      subscriptionIncludedReqs:
+        type: "integer"
+      apiKeyReqs:
+        type: "integer"
+      usageBasedReqs:
+        type: "integer"
+      bugbotUsages:
+        type: "integer"
+      mostUsedModel:
+        type: "string"
+      applyMostUsedExtension:
+        type: "string"
+      tabMostUsedExtension:
+        type: "string"
+      clientVersion:
+        type: "string"
+      email:
+        type: "string"
+        format: "email"
+
+  TeamMember:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      email:
+        type: "string"
+        format: "email"
+      role:
+        type: "string"
+        enum: ["member", "admin", "owner"]
+
+  Pagination:
+    type: "object"
+    properties:
+      numPages:
+        type: "integer"
+      currentPage:
+        type: "integer"
+      pageSize:
+        type: "integer"
+      hasNextPage:
+        type: "boolean"
+      hasPreviousPage:
+        type: "boolean"
+
+  UsageEvent:
+    type: "object"
+    properties:
+      timestamp:
+        type: "string"
+        format: "date-time"
+      model:
+        type: "string"
+      kindLabel:
+        type: "string"
+      maxMode:
+        type: "boolean"
+      requestsCosts:
+        type: "number"
+      isTokenBasedCall:
+        type: "boolean"
+      tokenUsage:
+        $ref: "#/definitions/TokenUsage"
+      isFreeBugbot:
+        type: "boolean"
+      userEmail:
+        type: "string"
+        format: "email"
+
+  TokenUsage:
+    type: "object"
+    properties:
+      inputTokens:
+        type: "integer"
+      outputTokens:
+        type: "integer"
+      cacheWriteTokens:
+        type: "integer"
+      cacheReadTokens:
+        type: "integer"
+      totalCents:
+        type: "integer"
+
+  DataPeriod:
+    type: "object"
+    properties:
+      startDate:
+        type: "integer"
+        format: "int64"
+      endDate:
+        type: "integer"
+        format: "int64" 

--- a/docs/sources/cursor/example-api-responses/original/daily-usage-data.json
+++ b/docs/sources/cursor/example-api-responses/original/daily-usage-data.json
@@ -1,0 +1,60 @@
+{
+    "data": [
+        {
+            "date": 1710720000000,
+            "isActive": true,
+            "totalLinesAdded": 1543,
+            "totalLinesDeleted": 892,
+            "acceptedLinesAdded": 1102,
+            "acceptedLinesDeleted": 645,
+            "totalApplies": 87,
+            "totalAccepts": 73,
+            "totalRejects": 14,
+            "totalTabsShown": 342,
+            "totalTabsAccepted": 289,
+            "composerRequests": 45,
+            "chatRequests": 128,
+            "agentRequests": 12,
+            "cmdkUsages": 67,
+            "subscriptionIncludedReqs": 180,
+            "apiKeyReqs": 0,
+            "usageBasedReqs": 5,
+            "bugbotUsages": 3,
+            "mostUsedModel": "gpt-4",
+            "applyMostUsedExtension": ".tsx",
+            "tabMostUsedExtension": ".ts",
+            "clientVersion": "0.25.1",
+            "email": "developer@company.com"
+        },
+        {
+            "date": 1710806400000,
+            "isActive": true,
+            "totalLinesAdded": 2104,
+            "totalLinesDeleted": 1203,
+            "acceptedLinesAdded": 1876,
+            "acceptedLinesDeleted": 987,
+            "totalApplies": 102,
+            "totalAccepts": 91,
+            "totalRejects": 11,
+            "totalTabsShown": 456,
+            "totalTabsAccepted": 398,
+            "composerRequests": 67,
+            "chatRequests": 156,
+            "agentRequests": 23,
+            "cmdkUsages": 89,
+            "subscriptionIncludedReqs": 320,
+            "apiKeyReqs": 15,
+            "usageBasedReqs": 0,
+            "bugbotUsages": 5,
+            "mostUsedModel": "claude-3-opus",
+            "applyMostUsedExtension": ".py",
+            "tabMostUsedExtension": ".py",
+            "clientVersion": "0.25.1",
+            "email": "developer@company.com"
+        }
+    ],
+    "period": {
+        "startDate": 1710720000000,
+        "endDate": 1710892800000
+    }
+}

--- a/docs/sources/cursor/example-api-responses/original/filtered-usage-events.json
+++ b/docs/sources/cursor/example-api-responses/original/filtered-usage-events.json
@@ -1,0 +1,60 @@
+{
+    "totalUsageEventsCount": 1250,
+    "pagination": {
+        "numPages": 25,
+        "currentPage": 1,
+        "pageSize": 50,
+        "hasNextPage": true,
+        "hasPreviousPage": false
+    },
+    "usageEvents": [
+        {
+            "timestamp": "2024-03-19T10:30:00Z",
+            "model": "gpt-4",
+            "kindLabel": "Usage-based",
+            "maxMode": false,
+            "requestsCosts": 0.05,
+            "isTokenBasedCall": true,
+            "tokenUsage": {
+                "inputTokens": 1500,
+                "outputTokens": 750,
+                "cacheWriteTokens": 0,
+                "cacheReadTokens": 0,
+                "totalCents": 25
+            },
+            "isFreeBugbot": false,
+            "userEmail": "developer@company.com"
+        },
+        {
+            "timestamp": "2024-03-19T11:15:00Z",
+            "model": "claude-3-opus",
+            "kindLabel": "Included in Business",
+            "maxMode": true,
+            "requestsCosts": 0.0,
+            "isTokenBasedCall": false,
+            "isFreeBugbot": false,
+            "userEmail": "senior.dev@company.com"
+        },
+        {
+            "timestamp": "2024-03-19T12:00:00Z",
+            "model": "gpt-4",
+            "kindLabel": "Usage-based",
+            "maxMode": false,
+            "requestsCosts": 0.03,
+            "isTokenBasedCall": true,
+            "tokenUsage": {
+                "inputTokens": 800,
+                "outputTokens": 400,
+                "cacheWriteTokens": 0,
+                "cacheReadTokens": 0,
+                "totalCents": 15
+            },
+            "isFreeBugbot": true,
+            "userEmail": "admin@company.com"
+        }
+    ],
+    "period": {
+        "startDate": 1710720000000,
+        "endDate": 1710806400000
+    }
+}

--- a/docs/sources/cursor/example-api-responses/original/team-members.json
+++ b/docs/sources/cursor/example-api-responses/original/team-members.json
@@ -1,0 +1,24 @@
+{
+    "teamMembers": [
+        {
+            "name": "Alex",
+            "email": "developer@company.com",
+            "role": "member"
+        },
+        {
+            "name": "Sam",
+            "email": "admin@company.com",
+            "role": "owner"
+        },
+        {
+            "name": "Jordan",
+            "email": "senior.dev@company.com",
+            "role": "member"
+        },
+        {
+            "name": "Taylor",
+            "email": "team.lead@company.com",
+            "role": "admin"
+        }
+    ]
+}

--- a/docs/sources/cursor/example-api-responses/sanitized/daily-usage-data.json
+++ b/docs/sources/cursor/example-api-responses/sanitized/daily-usage-data.json
@@ -1,0 +1,60 @@
+{
+    "data": [
+        {
+            "date": 1710720000000,
+            "isActive": true,
+            "totalLinesAdded": 1543,
+            "totalLinesDeleted": 892,
+            "acceptedLinesAdded": 1102,
+            "acceptedLinesDeleted": 645,
+            "totalApplies": 87,
+            "totalAccepts": 73,
+            "totalRejects": 14,
+            "totalTabsShown": 342,
+            "totalTabsAccepted": 289,
+            "composerRequests": 45,
+            "chatRequests": 128,
+            "agentRequests": 12,
+            "cmdkUsages": 67,
+            "subscriptionIncludedReqs": 180,
+            "apiKeyReqs": 0,
+            "usageBasedReqs": 5,
+            "bugbotUsages": 3,
+            "mostUsedModel": "gpt-4",
+            "applyMostUsedExtension": ".tsx",
+            "tabMostUsedExtension": ".ts",
+            "clientVersion": "0.25.1",
+            "email": "t~YxpQlV1gzukfVx5cPhRVzYGRnDkb5n1_d-tt6rnsKP4@company.com"
+        },
+        {
+            "date": 1710806400000,
+            "isActive": true,
+            "totalLinesAdded": 2104,
+            "totalLinesDeleted": 1203,
+            "acceptedLinesAdded": 1876,
+            "acceptedLinesDeleted": 987,
+            "totalApplies": 102,
+            "totalAccepts": 91,
+            "totalRejects": 11,
+            "totalTabsShown": 456,
+            "totalTabsAccepted": 398,
+            "composerRequests": 67,
+            "chatRequests": 156,
+            "agentRequests": 23,
+            "cmdkUsages": 89,
+            "subscriptionIncludedReqs": 320,
+            "apiKeyReqs": 15,
+            "usageBasedReqs": 0,
+            "bugbotUsages": 5,
+            "mostUsedModel": "claude-3-opus",
+            "applyMostUsedExtension": ".py",
+            "tabMostUsedExtension": ".py",
+            "clientVersion": "0.25.1",
+            "email": "t~YxpQlV1gzukfVx5cPhRVzYGRnDkb5n1_d-tt6rnsKP4@company.com"
+        }
+    ],
+    "period": {
+        "startDate": 1710720000000,
+        "endDate": 1710892800000
+    }
+}

--- a/docs/sources/cursor/example-api-responses/sanitized/filtered-usage-events.json
+++ b/docs/sources/cursor/example-api-responses/sanitized/filtered-usage-events.json
@@ -1,0 +1,60 @@
+{
+    "totalUsageEventsCount": 1250,
+    "pagination": {
+        "numPages": 25,
+        "currentPage": 1,
+        "pageSize": 50,
+        "hasNextPage": true,
+        "hasPreviousPage": false
+    },
+    "usageEvents": [
+        {
+            "timestamp": "2024-03-19T10:30:00Z",
+            "model": "gpt-4",
+            "kindLabel": "Usage-based",
+            "maxMode": false,
+            "requestsCosts": 0.05,
+            "isTokenBasedCall": true,
+            "tokenUsage": {
+                "inputTokens": 1500,
+                "outputTokens": 750,
+                "cacheWriteTokens": 0,
+                "cacheReadTokens": 0,
+                "totalCents": 25
+            },
+            "isFreeBugbot": false,
+            "userEmail": "t~YxpQlV1gzukfVx5cPhRVzYGRnDkb5n1_d-tt6rnsKP4@company.com"
+        },
+        {
+            "timestamp": "2024-03-19T11:15:00Z",
+            "model": "claude-3-opus",
+            "kindLabel": "Included in Business",
+            "maxMode": true,
+            "requestsCosts": 0.0,
+            "isTokenBasedCall": false,
+            "isFreeBugbot": false,
+            "userEmail": "t~L0nOqR3iBymxHz7eSkXtFaoGlc7p3_f-vv8tpuMlR6@company.com"
+        },
+        {
+            "timestamp": "2024-03-19T12:00:00Z",
+            "model": "gpt-4",
+            "kindLabel": "Usage-based",
+            "maxMode": false,
+            "requestsCosts": 0.03,
+            "isTokenBasedCall": true,
+            "tokenUsage": {
+                "inputTokens": 800,
+                "outputTokens": 400,
+                "cacheWriteTokens": 0,
+                "cacheReadTokens": 0,
+                "totalCents": 15
+            },
+            "isFreeBugbot": true,
+            "userEmail": "t~K9mNpQ2hAxlwGy6dRjWsEZnFkb6o2_e-uu7sotlLQ5@company.com"
+        }
+    ],
+    "period": {
+        "startDate": 1710720000000,
+        "endDate": 1710806400000
+    }
+}

--- a/docs/sources/cursor/example-api-responses/sanitized/team-members.json
+++ b/docs/sources/cursor/example-api-responses/sanitized/team-members.json
@@ -1,0 +1,24 @@
+{
+    "teamMembers": [
+        {
+            "name": "",
+            "email": "t~YxpQlV1gzukfVx5cPhRVzYGRnDkb5n1_d-tt6rnsKP4@company.com",
+            "role": "member"
+        },
+        {
+            "name": "",
+            "email": "t~K9mNpQ2hAxlwGy6dRjWsEZnFkb6o2_e-uu7sotlLQ5@company.com",
+            "role": "owner"
+        },
+        {
+            "name": "",
+            "email": "t~L0nOqR3iBymxHz7eSkXtFaoGlc7p3_f-vv8tpuMlR6@company.com",
+            "role": "member"
+        },
+        {
+            "name": "",
+            "email": "t~M1oPrS4jCznyI8fTlYuGbpHmd8q4_g-ww9uqvNmS7@company.com",
+            "role": "admin"
+        }
+    ]
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/RESTApiSanitizer.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/RESTApiSanitizer.java
@@ -20,22 +20,35 @@ public interface RESTApiSanitizer {
      * @param url to test
      * @return whether url is even allowed to be called via proxy, given Sanitizer rule set
      *
-     * q: some scope question about whether this is beyond Sanitizer responsibility or not
-     *   args for:
-     *      - it's an interpretation of rules
-     *      - correct if 'santizer' is sanitizing an "API" rather than "API response content"
-     *      - sanitization can't really be decoupled from the semantics of the endpoints in question
-     *   args against:
-     *      - could split this into two classes, with one that deals with endpoint level stuff, such
-     *        as 1) what endpoints allowed, and 2) what pseudonymizations and redactions to apply
-     *        to response given the endpoint; and the other(s) which just do the
-     *        pseudonymization/redaction (eg, pseudonymize(jsonPAths, content); redact(jsonPaths, content))
-     *        - just invariably that's quite coupled, per above
+     *         q: some scope question about whether this is beyond Sanitizer responsibility or not
+     *         args for:
+     *         - it's an interpretation of rules
+     *         - correct if 'santizer' is sanitizing an "API" rather than "API response content"
+     *         - sanitization can't really be decoupled from the semantics of the endpoints in
+     *         question
+     *         args against:
+     *         - could split this into two classes, with one that deals with endpoint level stuff,
+     *         such
+     *         as 1) what endpoints allowed, and 2) what pseudonymizations and redactions to apply
+     *         to response given the endpoint; and the other(s) which just do the
+     *         pseudonymization/redaction (eg, pseudonymize(jsonPAths, content); redact(jsonPaths,
+     *         content))
+     *         - just invariably that's quite coupled, per above
      */
     boolean isAllowed(String httpMethod, URL url);
 
     /**
+     * @param httpMethod to test
+     * @param url to test
+     * @param contentType to test
+     * @param requestBody to test
+     * @return whether url is even allowed to be called via proxy, given Sanitizer rule set
+     */
+    boolean isAllowed(String httpMethod, URL url, String contentType, String requestBody);
+
+    /**
      * Headers to include in the request
+     * 
      * @param httpMethod The method to test
      * @param url The url to test
      * @return
@@ -65,7 +78,8 @@ public interface RESTApiSanitizer {
      * @return
      * @throws IOException
      */
-    RESTApiSanitizerImpl.ProcessedStream sanitize(String httpMethod, URL url, InputStream response) throws IOException;
+    RESTApiSanitizerImpl.ProcessedStream sanitize(String httpMethod, URL url, InputStream response)
+            throws IOException;
 
     @RequiredArgsConstructor
     class ProcessedStream {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/auth/JwtAuthorizedResource.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/auth/JwtAuthorizedResource.java
@@ -16,14 +16,14 @@ public interface JwtAuthorizedResource {
 
     /**
      * returns a failure message if invalid, or empty otherwise
+     * 
      * @param signedJWT
      * @return optional with the failure, if any
      */
-    @SneakyThrows
     Optional<String> validate(SignedJWT signedJWT);
 
     /**
-     * @return  the issuer of the JWTs that this resource accepts, without trailing /
+     * @return the issuer of the JWTs that this resource accepts, without trailing /
      */
     String getIssuer();
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/impl/RESTApiSanitizerImpl.java
@@ -11,6 +11,7 @@ import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.rules.Endpoint;
 import com.avaulta.gateway.rules.JsonSchemaFilter;
 import com.avaulta.gateway.rules.JsonSchemaFilterUtils;
+import com.avaulta.gateway.rules.JsonSchemaValidationUtils;
 import com.avaulta.gateway.rules.ParameterSchemaUtils;
 import com.avaulta.gateway.rules.PathTemplateUtils;
 import com.avaulta.gateway.rules.transforms.Transform;
@@ -59,9 +60,10 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     final EmailAddressParser emailAddressParser;
 
 
-    //NOTE: JsonPath seems to be threadsafe
-    //  - https://github.com/json-path/JsonPath/issues/384
-    //  - https://github.com/json-path/JsonPath/issues/187 (earlier issue fixing stuff that wasn't thread-safe)
+    // NOTE: JsonPath seems to be threadsafe
+    // - https://github.com/json-path/JsonPath/issues/384
+    // - https://github.com/json-path/JsonPath/issues/187 (earlier issue fixing stuff that wasn't
+    // thread-safe)
 
     Map<Endpoint, Pattern> compiledAllowedEndpoints;
 
@@ -74,8 +76,8 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
 
     @AssistedInject
     public RESTApiSanitizerImpl(@Assisted RESTRules rules,
-                                @Assisted Pseudonymizer pseudonymizer,
-                                EmailAddressParser emailAddressParser) {
+            @Assisted Pseudonymizer pseudonymizer,
+            EmailAddressParser emailAddressParser) {
         this.rules = rules;
         this.pseudonymizer = pseudonymizer;
         this.emailAddressParser = emailAddressParser;
@@ -99,6 +101,8 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     ConfigService configService;
     @Inject
     SanitizerUtils sanitizerUtils;
+    @Inject
+    JsonSchemaValidationUtils jsonSchemaValidationUtils;
 
     @Inject
     @Named("ipEncryptionStrategy")
@@ -117,11 +121,59 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     }
 
     @Override
+    public boolean isAllowed(String httpMethod, URL url, String contentType, String requestBody) {
+        if (rules.getAllowAllEndpoints()) {
+            return true;
+        }
+        Optional<Pair<Pattern, Endpoint>> matchingEndpoint = getEndpoint(httpMethod, url);
+
+        if (matchingEndpoint.isEmpty()) {
+            return false;
+        }
+
+        Endpoint endpoint = matchingEndpoint.get().getValue();
+
+        if (endpoint.getRequestBody() == null) {
+            return true;
+        } else {
+            if (endpoint.getRequestBody().getRequired() && StringUtils.isEmpty(requestBody)) {
+                return false;
+            }
+            if (endpoint.getRequestBody().getContent() == null) {
+                // no schemas defined for request body, so we allow it
+                return true;
+            } else {
+                // TODO: support something OTHER than 'application/json' ???
+                // text/plain, application/x-www-form-urlencoded, ... OpenAPI 3 does this, still
+                // using JsonSchema
+                JsonSchemaFilter schema = endpoint.getRequestBody().getContent().get(contentType);
+                if (schema == null) {
+                    // no schema defined for request body, so we allow it
+                    return true;
+                } else {
+                    if (contentType.equals("application/json")) {
+                        return jsonSchemaValidationUtils.validateJsonBySchema(requestBody, schema);
+                    } else if (contentType.equals("application/x-www-form-urlencoded")) {
+                        // TODO: support this. it's defined in OpenAPI 3.0, but basically we'd need
+                        // to deserialize x-www-form-urlencoded into a java POJO, and validate that
+                        // ... not sure how nested stuff works, etc.
+                        throw new UnsupportedOperationException(
+                                "application/x-www-form-urlencoded not supported");
+                    } else {
+                        throw new UnsupportedOperationException(
+                                "content type not supported: " + contentType);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
     public Optional<Collection<String>> getAllowedHeadersToForward(String httpMethod, URL url) {
         return getEndpoint(httpMethod, url)
-            .map(Pair::getRight)
-            .map(endpoint -> endpoint.getAllowedRequestHeadersToForward())
-            .orElse(Optional.empty());
+                .map(Pair::getRight)
+                .map(endpoint -> endpoint.getAllowedRequestHeadersToForward())
+                .orElse(Optional.empty());
     }
 
     @SneakyThrows
@@ -132,8 +184,9 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
             return jsonResponse;
         }
         // Convert input String to InputStream (UTF-8 encoding)
-        try (InputStream input = new ByteArrayInputStream(jsonResponse.getBytes(StandardCharsets.UTF_8))) {
-             final ProcessedStream processedStream = sanitize(httpMethod, url, input);
+        try (InputStream input =
+                new ByteArrayInputStream(jsonResponse.getBytes(StandardCharsets.UTF_8))) {
+            final ProcessedStream processedStream = sanitize(httpMethod, url, input);
 
             // Read all bytes from the sanitized stream
             byte[] sanitizedBytes = processedStream.getStream().readAllBytes();
@@ -152,10 +205,13 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
 
     @SneakyThrows
     @Override
-    public ProcessedStream sanitize(String httpMethod, URL url, InputStream response) throws IOException {
-        //extra check ...
+    public ProcessedStream sanitize(String httpMethod, URL url, InputStream response)
+            throws IOException {
+        // extra check ...
         if (!isAllowed(httpMethod, url)) {
-            throw new IllegalStateException(String.format("Sanitizer called to sanitize response that should not have been retrieved: %s", url));
+            throw new IllegalStateException(String.format(
+                    "Sanitizer called to sanitize response that should not have been retrieved: %s",
+                    url));
         }
         Optional<Pair<Pattern, Endpoint>> matchingEndpoint = getEndpoint(httpMethod, url);
 
@@ -164,7 +220,7 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
             return new ProcessedStream(response, CompletableFuture.completedFuture(null));
         }
 
-        //q: overkill for NON-ndjson case?
+        // q: overkill for NON-ndjson case?
 
         // Create piped stream pair
         PipedOutputStream outPipe = new PipedOutputStream();
@@ -179,21 +235,26 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
             JsonFactory factory = objectMapper.getFactory();
 
             try (JsonParser parser = factory.createParser(response);
-                 OutputStreamWriter writer = new OutputStreamWriter(outPipe, StandardCharsets.UTF_8);
-                 BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
+                    OutputStreamWriter writer =
+                            new OutputStreamWriter(outPipe, StandardCharsets.UTF_8);
+                    BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
 
                 boolean first = true;
 
                 while (parser.nextToken() != null) {
-                    // in theory, should parse only the 'next' JSON object from the stream, such that NDJSON, or even "{}{}" works
-                    // string --> jackson jsonNode --> string -> jayway object  for compatibility with jayway jsonpath
-                    // despite jackson provider underneath, Jayway JSONPath seems not do deal with native jackson JsonNode
+                    // in theory, should parse only the 'next' JSON object from the stream, such
+                    // that NDJSON, or even "{}{}" works
+                    // string --> jackson jsonNode --> string -> jayway object for compatibility
+                    // with jayway jsonpath
+                    // despite jackson provider underneath, Jayway JSONPath seems not do deal with
+                    // native jackson JsonNode
                     // TODO: figure out a way to streamline this parsing
                     Object node = jsonConfiguration.jsonProvider().parse(
-                        objectMapper.writeValueAsString(objectMapper.readTree(parser)));
+                            objectMapper.writeValueAsString(objectMapper.readTree(parser)));
 
                     Object sanitized = sanitize(endpoint, node);
-                    if (!first) bufferedWriter.write("\n");
+                    if (!first)
+                        bufferedWriter.write("\n");
                     bufferedWriter.write(jsonConfiguration.jsonProvider().toJson(sanitized));
                     first = false;
                 }
@@ -219,28 +280,32 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     /**
      * sanitized a response JSON by applying the endpoint's response schema and transforms
      *
-     * if endpoint allows for ndjson, we expect this to be just a single JSON object at a time, and you call this once per row in the response
+     * if endpoint allows for ndjson, we expect this to be just a single JSON object at a time, and
+     * you call this once per row in the response
      */
     private Object sanitize(Endpoint endpoint, Object jsonResponse) {
         Object document = endpoint.getResponseSchemaOptional()
                 .map(schema -> {
-                    //q: this read
+                    // q: this read
                     try {
-                        //TODO: jayway jsonpath Object --> String --> jayway jsonpath Object here is needlessly inefficient
+                        // TODO: jayway jsonpath Object --> String --> jayway jsonpath Object here
+                        // is needlessly inefficient
                         String json = jsonConfiguration.jsonProvider().toJson(jsonResponse);
-                        return jsonConfiguration.jsonProvider().parse(jsonSchemaFilterUtils.filterJsonBySchema(json, schema, getRootDefinitions()));
+                        return jsonConfiguration.jsonProvider().parse(jsonSchemaFilterUtils
+                                .filterJsonBySchema(json, schema, getRootDefinitions()));
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
                 })
                 .orElse(jsonResponse);
 
-            if (ObjectUtils.isNotEmpty(endpoint.getTransforms())) {
-                for (Transform transform : endpoint.getTransforms()) {
-                    sanitizerUtils.applyTransform(getPseudonymizer(), transform, document, this.compiledTransforms);
-                }
+        if (ObjectUtils.isNotEmpty(endpoint.getTransforms())) {
+            for (Transform transform : endpoint.getTransforms()) {
+                sanitizerUtils.applyTransform(getPseudonymizer(), transform, document,
+                        this.compiledTransforms);
             }
-            return document;
+        }
+        return document;
     }
 
 
@@ -249,8 +314,9 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
             synchronized ($writeLock) {
                 if (compiledAllowedEndpoints == null) {
                     compiledAllowedEndpoints = rules.getEndpoints().stream()
-                        .collect(Collectors.toMap(Function.identity(),
-                            endpoint -> Pattern.compile(effectiveRegex(endpoint), CASE_INSENSITIVE)));
+                            .collect(Collectors.toMap(Function.identity(),
+                                    endpoint -> Pattern.compile(effectiveRegex(endpoint),
+                                            CASE_INSENSITIVE)));
                 }
             }
         }
@@ -260,24 +326,26 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
     @VisibleForTesting
     String effectiveRegex(Endpoint endpoint) {
         return Optional.ofNullable(endpoint.getPathRegex())
-            .orElseGet(() -> pathTemplateUtils.asRegex(endpoint.getPathTemplate()));
+                .orElseGet(() -> pathTemplateUtils.asRegex(endpoint.getPathTemplate()));
     }
 
     boolean allowedQueryParams(Endpoint endpoint, List<Pair<String, String>> queryParams) {
         boolean matchesAllowed = endpoint.getAllowedQueryParamsOptional()
-            .map(allowedParams -> allowedParams.containsAll(queryParams.stream().map(Pair::getKey).collect(Collectors.toList())))
-            .orElse(true);
+                .map(allowedParams -> allowedParams.containsAll(
+                        queryParams.stream().map(Pair::getKey).collect(Collectors.toList())))
+                .orElse(true);
         return matchesAllowed
-            && endpoint.getQueryParamSchemasOptional()
-            .map(schemas -> parameterSchemaUtils.validateAll(schemas, queryParams))
-            .orElse(true);
+                && endpoint.getQueryParamSchemasOptional()
+                        .map(schemas -> parameterSchemaUtils.validateAll(schemas, queryParams))
+                        .orElse(true);
     }
 
     JsonSchemaFilter getRootDefinitions() {
         if (rootDefinitions == null) {
             synchronized ($writeLock) {
                 if (rootDefinitions == null) {
-                    rootDefinitions = JsonSchemaFilter.builder().definitions(rules.getDefinitions()).build();
+                    rootDefinitions =
+                            JsonSchemaFilter.builder().definitions(rules.getDefinitions()).build();
                 }
             }
         }
@@ -289,20 +357,21 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
         if (targetHostPath == null) {
             synchronized ($writeLock) {
                 if (targetHostPath == null) {
-                    targetHostPath = configService.getConfigPropertyAsOptional(ApiModeConfigProperty.TARGET_HOST)
-                        .map(s -> {
-                            try {
-                                if (!s.startsWith("https://")) {
-                                    s = "https://" + s;
+                    targetHostPath = configService
+                            .getConfigPropertyAsOptional(ApiModeConfigProperty.TARGET_HOST)
+                            .map(s -> {
+                                try {
+                                    if (!s.startsWith("https://")) {
+                                        s = "https://" + s;
+                                    }
+                                    return new URL(s).getPath();
+                                } catch (MalformedURLException e) {
+                                    log.log(Level.WARNING, "Invalid API_HOST: " + s, e);
+                                    // shouldn't happen
+                                    return "";
                                 }
-                                return new URL(s).getPath();
-                            } catch (MalformedURLException e) {
-                                log.log(Level.WARNING, "Invalid API_HOST: " + s, e);
-                                //shouldn't happen
-                                return "";
-                            }
-                        })
-                        .orElse("");
+                            })
+                            .orElse("");
                 }
             }
         }
@@ -324,18 +393,22 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
             if (entry.getKey().getPathTemplate() != null) {
                 Matcher matcher = entry.getValue().matcher(stripTargetHostPath(url.getPath()));
                 if (matcher.matches()) {
-                    // this should NOT match on empty path segments; eg "/foo//bar" should not match "/foo/{param}/bar"
+                    // this should NOT match on empty path segments; eg "/foo//bar" should not match
+                    // "/foo/{param}/bar"
                     boolean allParamsValid =
-                        entry.getKey().getPathParameterSchemasOptional()
-                            .map(schemas -> schemas.entrySet().stream()
-                                .allMatch(paramSchema -> parameterSchemaUtils.validate(paramSchema.getValue(), matcher.group(paramSchema.getKey()))))
-                            .orElse(true);
+                            entry.getKey().getPathParameterSchemasOptional()
+                                    .map(schemas -> schemas.entrySet().stream()
+                                            .allMatch(paramSchema -> parameterSchemaUtils.validate(
+                                                    paramSchema.getValue(),
+                                                    matcher.group(paramSchema.getKey()))))
+                                    .orElse(true);
 
-                    //q: need to catch possible IllegalArgumentException if path parameter defined in `pathParameterSchemas`
+                    // q: need to catch possible IllegalArgumentException if path parameter defined
+                    // in `pathParameterSchemas`
                     // not in the path template??
 
                     return allParamsValid &&
-                        allowedQueryParams(entry.getKey(), URLUtils.parseQueryParams(url));
+                            allowedQueryParams(entry.getKey(), URLUtils.parseQueryParams(url));
                 }
             }
             return false;
@@ -344,17 +417,17 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
 
     @VisibleForTesting
     Predicate<Endpoint> allowsHttpMethod(@NonNull String httpMethod) {
-        return (endpoint) ->
-            endpoint.getAllowedMethods()
-                .map(methods -> methods.stream().map(String::toUpperCase).collect(Collectors.toList())
-                    .contains(httpMethod.toUpperCase()))
+        return (endpoint) -> endpoint.getAllowedMethods()
+                .map(methods -> methods.stream().map(String::toUpperCase)
+                        .collect(Collectors.toList())
+                        .contains(httpMethod.toUpperCase()))
                 .orElse(true);
     }
 
     @VisibleForTesting
     Predicate<Map.Entry<Endpoint, Pattern>> getHasPathRegexMatchingUrl(String relativeUrl) {
-        return (entry) ->
-            entry.getKey().getPathRegex() != null && entry.getValue().matcher(relativeUrl).matches();
+        return (entry) -> entry.getKey().getPathRegex() != null
+                && entry.getValue().matcher(relativeUrl).matches();
     }
 
 
@@ -363,19 +436,24 @@ public class RESTApiSanitizerImpl implements RESTApiSanitizer {
         String relativeUrl = stripTargetHostPath(URLUtils.relativeURL(url));
 
         Predicate<Map.Entry<Endpoint, Pattern>> hasPathRegexMatchingUrl =
-            getHasPathRegexMatchingUrl(relativeUrl);
+                getHasPathRegexMatchingUrl(relativeUrl);
 
         Predicate<Map.Entry<Endpoint, Pattern>> hasPathTemplateMatchingUrl =
-            getHasPathTemplateMatchingUrl(url);
+                getHasPathTemplateMatchingUrl(url);
 
         Predicate<Endpoint> allowsHttpMethod = allowsHttpMethod(httpMethod);
 
         return getCompiledAllowedEndpoints().entrySet().stream()
-            .filter(entry -> hasPathRegexMatchingUrl.test(entry) || hasPathTemplateMatchingUrl.test(entry))
-            .filter(entry -> allowedQueryParams(entry.getKey(), URLUtils.parseQueryParams(url))) // redundant in the pathTemplate case
-            .filter(entry -> allowsHttpMethod.test(entry.getKey()))
-            .findAny()
-            .map(entry -> Pair.of(entry.getValue(), entry.getKey()));
+                .filter(entry -> hasPathRegexMatchingUrl.test(entry)
+                        || hasPathTemplateMatchingUrl.test(entry))
+                .filter(entry -> allowedQueryParams(entry.getKey(), URLUtils.parseQueryParams(url))) // redundant
+                                                                                                     // in
+                                                                                                     // the
+                                                                                                     // pathTemplate
+                                                                                                     // case
+                .filter(entry -> allowsHttpMethod.test(entry.getKey()))
+                .findAny()
+                .map(entry -> Pair.of(entry.getValue(), entry.getKey()));
     }
 
 }

--- a/java/gateway-core/pom.xml
+++ b/java/gateway-core/pom.xml
@@ -95,6 +95,13 @@
             <version>${dependency.jackson.version}</version>
         </dependency>
 
+        <!-- json schema validator-->
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.5.8</version>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/Endpoint.java
@@ -9,11 +9,12 @@ import lombok.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@JsonPropertyOrder({"pathRegex", "pathTemplate", "allowedQueryParams", "supportedHeaders", "transforms"})
+@JsonPropertyOrder({"pathRegex", "pathTemplate", "allowedQueryParams", "supportedHeaders",
+        "transforms"})
 @Builder(toBuilder = true)
 @With
-@AllArgsConstructor //for builder
-@NoArgsConstructor //for Jackson
+@AllArgsConstructor // for builder
+@NoArgsConstructor // for Jackson
 @Getter
 public class Endpoint {
 
@@ -21,8 +22,8 @@ public class Endpoint {
      * path template, eg, /api/v1/{id}/foo/{bar}
      *
      * @see "https://swagger.io/docs/specification/paths-and-operations/"
-     * <p>
-     * if provided, has the effect of pathRegex = "^/api/v1/[^/]+/foo/[^/]+$"
+     *      <p>
+     *      if provided, has the effect of pathRegex = "^/api/v1/[^/]+/foo/[^/]+$"
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String pathTemplate;
@@ -45,9 +46,9 @@ public class Endpoint {
      * schemas used to validate path parameters
      *
      * <p>
-     *   - if provided, values matched to a named parameter in the pathTemplate will be validated
-     *     against the schema provided here.
-     *   - if no schema is provided for a given parameter, any values is permitted.
+     * - if provided, values matched to a named parameter in the pathTemplate will be validated
+     * against the schema provided here.
+     * - if no schema is provided for a given parameter, any values is permitted.
      * </p>
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -58,7 +59,7 @@ public class Endpoint {
         return Optional.ofNullable(pathParameterSchemas);
     }
 
-    //if provided, only query params in this list will be allowed
+    // if provided, only query params in this list will be allowed
     @JsonInclude(JsonInclude.Include.NON_NULL)
     List<String> allowedQueryParams;
 
@@ -71,9 +72,9 @@ public class Endpoint {
      * schemas used to validate query parameters
      *
      * <p>
-     *   - if a schema is provided for a named parameter here, the value for this parameter in the
-     *     request will be validated against the schema.
-     *   - if no scheam provided for the named parameter, any value is permitted.
+     * - if a schema is provided for a named parameter here, the value for this parameter in the
+     * request will be validated against the schema.
+     * - if no scheam provided for the named parameter, any value is permitted.
      * </p>
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -83,6 +84,8 @@ public class Endpoint {
     public Optional<Map<String, QueryParameterSchema>> getQueryParamSchemasOptional() {
         return Optional.ofNullable(queryParamSchemas);
     }
+
+
 
     /**
      * if provided, only HTTP methods in this list will be allowed (eg, GET, HEAD, etc)
@@ -112,11 +115,19 @@ public class Endpoint {
     }
 
     /**
+     * schema used to validate the request body, if any
+     * if provided, the request body will be validated against the schema provided here.
+     * if no schema is provided, any request body is permitted.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    RequestBodySchema requestBody;
+
+    /**
      * if provided HTTP response will be *filtered* against this schema, with any nodes in the JSON
      * that are not present in the schema being removed.
      *
      * (do not confuse this with plain JSON Schema, which is typically used for validation rather
-     *  than filtering)
+     * than filtering)
      *
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -136,8 +147,10 @@ public class Endpoint {
     public Endpoint clone() {
         return this.toBuilder()
                 .clearTransforms()
-                .transforms(this.transforms.stream().map(Transform::clone).collect(Collectors.toList()))
-                .allowedQueryParams(this.getAllowedQueryParamsOptional().map(ArrayList::new).orElse(null))
+                .transforms(
+                        this.transforms.stream().map(Transform::clone).collect(Collectors.toList()))
+                .allowedQueryParams(
+                        this.getAllowedQueryParamsOptional().map(ArrayList::new).orElse(null))
                 .pathTemplate(this.pathTemplate)
                 .allowedMethods(this.allowedMethods)
                 .allowedRequestHeadersToForward(this.allowedRequestHeadersToForward)

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchema.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchema.java
@@ -3,6 +3,7 @@ package com.avaulta.gateway.rules;
 
 import java.util.List;
 import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
  * This is a simplified implementation that supports basic object validation
  * without deep nesting or complex JSON Schema features.
  */
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor // for builder
 @Data
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 
 public class JsonSchema {
+
 
     String type;
 

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchema.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchema.java
@@ -1,0 +1,66 @@
+
+package com.avaulta.gateway.rules;
+
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * a JsonSchema container class, meant for serializing/deserializing JsonSchemas
+ * 
+ * should be mappable to/from networknt's JsonSchema
+ * 
+ * This is a simplified implementation that supports basic object validation
+ * without deep nesting or complex JSON Schema features.
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor // for builder
+@Data
+@JsonPropertyOrder({"type", "format", "items", "properties", "required", "enumValues",
+        "additionalProperties"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+
+public class JsonSchema {
+
+    String type;
+
+    // only applicable if type==String
+    String format;
+
+    Map<String, JsonSchema> properties;
+
+    // only applicable if type==array
+    JsonSchema items;
+
+    // List of required property names (only for objects)
+    List<String> required;
+
+    // Pattern for string validation
+    String pattern;
+
+    // Enum values for string validation
+    List<String> enumValues;
+
+    // Whether additional properties are allowed (only for objects); default is true, consistent
+    // with JsonSchema standard
+    Boolean additionalProperties;
+
+    public enum StringFormat {
+        PSEUDONYM,
+        ;
+
+        public String getStringEncoding() {
+            return this.name().replace("_", "-").toLowerCase();
+        }
+
+        static StringFormat parse(String encoded) {
+            return StringFormat.valueOf(encoded.replace("-", "_").toUpperCase());
+        }
+    }
+}

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaValidationUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaValidationUtils.java
@@ -1,0 +1,56 @@
+
+package com.avaulta.gateway.rules;
+
+import java.util.Set;
+import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.ExecutionContext;
+import com.networknt.schema.Format;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import com.networknt.schema.JsonMetaSchema;
+
+@RequiredArgsConstructor
+public class JsonSchemaValidationUtils {
+
+
+    final ObjectMapper objectMapper;
+    final JsonMetaSchema metaSchema = JsonMetaSchema.builder(JsonMetaSchema.getV202012())
+            .format(new PseudonymFormat()).build();
+    final JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(VersionFlag.V202012,
+            builder -> builder.metaSchema(metaSchema));
+
+    @SneakyThrows
+    public boolean validateJsonBySchema(String jsonString,
+            com.avaulta.gateway.rules.JsonSchema schema) {
+        JsonNode deserialized = objectMapper.readTree(jsonString);
+
+        // TODO: cache this??? in practice, each instance is only going to have 3-4 of them. so why
+        // the object conversion EVERY time?
+        JsonNode schemaNode = objectMapper.valueToTree(schema);
+        JsonSchema jsonSchema = jsonSchemaFactory.getSchema(schemaNode);
+
+        Set<ValidationMessage> validationMessages = jsonSchema.validate(deserialized);
+        return validationMessages.isEmpty();
+    }
+}
+
+
+class PseudonymFormat implements Format {
+
+    @Override
+    public boolean matches(ExecutionContext executionContext, String value) {
+        return UrlSafeTokenPseudonymEncoder.REVERSIBLE_PSEUDONYM_PATTERN.matcher(value).matches();
+    }
+
+    @Override
+    public String getName() {
+        return "pseudonym";
+    }
+}
+

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/RequestBodySchema.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/RequestBodySchema.java
@@ -1,0 +1,33 @@
+package com.avaulta.gateway.rules;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * variation on OpenAPI 3.0, a body schema for a requests.
+ */
+@Builder(toBuilder = true)
+@AllArgsConstructor // for builder
+@NoArgsConstructor // for Jackson
+@Data
+public class RequestBodySchema {
+
+    /**
+     * whether the request body is required (default false)
+     */
+    Boolean required;
+
+
+    /**
+     * map of content-type to schema
+     * 
+     * eg `application/json` -> schema
+     * 
+     */
+    private Map<String, JsonSchema> content;
+
+}

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaValidationUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaValidationUtilsTest.java
@@ -1,0 +1,133 @@
+package com.avaulta.gateway.rules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonSchemaValidationUtilsTest {
+
+    private JsonSchemaValidationUtils validationUtils;
+    private com.avaulta.gateway.rules.JsonSchema testSchema;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        validationUtils = new JsonSchemaValidationUtils(objectMapper);
+
+        // Create the test schema with representative subset
+        testSchema = createTestSchema();
+    }
+
+    private com.avaulta.gateway.rules.JsonSchema createTestSchema() {
+        Map<String, com.avaulta.gateway.rules.JsonSchema> properties = new HashMap<>();
+
+        // startDate - number, optional
+        properties.put("startDate", com.avaulta.gateway.rules.JsonSchema.builder()
+                .type("number")
+                .build());
+
+        // email - string, optional
+        properties.put("email", com.avaulta.gateway.rules.JsonSchema.builder()
+                .type("string")
+                .build());
+
+        return com.avaulta.gateway.rules.JsonSchema.builder()
+                .type("object")
+                .properties(properties)
+                .additionalProperties(false) // Explicitly disallow extra fields
+                .build();
+    }
+
+    @Test
+    void testValidateJsonBySchema_ValidEmptyObject() {
+        String jsonString = "{}";
+        assertTrue(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_ValidWithAllFields() {
+        String jsonString = """
+                {
+                    "startDate": 1640995200000,
+                    "email": "test@example.com"
+                }
+                """;
+        assertTrue(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_ValidWithNumberField() {
+        String jsonString = """
+                {
+                    "startDate": 1640995200000
+                }
+                """;
+        assertTrue(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_ValidWithStringField() {
+        String jsonString = """
+                {
+                    "email": "test@example.com"
+                }
+                """;
+        assertTrue(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_InvalidNotObject() {
+        String jsonString = "[]";
+        assertFalse(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_InvalidExtraField() {
+        String jsonString = """
+                {
+                    "startDate": 1640995200000,
+                    "extraField": "should not be allowed"
+                }
+                """;
+        assertFalse(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_InvalidWrongTypeForNumber() {
+        String jsonString = """
+                {
+                    "startDate": "not a number"
+                }
+                """;
+        assertFalse(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @Test
+    void testValidateJsonBySchema_InvalidWrongTypeForString() {
+        String jsonString = """
+                {
+                    "email": 12345
+                }
+                """;
+        assertFalse(validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "p~asdfasdfasdfasdfasdfasdfasdfsadfasdfasdfasdfasdf, true",
+            "alice@acme.com, false"
+    })
+    void testPseudonymFormat(String value, boolean expected) {
+        testSchema = com.avaulta.gateway.rules.JsonSchema.builder()
+                .type("string").format("pseudonym").build();
+        assertEquals(expected, validationUtils.validateJsonBySchema("\"${value}\"", testSchema));
+    }
+
+}

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaValidationUtilsTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/rules/JsonSchemaValidationUtilsTest.java
@@ -127,7 +127,19 @@ public class JsonSchemaValidationUtilsTest {
     void testPseudonymFormat(String value, boolean expected) {
         testSchema = com.avaulta.gateway.rules.JsonSchema.builder()
                 .type("string").format("pseudonym").build();
-        assertEquals(expected, validationUtils.validateJsonBySchema("\"${value}\"", testSchema));
+        String jsonString = "\"" + value + "\"";
+        assertEquals(expected, validationUtils.validateJsonBySchema(jsonString, testSchema));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "p~asdfasdfasdfasdfasdfasdfasdfsadfasdfasdfasdfasdf, true",
+            "alice@acme.com, false"
+    })
+    void testPseudonymPattern(String value, boolean expected) {
+        testSchema = com.avaulta.gateway.rules.JsonSchema.builder()
+                .type("string").pattern("^p~[a-zA-Z0-9_-]{43}$").build();
+        String jsonString = "\"" + value + "\"";
+        assertEquals(expected, validationUtils.validateJsonBySchema(jsonString, testSchema));
+    }
 }


### PR DESCRIPTION
### Features
- add validation of request bodies via rules base on JsonSchema, so we can auth POST/PUT request params
- `cursor` integration
- `windsurf` integration


### TODO
- [ ] spec for `cursor`
- [ ] spec, rules, examples for `windsurf`
- [ ] test tool support for POST/PUT requests
- [ ] support for 

### Change implications

- **dependencies added/changed?** **yes, new networknt JsonSchema lib, rather than implement our own**
- **something important to note in future release notes?** **cursor integration alpha, 
