### PR TITLE
add configurable gcp bulk run timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes to be including in future/planned release notes will be added here.
 ## Next
 ## [0.5.10](https://github.com/Worklytics/psoxy/release/tag/v0.5.10)
 - `GitHub`: adding support for returning `RateLimit` information for GraphQL
+- `gcp`: `timeout_seconds` configurable for bulk connectors
 
 ## [0.5.9](https://github.com/Worklytics/psoxy/release/tag/v0.5.9)
 - `Confluence`: support extensions and previous version from Content Search

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -324,6 +324,8 @@ variable "custom_bulk_connectors" {
         transforms = optional(list(map(string)), [])
       })))
     }))
+    available_memory_mb = optional(number)
+    timeout_seconds = optional(number)
     rules_file          = optional(string)
     settings_to_provide = optional(map(string), {})
     example_file        = optional(string)
@@ -381,7 +383,7 @@ variable "custom_bulk_connector_rules" {
 variable "custom_bulk_connector_arguments" {
   type = map(object({
     available_memory_mb = optional(number)
-    # what else to add here?
+    timeout_seconds = optional(number)
   }))
 
   description = "map of connector id --> arguments object, to override defaults for bulk connector instances"

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -325,7 +325,7 @@ variable "custom_bulk_connectors" {
       })))
     }))
     available_memory_mb = optional(number)
-    timeout_seconds = optional(number)
+    timeout_seconds     = optional(number)
     rules_file          = optional(string)
     settings_to_provide = optional(map(string), {})
     example_file        = optional(string)
@@ -383,7 +383,7 @@ variable "custom_bulk_connector_rules" {
 variable "custom_bulk_connector_arguments" {
   type = map(object({
     available_memory_mb = optional(number)
-    timeout_seconds = optional(number)
+    timeout_seconds     = optional(number)
   }))
 
   description = "map of connector id --> arguments object, to override defaults for bulk connector instances"

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -327,7 +327,7 @@ module "bulk_connector" {
   sanitized_bucket_name             = try(each.value.sanitized_bucket_name, null)
   default_labels                    = var.default_labels
   todos_as_local_files              = var.todos_as_local_files
-  available_memory_mb               = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 1024)
+  available_memory_mb               = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 512)
   timeout_seconds                   = coalesce(try(var.custom_bulk_connector_arguments[each.key].timeout_seconds, null), try(each.value.timeout_seconds, null), 540) # TODO: bump to 1800 (30 minutes) in 0.6.x
   gcp_principals_authorized_to_test = var.gcp_principals_authorized_to_test
   bucket_force_destroy              = var.bucket_force_destroy

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -327,7 +327,8 @@ module "bulk_connector" {
   sanitized_bucket_name             = try(each.value.sanitized_bucket_name, null)
   default_labels                    = var.default_labels
   todos_as_local_files              = var.todos_as_local_files
-  available_memory_mb               = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 512)
+  available_memory_mb               = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 1024)
+  timeout_seconds                   = coalesce(try(var.custom_bulk_connector_arguments[each.key].timeout_seconds, null), try(each.value.timeout_seconds, null), 540) # TODO: bump to 1800 (30 minutes) in 0.6.x
   gcp_principals_authorized_to_test = var.gcp_principals_authorized_to_test
   bucket_force_destroy              = var.bucket_force_destroy
 

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -300,7 +300,7 @@ variable "custom_bulk_connector_rules" {
 variable "custom_bulk_connector_arguments" {
   type = map(object({
     available_memory_mb = optional(number)
-    timeout_seconds = optional(number)
+    timeout_seconds     = optional(number)
   }))
 
   description = "map of connector id --> settings object"

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -300,7 +300,7 @@ variable "custom_bulk_connector_rules" {
 variable "custom_bulk_connector_arguments" {
   type = map(object({
     available_memory_mb = optional(number)
-    # what else to add here?
+    timeout_seconds = optional(number)
   }))
 
   description = "map of connector id --> settings object"

--- a/infra/modules/gcp-psoxy-bulk/main.tf
+++ b/infra/modules/gcp-psoxy-bulk/main.tf
@@ -187,7 +187,7 @@ resource "google_cloudfunctions2_function" "function" {
   service_config {
     available_memory      = "${coalesce(var.available_memory_mb, 1024)}M"
     service_account_email = google_service_account.service_account.email
-    timeout_seconds       = 540 # 9 minutes
+    timeout_seconds       = var.timeout_seconds
     ingress_settings      = "ALLOW_INTERNAL_ONLY"
 
     vpc_connector                 = var.vpc_config == null ? null : var.vpc_config.serverless_connector

--- a/infra/modules/gcp-psoxy-bulk/variables.tf
+++ b/infra/modules/gcp-psoxy-bulk/variables.tf
@@ -89,8 +89,14 @@ variable "bucket_write_role_id" {
 
 variable "available_memory_mb" {
   type        = number
-  description = "Memory (in MB), available to the function. Default value is 1024. Possible values include 128, 256, 512, 1024, etc."
+  description = "Memory (in MB), available to the function. Default value is 1024. Possible values include 128, 256, 512, 1024, 2048, 4096; above that requires multiple CPUs, beyond scope of our built-in configurations."
   default     = 1024
+}
+
+variable "timeout_seconds" {
+  type        = number
+  description = "Timeout (in seconds) for the function. Default value is 540 (9 minutes)."
+  default     = 540 # TODO: bump to 1800 (30 minutes) in 0.6.x
 }
 
 variable "example_file" {


### PR DESCRIPTION
### Features
- configureable timeout for GCP bulk connectors (but default value remains the same, as would have been change that shows in TF plans, and really not necessary except a few extraordinary cases)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**
   - breaking changes? **no**
