### PR TITLE
Fix rules for room participant history

### DIFF
--- a/docs/sources/slack/slack-discovery-api/discovery.yaml
+++ b/docs/sources/slack/slack-discovery-api/discovery.yaml
@@ -196,9 +196,7 @@ definitions:
         type: "string"
   Attachment:
     type: "object"
-    properties:
-      id:
-        type: "integer"
+    properties: {}
   Block:
     type: "object"
     properties:
@@ -268,7 +266,7 @@ definitions:
       is_member:
         type: "boolean"
       is_moved:
-        type: "integer"
+        type: "boolean"
       is_mpim:
         type: "boolean"
       is_org_default:
@@ -474,6 +472,10 @@ definitions:
         type: "boolean"
       media_backend_type:
         type: "string"
+      participant_history:
+        type: "array"
+        items:
+          type: "string"
       thread_root_ts:
         type: "string"
       was_accepted:

--- a/docs/sources/slack/slack-discovery-api/discovery.yaml
+++ b/docs/sources/slack/slack-discovery-api/discovery.yaml
@@ -266,7 +266,7 @@ definitions:
       is_member:
         type: "boolean"
       is_moved:
-        type: "boolean"
+        type: "integer"
       is_mpim:
         type: "boolean"
       is_org_default:

--- a/docs/sources/slack/slack-discovery-api/example-api-responses/sanitized/discovery-conversations-history.json
+++ b/docs/sources/slack/slack-discovery-api/example-api-responses/sanitized/discovery-conversations-history.json
@@ -55,9 +55,7 @@
         "ts":"38327498237.000000"
       },
       "attachments":[
-        {
-          "id":1
-        }
+        { }
       ]
     },
     {
@@ -165,6 +163,10 @@
         "created_by":"t~ht3jIZhCUKqR7UVboNfpxTZZUWLoExaW1WX6GG19JVg",
         "date_start":1720542372,
         "date_end":1720542756,
+        "participant_history":[
+          "t~ht3jIZhCUKqR7UVboNfpxTZZUWLoExaW1WX6GG19JVg",
+          "t~C35tSgm0FijTntSB1kSz4RzerO3J58n-H3rwI7A0698"
+        ],
         "canvas_thread_ts":"1720542372.566689",
         "thread_root_ts":"1720542372.566689",
         "channels":[


### PR DESCRIPTION
`participants_history` were redacted instead of pseudonymized. 

See https://github.com/Worklytics/evalengin/pull/7898

### Fixes
[Update rules](https://app.asana.com/1/27145998307022/task/1211358180361443)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211358180361445