### PR TITLE
Using access token for ChatGPT

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -87,10 +87,10 @@ EOT
       display_name : "ChatGPT Enterprise"
       worklytics_connector_name : "ChatGPT Enterprise via Psoxy"
       target_host : "api.chatgpt.com"
-      source_auth_strategy : "basic_auth" # ChatGPT API uses basic auth (RFC 7617 Section 2, with API key as 'user-id' and no password
+      source_auth_strategy : "oauth2_access_token"
       secured_variables : [
         {
-          name : "BASIC_AUTH_USER_ID" # ChatGPT's UX calls this an 'API Key', but it's actually a Basic Auth 'user-id'; should we have aliases or something?
+          name : "ACCESS_TOKEN" # ChatGPT's UX calls this an 'API Key', but it's actually an access token;
           writable : false
           sensitive : true
           value_managed_by_tf : false


### PR DESCRIPTION
After https://github.com/Worklytics/psoxy/pull/949, I've realized that the authentication was wrong. It request a fixed token to be used as part of Bearer authentication, so it is not a basic key but a `oauth2_access_token`

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
