### PR TITLE
Support rateLimit object in GitHub GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ in each release's notes.
 Changes to be including in future/planned release notes will be added here.
 
 ## Next
+## [0.5.10](https://github.com/Worklytics/psoxy/release/tag/v0.5.10)
+- `GitHub`: adding support for returning `RateLimit` information for GraphQL
 
 ## [0.5.9](https://github.com/Worklytics/psoxy/release/tag/v0.5.9)
 - `Confluence`: support extensions and previous version from Content Search

--- a/docs/sources/github/copilot/github-copilot.yaml
+++ b/docs/sources/github/copilot/github-copilot.yaml
@@ -378,6 +378,22 @@ endpoints:
                               type: "string"
                             hasNextPage:
                               type: "boolean"
+            rateLimit:
+              type: "object"
+              properties:
+                cost:
+                  type: "integer"
+                limit:
+                  type: "integer"
+                nodeCount:
+                  type: "integer"
+                remaining:
+                  type: "integer"
+                resetAt:
+                  type: "string"
+                  format: "date-time"
+                used:
+                  type: "integer"
         errors:
           type: "array"
           items:

--- a/docs/sources/github/enterprise-server/github-enterprise-server.yaml
+++ b/docs/sources/github/enterprise-server/github-enterprise-server.yaml
@@ -378,6 +378,22 @@ endpoints:
                               type: "string"
                             hasNextPage:
                               type: "boolean"
+            rateLimit:
+              type: "object"
+              properties:
+                cost:
+                  type: "integer"
+                limit:
+                  type: "integer"
+                nodeCount:
+                  type: "integer"
+                remaining:
+                  type: "integer"
+                resetAt:
+                  type: "string"
+                  format: "date-time"
+                used:
+                  type: "integer"
         errors:
           type: "array"
           items:

--- a/docs/sources/github/github-non-enterprise/github-non-enterprise.yaml
+++ b/docs/sources/github/github-non-enterprise/github-non-enterprise.yaml
@@ -338,6 +338,22 @@ endpoints:
                                       type: "string"
                                     hasNextPage:
                                       type: "boolean"
+            rateLimit:
+              type: "object"
+              properties:
+                cost:
+                  type: "integer"
+                limit:
+                  type: "integer"
+                nodeCount:
+                  type: "integer"
+                remaining:
+                  type: "integer"
+                resetAt:
+                  type: "string"
+                  format: "date-time"
+                used:
+                  type: "integer"
         errors:
           type: "array"
           items:

--- a/docs/sources/github/github/example-api-responses/original/pull_commits_graphql.json
+++ b/docs/sources/github/github/example-api-responses/original/pull_commits_graphql.json
@@ -1,5 +1,13 @@
 {
   "data": {
+    "rateLimit": {
+      "limit": 5000,
+      "nodeCount": 600,
+      "remaining": 4997,
+      "resetAt": "2025-09-22T15:59:03Z",
+      "used": 3,
+      "cost": 1
+    },
     "organization": {
       "repository": {
         "pullRequest": {

--- a/docs/sources/github/github/example-api-responses/sanitized/pull_commits_graphql.json
+++ b/docs/sources/github/github/example-api-responses/sanitized/pull_commits_graphql.json
@@ -1,5 +1,13 @@
 {
   "data":{
+    "rateLimit":{
+      "limit":5000,
+      "nodeCount":600,
+      "remaining":4997,
+      "resetAt":"2025-09-22T15:59:03Z",
+      "used":3,
+      "cost":1
+    },
     "organization":{
       "repository":{
         "pullRequest":{

--- a/docs/sources/github/github/github.yaml
+++ b/docs/sources/github/github/github.yaml
@@ -378,6 +378,22 @@ endpoints:
                               type: "string"
                             hasNextPage:
                               type: "boolean"
+            rateLimit:
+              type: "object"
+              properties:
+                cost:
+                  type: "integer"
+                limit:
+                  type: "integer"
+                nodeCount:
+                  type: "integer"
+                remaining:
+                  type: "integer"
+                resetAt:
+                  type: "string"
+                  format: "date-time"
+                used:
+                  type: "integer"
         errors:
           type: "array"
           items:

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -819,6 +819,29 @@ public class PrebuiltSanitizerRules {
                     put("data", JsonSchemaFilter.<String, RESTRules>builder()
                             .type("object")
                             .properties(new LinkedHashMap<String, JsonSchemaFilter>() {{
+                                put("rateLimit", JsonSchemaFilter.builder()
+                                    .type("object")
+                                    .properties(new LinkedHashMap<String, JsonSchemaFilter>() {{
+                                        put("limit", JsonSchemaFilter.builder()
+                                            .type("integer")
+                                            .build());
+                                        put("nodeCount", JsonSchemaFilter.builder()
+                                            .type("integer")
+                                            .build());
+                                        put("remaining", JsonSchemaFilter.builder()
+                                            .type("integer")
+                                            .build());
+                                        put("resetAt", JsonSchemaFilter.builder()
+                                            .type("string")
+                                            .format("date-time")
+                                            .build());
+                                        put("used", JsonSchemaFilter.builder()
+                                            .type("integer")
+                                            .build());
+                                        put("cost", JsonSchemaFilter.builder()
+                                                .type("integer")
+                                                .build());
+                                        }}).build());
                                 put("organization", JsonSchemaFilter.builder()
                                         .type("object")
                                         .properties(new LinkedHashMap<String, JsonSchemaFilter>() {{


### PR DESCRIPTION
Add support for `rateLimit` in response model when a GraphQL is done in Github. `rateLimit` will only appear if requested on the query and it is interesting to get more insights about the rate limits and graphQL usage.

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[GH: Include graphQL rate limit in rules responses](https://app.asana.com/1/27145998307022/project/1211058429113281/task/1211181618996259)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
