### PR TITLE
Fix variable name for confluence in docs

### DIFF
--- a/docs/sources/atlassian/confluence/README.md
+++ b/docs/sources/atlassian/confluence/README.md
@@ -140,7 +140,7 @@ curl --request POST --url 'https://auth.atlassian.com/oauth/token' --header 'Con
      }
    ]
    ```
-Add the `id` value from that JSON response as the value of the `confluence_cloud_id` variable in the
+Add the `id` value from that JSON response as the value of the `confluence_example_cloud_id` variable in the
 `terraform.tfvars` file of your Terraform configuration. This will generate all the test URLs with
 a proper value.
 

--- a/tools/confluence-cloud-auth.sh
+++ b/tools/confluence-cloud-auth.sh
@@ -87,5 +87,5 @@ printf "${YELLOW}${PREFIX}CONFLUENCE_CLOUD_REFRESH_TOKEN${NC}: ${REFRESH_TOKEN}\
 printf "${YELLOW}${PREFIX}CONFLUENCE_CLOUD_CLIENT_ID${NC}: ${CLIENT_ID}\n"
 printf "${YELLOW}${PREFIX}CONFLUENCE_CLOUD_CLIENT_SECRET${NC}: ${CLIENT_SECRET}\n"
 
-printf "And set the cloud ID (${YELLOW}${CLOUD_ID}${NC}) as the value of ${YELLOW}confluence_cloud_id${NC} in your ${YELLOW}terraform.tfvars${NC} file.\n"
+printf "And set the cloud ID (${YELLOW}${CLOUD_ID}${NC}) as the value of ${YELLOW}confluence_example_cloud_id${NC} in your ${YELLOW}terraform.tfvars${NC} file.\n"
 


### PR DESCRIPTION
`confluence_example_cloud_id` should be used for `confluence_cloud_id`, which was not correct after #973 

### Fixes
[confluence_cloud_id missing from exampled](https://app.asana.com/1/27145998307022/project/1201039336231823/task/1211368729569639)

### Features
> paste links to issues/tasks in project management
 - []()

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
