### PR TITLE
json schema filter / parameter schema `anyOf` (replacing `oneOf`/`or`)

### DIFF
--- a/docs/sources/google-workspace/gemini-in-workspace-apps/gemini-in-workspace-apps.yaml
+++ b/docs/sources/google-workspace/gemini-in-workspace-apps/gemini-in-workspace-apps.yaml
@@ -18,7 +18,7 @@ endpoints:
           - "$.items[*].ipAddress"
     pathParameterSchemas:
       userKey:
-        or:
+        anyOf:
           - type: "string"
             enum:
               - "all"

--- a/docs/sources/salesforce/salesforce.yaml
+++ b/docs/sources/salesforce/salesforce.yaml
@@ -425,7 +425,7 @@ endpoints:
         records:
           type: "array"
           items:
-            oneOf:
+            anyOf:
               - type: "object"
                 properties: {}
                 _if:

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/salesforce/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/salesforce/PrebuiltSanitizerRules.java
@@ -334,7 +334,7 @@ public class PrebuiltSanitizerRules {
                     put("records", JsonSchemaFilter.builder()
                             .type("array")
                             .items(JsonSchemaFilter.builder()
-                                    .oneOf(Arrays.asList(
+                                    .anyOf(Arrays.asList(
                                                     JsonSchemaFilter.builder().type("object")
                                                             .properties(Collections.emptyMap())._if(JsonSchemaFilterUtils.ConditionJsonSchema.builder().properties(new LinkedHashMap<String, JsonSchemaFilter>() {{ //req for java8-backwards compatibility
                                                                 put("attributes", buildAttributeWithType("User"));

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilter.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilter.java
@@ -1,16 +1,20 @@
 package com.avaulta.gateway.rules;
 
-import com.fasterxml.jackson.annotation.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.With;
 import lombok.experimental.SuperBuilder;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
 
 @With
 @SuperBuilder(toBuilder = true)
@@ -85,7 +89,19 @@ public class JsonSchemaFilter {
     //  what if something validates against multiple of these, but filtering by the valid ones
     //  yields different result??
     // ultimately, don't see a use case anyways
+    /**
+     * passes filter if matches ANY of the schemas in the list (at least one)
+     * --> current implementation (as of 0.5.5) is NOT semantically equivalent to JSONS schema's oneOf, which seems wrong!! 
+     * JSON schema oneOf is exclusiveOr, not inclusiveOr; so in theory we should filter value OUT if it matches 0, or >1 
+     * of the schemas in the list; what's the use of that??? 
+     */
+    @Deprecated // use anyOf instead, which is cleaer
     List<JsonSchemaFilter> oneOf;
+
+    /**
+     * passes filter if matches ANY of the schemas in the list (at least one)
+     */
+    List<JsonSchemaFilter> anyOf;
 
     // part of JSON schema standard
     // it's clear how we would implement this as a filter (chain them), but not why
@@ -182,8 +198,14 @@ public class JsonSchemaFilter {
         return this.constant != null;
     }
 
+    @Deprecated
     @JsonIgnore
-    public boolean hashOneOf() {
+    public boolean hasOneOf() {
         return this.oneOf != null && !this.oneOf.isEmpty();
+    }
+
+    @JsonIgnore
+    public boolean hasAnyOf() {
+        return this.anyOf != null && !this.anyOf.isEmpty();
     }
 }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -112,7 +112,7 @@ public class JsonSchemaFilterUtils {
                 // cases like URLs relative to schema URI are not supported
                 throw new RuntimeException("unsupported ref: " + schema.getRef());
             }
-        } else if (schema.hashOneOf()) {
+        } else if (schema.hasOneOf()) {
             // Get first schema with matches its inner condition.
             // See https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
             // NOTE: If is expected that the "oneOf" candidate should hava an if-else-then or
@@ -120,6 +120,7 @@ public class JsonSchemaFilterUtils {
             // inside, otherwise the condition will not be evaluated and only the first occurrence
             // appearing in the list
             // will be chosen
+            // DEPRECATED, bc case above is weird to me
             for (JsonSchemaFilter oneOfCandidate : schema.getOneOf()) {
                 Object result = filterBySchema(path, provisionalOutput, oneOfCandidate, root,
                         redactionsMade);
@@ -130,6 +131,25 @@ public class JsonSchemaFilterUtils {
             }
 
             return null;
+        } else if (schema.hasAnyOf()) {
+            // Get first schema with matches its inner condition.
+            // See https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
+            // NOTE: If is expected that the "oneOf" candidate should hava an if-else-then or
+            // if-then nodes
+            // inside, otherwise the condition will not be evaluated and only the first occurrence
+            // appearing in the list
+            // will be chosen
+            for (JsonSchemaFilter anyOfCandidate : schema.getAnyOf()) {
+                Object result = filterBySchema(path, provisionalOutput, anyOfCandidate, root, redactionsMade);
+
+                //short-circuit on first match
+                if (!(result instanceof NotMatchedConstant)) {
+                    return result;
+                }
+            }
+
+            return null;
+
         } else if (schema instanceof ConditionJsonSchema) {
             // Conditions are schemas without no type definition
             // Only one property are supported by conditions. See

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -134,7 +134,7 @@ public class JsonSchemaFilterUtils {
         } else if (schema.hasAnyOf()) {
             // Get first schema with matches its inner condition.
             // See https://json-schema.org/understanding-json-schema/reference/combining#anyOf
-            // NOTE: If is expected that the "oneOf" candidate should hava an if-else-then or
+            // NOTE: If is expected that the "anyOf" candidate should hava an if-else-then or
             // if-then nodes
             // inside, otherwise the condition will not be evaluated and only the first occurrence
             // appearing in the list

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/JsonSchemaFilterUtils.java
@@ -133,7 +133,7 @@ public class JsonSchemaFilterUtils {
             return null;
         } else if (schema.hasAnyOf()) {
             // Get first schema with matches its inner condition.
-            // See https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
+            // See https://json-schema.org/understanding-json-schema/reference/combining#anyOf
             // NOTE: If is expected that the "oneOf" candidate should hava an if-else-then or
             // if-then nodes
             // inside, otherwise the condition will not be evaluated and only the first occurrence

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ParameterSchema.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ParameterSchema.java
@@ -79,13 +79,22 @@ public class ParameterSchema {
     List<String> enumValues;
 
     /**
+     * DEPRECATED, use anyOf instead
      * values matching any schema in this list are valid
      */
+    @Deprecated
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("or") //align to JsonSchema
     @Singular
     List<ParameterSchema> ors;
 
+    /**
+     * values matching any schema in this list are valid
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("anyOf") //align to JsonSchema
+    @Singular
+    List<ParameterSchema> anyOfs;
 
 
 

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ParameterSchemaUtils.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/rules/ParameterSchemaUtils.java
@@ -76,6 +76,12 @@ public class ParameterSchemaUtils {
                 }
             }
 
+            if (ObjectUtils.isNotEmpty(schema.getAnyOfs())) {
+                return schema.getAnyOfs().stream().anyMatch(
+                    anyOfSubSchema -> validate(anyOfSubSchema, value));
+            }
+
+            // TODO remove in v0.6
             if (ObjectUtils.isNotEmpty(schema.getOrs())) {
                 return schema.getOrs().stream().anyMatch(
                     orSubSchema -> validate(orSubSchema, value));


### PR DESCRIPTION
@jlorper asking for `or` to better support Slack schema filters; realize that we have it as `oneOf`; really should be called `anyOf` to align with JSON Schema. 



### Fixes
 - No specific issue linked. Please ensure any related tasks in the project management system are referenced here.

### Features
 - add `anyOf` in `JSONSchemaFilter`, `ParameterSchema`
 - mark `oneOf` deprecated on `JSONSchemaFilter`; `or` deprecated on `ParameterSchema`
 - update `salesforce` rules: `oneOf` --> `anyOf`
 - `gemini-in-workspace-apps` rules: `or` --> `anyOf`

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
 - breaking changes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210841700280592