### PR TITLE
improve Google Workspace API key management

### DIFF
--- a/infra/examples-dev/aws/google-workspace-variables.tf
+++ b/infra/examples-dev/aws/google-workspace-variables.tf
@@ -32,6 +32,17 @@ variable "google_workspace_provision_keys" {
   default     = true
 }
 
+variable "google_workspace_key_rotation_days" {
+  type        = number
+  description = "rotation period for the GCP Service Account keys, in days; not applicable if provision_gcp_sa_keys is false"
+  default     = 60
+
+  validation {
+    condition     = var.google_workspace_key_rotation_days > 0
+    error_message = "gcp_sa_keygoogle_workspace_key_rotation_days_rotation_days must be greater than 0"
+  }
+}
+
 locals {
   # tflint-ignore: terraform_unused_declarations
   some_google_connector_enabled                    = (length(setintersection(var.enabled_connectors, ["gcal", "gdirectory", "gdrive", "gmail", "google-meet", "google-chat", "gemini-for-workspace"])) > 0)

--- a/infra/examples-dev/aws/google-workspace.tf
+++ b/infra/examples-dev/aws/google-workspace.tf
@@ -20,6 +20,7 @@ module "worklytics_connectors_google_workspace" {
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
   provision_gcp_sa_keys          = var.google_workspace_provision_keys
+  gcp_sa_key_rotation_days       = var.google_workspace_key_rotation_days
   todos_as_local_files           = var.todos_as_local_files
 }
 

--- a/infra/examples-dev/gcp/google-workspace-variables.tf
+++ b/infra/examples-dev/gcp/google-workspace-variables.tf
@@ -32,6 +32,17 @@ variable "google_workspace_provision_keys" {
   default     = true
 }
 
+variable "google_workspace_key_rotation_days" {
+  type        = number
+  description = "rotation period for the GCP Service Account keys, in days; not applicable if provision_gcp_sa_keys is false"
+  default     = 60
+
+  validation {
+    condition     = var.google_workspace_key_rotation_days > 0
+    error_message = "gcp_sa_keygoogle_workspace_key_rotation_days_rotation_days must be greater than 0"
+  }
+}
+
 locals {
   # tflint-ignore: terraform_unused_declarations
   some_google_connector_enabled                    = (length(setintersection(var.enabled_connectors, ["gcal", "gdirectory", "gdrive", "gmail", "google-meet", "google-chat", "gemini-for-workspace"])) > 0)

--- a/infra/examples-dev/gcp/google-workspace-variables.tf
+++ b/infra/examples-dev/gcp/google-workspace-variables.tf
@@ -39,7 +39,7 @@ variable "google_workspace_key_rotation_days" {
 
   validation {
     condition     = var.google_workspace_key_rotation_days > 0
-    error_message = "gcp_sa_keygoogle_workspace_key_rotation_days_rotation_days must be greater than 0"
+    error_message = "google_workspace_key_rotation_days must be greater than 0"
   }
 }
 

--- a/infra/examples-dev/gcp/google-workspace.tf
+++ b/infra/examples-dev/gcp/google-workspace.tf
@@ -20,6 +20,7 @@ module "worklytics_connectors_google_workspace" {
   google_workspace_example_user  = var.google_workspace_example_user
   google_workspace_example_admin = var.google_workspace_example_admin
   provision_gcp_sa_keys          = var.google_workspace_provision_keys
+  gcp_sa_key_rotation_days       = var.google_workspace_key_rotation_days
   todos_as_local_files           = var.todos_as_local_files
 }
 

--- a/infra/modules/gcp-sa-auth-key/main.tf
+++ b/infra/modules/gcp-sa-auth-key/main.tf
@@ -24,14 +24,11 @@ resource "time_rotating" "sa-key-rotation" {
 resource "google_service_account_key" "key" {
   service_account_id = var.service_account_id
 
-  # does this actually destroy/disable the old key? that's a problem as Cloud functions pull the
-  # value at instance start-up and don't refresh it
-  keepers = {
-    rotation_time = time_rotating.sa-key-rotation.rotation_rfc3339
-  }
-
   lifecycle {
     create_before_destroy = true
+    replace_triggered_by = [
+      time_rotating.sa-key-rotation
+    ]
   }
 
   depends_on = [

--- a/infra/modules/worklytics-connectors-google-workspace/main.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/main.tf
@@ -78,6 +78,7 @@ module "google_workspace_connection_auth" {
   source = "../../modules/gcp-sa-auth-key"
 
   service_account_id = each.value
+  rotation_days      = var.gcp_sa_key_rotation_days
 }
 
 

--- a/infra/modules/worklytics-connectors-google-workspace/variables.tf
+++ b/infra/modules/worklytics-connectors-google-workspace/variables.tf
@@ -37,6 +37,17 @@ variable "provision_gcp_sa_keys" {
   default     = true
 }
 
+variable "gcp_sa_key_rotation_days" {
+  type        = number
+  description = "rotation period for the GCP Service Account key, in day; not applicable if provision_gcp_sa_keys is false"
+  default     = 60
+
+  validation {
+    condition     = var.gcp_sa_key_rotation_days > 0
+    error_message = "gcp_sa_key_rotation_days must be greater than 0"
+  }
+}
+
 variable "todos_as_local_files" {
   type        = bool
   description = "whether to render TODOs as flat files"


### PR DESCRIPTION
### Fixes
- implement GCP SA key (what functions as Google Workspace API keys) rotation in a way that both provisions new keys AND destroys the old ones

### Change implications

- dependencies added/changed? **No**
- something important to note in future release notes? **will see gcp sa keys rotate, even if < 60 days since last apply**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211119392009398