### PR TITLE
Leave settings as default route

### DIFF
--- a/.github/workflows/publish-release-artifacts.yaml
+++ b/.github/workflows/publish-release-artifacts.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           REF_NAME="${{ github.ref_name }}"
           echo "Running on ref: $REF_NAME"
-          
+
           if [[ "$REF_NAME" == "main" ]]; then
             echo "✅ Validated running on main branch."
           elif [[ "$REF_NAME" =~ ^v ]]; then
@@ -41,7 +41,6 @@ jobs:
           java-version: '21'
           distribution: 'zulu'
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # Location for the settings.xml file
           cache: 'maven'
 
       - name: Publish Maven Artifacts
@@ -51,7 +50,7 @@ jobs:
           # The script expects GITHUB_TOKEN in settings.xml or environment
           # We need to ensure settings.xml is configured correctly for GitHub Packages
           # actions/setup-java does this if we set server-id
-          
+
           ./tools/release/publish-mvn-artifacts.sh .
 
       - name: Generate SBOMs and Build Bundles
@@ -59,7 +58,7 @@ jobs:
         run: |
           # This script builds the modules and generates SBOMs
           ./tools/release/generate-sbom.sh
-        
+
       - name: Locate Artifacts
         id: locate-artifacts
         if: startsWith(github.ref, 'refs/tags/v')
@@ -67,16 +66,16 @@ jobs:
           # Find the generated JARs - verifying path assumptions from build scripts
           AWS_JAR=$(find java/impl/aws/target/deployment -name "psoxy-aws-*.jar" | head -n 1)
           GCP_JAR=$(find java/impl/gcp/target/deployment -name "psoxy-gcp-*.jar" | head -n 1)
-          
+
           echo "aws_jar=$AWS_JAR" >> $GITHUB_OUTPUT
           echo "gcp_jar=$GCP_JAR" >> $GITHUB_OUTPUT
-          
-          # Rename SBOMs to likely match the release artifact naming convention if desired, 
+
+          # Rename SBOMs to likely match the release artifact naming convention if desired,
           # or just keep as is. The generate-sbom.sh copies them to docs/aws/sbom.json
-          
+
           cp docs/aws/sbom.json psoxy-aws-sbom.json
           cp docs/gcp/sbom.json psoxy-gcp-sbom.json
-          
+
           echo "aws_sbom=psoxy-aws-sbom.json" >> $GITHUB_OUTPUT
           echo "gcp_sbom=psoxy-gcp-sbom.json" >> $GITHUB_OUTPUT
 
@@ -100,13 +99,13 @@ jobs:
         run: |
           # Use the tag that triggered this workflow as the release identifier
           TAG_NAME=${{ github.ref_name }}
-          
+
           AWS_JAR="${{ steps.locate-artifacts.outputs.aws_jar }}"
           GCP_JAR="${{ steps.locate-artifacts.outputs.gcp_jar }}"
           AWS_SBOM="${{ steps.locate-artifacts.outputs.aws_sbom }}"
           GCP_SBOM="${{ steps.locate-artifacts.outputs.gcp_sbom }}"
-          
+
           echo "Uploading assets to release $TAG_NAME..."
-          
+
           # Upload files with clobber to overwrite if they exist
           gh release upload "$TAG_NAME" "$AWS_JAR" "$GCP_JAR" "$AWS_SBOM" "$GCP_SBOM" --clobber


### PR DESCRIPTION
There is a 401 while publishing packages from the action. It could be related to an invalid token, but I think the issue is that the settings are not in the same path as the java action is configured and the maven tool run in the script later. 

See my review comment

### Fixes
[401 while publishing psoxy packages](https://app.asana.com/1/27145998307022/project/1201039336231823/task/1213233589869316)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
