### PR TITLE
misc improvements: java24, async mem

### DIFF
--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -16,6 +16,11 @@ on:
         type: string
         description: java distribution to use # see https://github.com/actions/setup-java#supported-distributions
         default: corretto
+      maven-version:
+        required: false
+        type: string
+        description: maven version to use # see https://github.com/s4u/setup-maven-action#supported-version-syntax
+        default: '3.9.10' # 3.9.10+ is required for Java 24; in theory, we support earlier shoudl we test?
 
 jobs:
   ci_java:
@@ -29,6 +34,11 @@ jobs:
           java-version: ${{ inputs.java-version }}
           # https://github.com/actions/setup-java#supported-distributions
           distribution: ${{ inputs.java-distribution }}
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@v1
+        with:
+          java-version: ${{ inputs.java-version }}
+          maven-version: ${{ inputs.maven-version }}
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -19,6 +19,7 @@ jobs:
     uses: ./.github/workflows/build-java.yaml
     with:
       java-version: '17'
+      maven-version: '3.6.3' # just for interests sake
 
   # Java 21 - released 19 Sept 2023, supported until Sept 2028 (LTS)
   ci_java21:

--- a/.github/workflows/ci-java-all.yaml
+++ b/.github/workflows/ci-java-all.yaml
@@ -32,10 +32,8 @@ jobs:
     with:
       java-version: '23'
 
-# Java 24 disabled, pending Maven releasing 3.9.10 or 4.x version that supports Java 24
-# specific issue is https://issues.apache.org/jira/browse/MNG-8248
-#  # Java 24 - released 18 March 2025, supported until Sept 2025
-#  ci_java24:
-#    uses: ./.github/workflows/build-java.yaml
-#    with:
-#      java-version: '24'
+ # Java 24 - released 18 March 2025, supported until Sept 2025
+ ci_java24:
+   uses: ./.github/workflows/build-java.yaml
+   with:
+     java-version: '24'

--- a/docs/README.md
+++ b/docs/README.md
@@ -214,11 +214,10 @@ You will need all the following in your deployment environment (eg, your laptop)
 | Tool                                         | Version              | Test Command          |
 |----------------------------------------------|----------------------|-----------------------|
 | [git](https://git-scm.com/)                  | 2.17+                | `git --version`       |
-| [Maven](https://maven.apache.org/)           | 3.6+                 | `mvn -v`              |
-| [Java JDK 17+](https://openjdk.org/install/) | 17, 21 (see notes) | `mvn -v \| grep Java` |
+| [Maven](https://maven.apache.org/)           | 3.6+ ; 3.9.10+ required for java 24  | `mvn -v`              |
+| [Java JDK 17+](https://openjdk.org/install/) | 17, 21, 24 (see notes) | `mvn -v \| grep Java` |
 | [Terraform](https://www.terraform.io/)       | 1.6+, < 2.0          | `terraform version`   |
 
-NOTE: as of Apr 8, 2024, although Java 24 has been released Maven 3.9.9 is not compatible with it. Maven has fixed this, but has yet to release a version 3.9.10 or 4.0.x with the fix. Until then, we don't officially support Java 24.
 
 NOTE: we will support Java versions for duration of official support windows, in particular the LTS versions. Minor versions, such as 18-20, 22-23 which are out of official support, may work but are not routinely tested.
 

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -207,6 +207,7 @@ module "api_connector" {
   side_output_original                  = try(local.custom_original_side_outputs[each.key], null)
   side_output_sanitized                 = try(local.sanitized_side_outputs[each.key], null)
   enable_async_processing               = each.value.enable_async_processing
+  memory_size_mb                        = each.value.enable_async_processing ? 1024 : 512 # default is 512; double it for async case, to give additional margin
 
   todos_as_local_files = var.todos_as_local_files
   todo_step            = var.todo_step

--- a/tools/check-prereqs.sh
+++ b/tools/check-prereqs.sh
@@ -50,10 +50,20 @@ JAVA_VERSION_MAJOR=$(echo $JAVA_VERSION | sed -n 's/^Java version: \([0-9]*\).*/
 
 printf "Your Maven installation uses ${BLUE}${JAVA_VERSION}${NC}.\n"
 
-if [[  "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21  && "$JAVA_VERSION_MAJOR" != 23  ]]; then
-  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires an Oracle-supported version of Java 17 or later;  as of April 2025, this includes Java 17 or 21. See https://maven.apache.org/install.html\n"
+if [[  "$JAVA_VERSION_MAJOR" != 17 && "$JAVA_VERSION_MAJOR" != 21  && "$JAVA_VERSION_MAJOR" != 23  && "$JAVA_VERSION_MAJOR" != 24 ]]; then
+  printf "${RED}This Java version appears to be unsupported. You should upgrade it, or may have compile errors.${NC} Psoxy requires an Oracle-supported version of Java 17 or later;  as of April 2025, this includes Java 17, 21, or 24. See https://maven.apache.org/install.html\n"
   if $HOMEBREW_AVAILABLE; then printf "or as you have Homebrew available, run ${BLUE}brew install openjdk@17${NC}\n"; fi
   printf "If you have an alternative JDK installed, then you must update your ${BLUE}JAVA_HOME${NC} environment variable to point to it.\n"
+fi
+
+printf "\n"
+
+# if java > 23, then mvn must be 3.9.10+
+if (( $(echo "$JAVA_VERSION_MAJOR > 23" | bc ) == 1 )); then
+  if (( $(echo "$MVN_VERSION_MAJOR_MINOR < 3.9.10" | bc ) == 1 )); then
+    printf "${RED}Maven < 3.9.10 has compatibility issues with Java 24.${NC} If you're using Java 24, psoxy will NOT build correctly unless you upgrade Maven to 3.9.10 or later.\n"
+    printf "See https://maven.apache.org/install.html\n"
+  fi
 fi
 
 printf "\n"


### PR DESCRIPTION
### Features
 - bump mem in async
 - java 24 support, testing (prev blocked by Maven bug)

### Change implications

 - dependencies added/changed? **yes (explain) - maven 3.9.10+ if java24+**
 - something important to note in future release notes? **no**
