### PR TITLE
fix AWS artifact publish

### DIFF
--- a/tools/release/publish-aws-release-artifact.sh
+++ b/tools/release/publish-aws-release-artifact.sh
@@ -136,7 +136,7 @@ assume_role() {
 publish_to_region() {
     local region="$1"
     local bucket_name="${BUCKET_PREFIX}-${region}"
-    local s3_path="s3://${bucket_name}/aws/${JAR_FILENAME}"
+    local s3_path="s3://${bucket_name}/${DEPLOYMENT_ARTIFACT}"
 
     echo -e "${BLUE}Publishing to ${GREEN}${region}${BLUE} (${s3_path})${NC}"
 
@@ -188,7 +188,7 @@ publish() {
         echo -e "${BLUE}Download URLs:${NC}"
         for region in "${REGIONS[@]}"; do
             local bucket_name="${BUCKET_PREFIX}-${region}"
-            echo -e "  ${GREEN}${region}:${NC} https://${bucket_name}.s3.${region}.amazonaws.com/aws/${JAR_FILENAME}"
+            echo -e "  ${GREEN}${region}:${NC} https://${bucket_name}.s3.${region}.amazonaws.com/${DEPLOYMENT_ARTIFACT}"
         done
     else
         echo -e "${YELLOW}⚠ Some regions failed to publish${NC}"

--- a/tools/release/publish-aws-release-artifact.sh
+++ b/tools/release/publish-aws-release-artifact.sh
@@ -155,15 +155,6 @@ publish_to_region() {
 
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✓ Successfully published to ${region}${NC}"
-
-        # Make the object publicly readable
-        aws s3api put-object-acl \
-            --bucket "$bucket_name" \
-            --key "aws/${JAR_FILENAME}" \
-            --acl public-read \
-            --region "$region"
-
-        echo -e "${GREEN}✓ Made object publicly readable in ${region}${NC}"
     else
         echo -e "${RED}✗ Failed to publish to ${region}${NC}"
         return 1


### PR DESCRIPTION
### Fixes
 - trying to set ACL on object, which fails and is unneeded
 - paths shown in feedback are wrong
 - don't really want them in `aws/` subdirectory; that's implied by context of being in `s3`

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211124200696278