### PR TITLE
add google trademarks

### DIFF
--- a/docs/sources/google-workspace/README.md
+++ b/docs/sources/google-workspace/README.md
@@ -1,48 +1,48 @@
-# Google Workspace
+# Google Workspace&trade;
 
-Google Workspace sources can be setup via Terraform, using modules found in our GitHub repo.
+Google Workspace&trade; sources can be setup via Terraform, using modules found in our GitHub repo.
 
 As of August 2023, we suggest you use one of our template repos, eg:
 
 - [`aws`](https://github.com/Worklytics/psoxy-example-aws)
 - [`gcp`](https://github.com/Worklytics/psoxy-example-gcp)
 
-Within those, the `google-workspace.tf` and `google-workspace-variables.tf` files specify the terraform configuration to use Google Workspace sources.
+Within those, the `google-workspace.tf` and `google-workspace-variables.tf` files specify the terraform configuration to use Google Workspace&trade; sources.
 
 ## Available connectors
 
-- [calendar](calendar/README.md)
-- [directory](directory/README.md)
-- [gdrive](gdrive/README.md)
+- [calendar](calendar/README.md) (Google Calendar&trade;)
+- [directory](directory/README.md) (Google Workspace&trade; Directory)
+- [gdrive](gdrive/README.md) (Google Drive&trade;)
 - [gemini-in-workspace-apps](gemini-in-workspace-apps/README.md)
 - [gemini-usage-bulk](gemini-usage-bulk/README.md)
-- [gmail](gmail/README.md)
-- [google-chat](google-chat/README.md)
-- [meet](meet/README.md)
+- [gmail](gmail/README.md) (Gmail&trade;)
+- [google-chat](google-chat/README.md) (Google Chat&trade;)
+- [meet](meet/README.md) (Google Meet&trade;)
 
 ## Required Permissions
 
-You (the user running Terraform) must have the following roles (or some of the permissions within them) in the GCP project in which you will provision the OAuth clients that will be used to connect to your Google Workspace data:
+You (the user running Terraform) must have the following roles (or some of the permissions within them) in the GCP project in which you will provision the OAuth clients that will be used to connect to your Google Workspace&trade; data:
 
 | Role                                                                                                          | Reason                                                                                         |
 | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [Service Account Creator](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountCreator)    | create Service Accounts to be used as API clients                                              |
-| [Service Account Key Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountKeyAdmin) | to access Google Workspace API, proxy _must_ be authenticated by a key that you need to create |
-| [Service Usage Admin](https://cloud.google.com/iam/docs/understanding-roles#serviceusage.serviceUsageAdmin)   | you will need to enable the Google Workspace APIs in your GCP Project                          |
+| [Service Account Key Admin](https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountKeyAdmin) | to access Google Workspace&trade; API, proxy _must_ be authenticated by a key that you need to create |
+| [Service Usage Admin](https://cloud.google.com/iam/docs/understanding-roles#serviceusage.serviceUsageAdmin)   | you will need to enable the Google Workspace&trade; APIs in your GCP Project                          |
 
 As these are very permissive roles, we recommend that you use a _dedicated_ GCP project so that these roles are scoped just to the Service Accounts used for this deployment. If you used a shared GCP project, these roles would give you access to create keys for ALL the service accounts in the project, for example - which is not good practice.
 
-Additionally, a Google Workspace Admin will need to make a Domain-wide Delegation grant to the Oauth Clients you create. This is done via the Google Workspace Admin console. In default setup, this requires [Super Admin](https://support.google.com/a/answer/2405986?hl=en&fl=1) role, but your organization may have a Custom Role with sufficient privileges.
+Additionally, a Google Workspace&trade; Admin will need to make a Domain-wide Delegation grant to the Oauth Clients you create. This is done via the Google Workspace&trade; Admin console. In default setup, this requires [Super Admin](https://support.google.com/a/answer/2405986?hl=en&fl=1) role, but your organization may have a Custom Role with sufficient privileges.
 
-## Google Workspace User for Connection
+## Google Workspace&trade; User for Connection
 
-We also recommend you create a dedicated Google Workspace user for Psoxy to use when connecting to your Google Workspace Admin API, with the specific permissions needed. This avoids the connection being tied to a personal account and helps with auditing and security.
+We also recommend you create a dedicated Google Workspace&trade; user for Psoxy to use when connecting to your Google Workspace&trade; Admin API, with the specific permissions needed. This avoids the connection being tied to a personal account and helps with auditing and security.
 
-This is not to be confused with a GCP Service Account. Rather, this is a regular Google Workspace user account, but intended to be assigned to a service rather than a human user. Your proxy instance will impersonate this user when accessing the [Google Admin Directory](https://developers.google.com/admin-sdk/directory/v1/guides) and [Reports](https://developers.google.com/admin-sdk/reports/v1/guides) APIs. (Google requires thatthese be accessed via impersonation of a Google user account, rather than directly using a GCP service account).
+This is not to be confused with a GCP Service Account. Rather, this is a regular Google Workspace&trade; user account, but intended to be assigned to a service rather than a human user. Your proxy instance will impersonate this user when accessing the [Google Admin Directory](https://developers.google.com/admin-sdk/directory/v1/guides) and [Reports](https://developers.google.com/admin-sdk/reports/v1/guides) APIs. (Google requires thatthese be accessed via impersonation of a Google user account, rather than directly using a GCP service account).
 
 We recommend naming the account `svc-worklytics@{your-domain.com}`.
 
-If you have already created a sufficiently privileged service account user for a different Google Workspace connection, you can re-use that one.
+If you have already created a sufficiently privileged service account user for a different Google Workspace&trade; connection, you can re-use that one.
 
 Assign the account a sufficiently privileged role. At minimum, the role must have the following privileges, _read-only_:
 
@@ -50,14 +50,14 @@ Assign the account a sufficiently privileged role. At minimum, the role must hav
 - Domain Settings
 - Groups
 - Organizational Units
-- Reports (required only if you are connecting to the Audit Logs, used for Google Chat, Meet, etc)
+- Reports (required only if you are connecting to the Audit Logs, used for Google Chat&trade;, Google Meet&trade;, etc)
 - Users
 
 Those refer to [Google's documentation](https://support.google.com/a/answer/1219251?fl=1&sjid=8026519161455224599-NA), as shown below (as of Aug 2023); you can refer there for more details about these privileges.
 
 ![google-workspace-admin-privileges.png](google-workspace-admin-privileges.png)
 
-The email address of the account you created will be used when creating the data connection to the Google Directory in the Worklytics portal. Provide it as the value of the 'Google Account to Use for Connection' setting when they create the connection.
+The email address of the account you created will be used when creating the data connection to the Google Directory in the Worklytics&trade; portal. Provide it as the value of the 'Google Account to Use for Connection' setting when they create the connection.
 
 ### Custom Role
 
@@ -65,20 +65,20 @@ If you choose not to use a predefined role that covers the above, you can define
 
 Using a Custom Role, with 'Read' access to each of the required Admin API privileges is good practice, but least-privilege is also enforced in TWO additional ways:
 
-- the Proxy API rules restrict the API endpoints that Worklytics can access, as well as the HTTP methods that may be used. This enforces read-only access, limited to the required data types (and actually even more granular that what Workspace Admin privileges and OAuth Scopes support).
-- the Oauth Scopes granted to the API client via Domain-wide delegation. Each OAuth Client used by Worklytics is granted only read-only scopes, least-permissive for the data types required. eg `https://www.googleapis.com/auth/admin.directory.users.readonly`.
+- the Proxy API rules restrict the API endpoints that Worklytics&trade; can access, as well as the HTTP methods that may be used. This enforces read-only access, limited to the required data types (and actually even more granular that what Workspace Admin privileges and OAuth Scopes support).
+- the Oauth Scopes granted to the API client via Domain-wide delegation. Each OAuth Client used by Worklytics&trade; is granted only read-only scopes, least-permissive for the data types required. eg `https://www.googleapis.com/auth/admin.directory.users.readonly`.
 
 So a least-privileged custom role is essentially a 3rd layer of enforcement.
 
-In the Google Workspace Admin Console as of August 2023, creating a 'Custom Role' for this user will look something like the following:
+In the Google Workspace&trade; Admin Console as of August 2023, creating a 'Custom Role' for this user will look something like the following:
 
 ![custom-role.png](custom-role.png)
 
-**YMMV** - Google's UI changes frequently and varies by Google Workspace edition, so you may see more or fewer options than shown above. Please scroll the list of privileges to ensure you grant READ access to API for all required data.
+**YMMV** - Google's UI changes frequently and varies by Google Workspace&trade; edition, so you may see more or fewer options than shown above. Please scroll the list of privileges to ensure you grant READ access to API for all required data.
 
 ## General Authentication Overview
 
-Google Workspace APIs use OAuth 2.0 for authentication and authorization. You create an Oauth 2.0 client in Google Cloud Platform and a credential (service account key), which you store in as a secret in your Proxy instance.
+Google Workspace&trade; APIs use OAuth 2.0 for authentication and authorization. You create an Oauth 2.0 client in Google Cloud Platform and a credential (service account key), which you store in as a secret in your Proxy instance.
 
 When the proxy connects to Google, it first authenticates with Google API using this secret (a service account key) by signing a request for a short-lived access token. Google returns this access token, which the proxy then uses for subsequent requests to Google's APIS until the token expires.
 
@@ -86,7 +86,7 @@ The service account key can be rotated at any time, and the terraform configurat
 
 More information: https://developers.google.com/workspace/guides/auth-overview
 
-To initially authorize each connector, a sufficiently privileged Google Workspace Admin must make a Domain-wide Delegation grant to the Oauth Client you create, by pasting its numeric ID and a CSV of the required OAuth Scopes into the Google Workspace Admin console. This is a one-time setup step.
+To initially authorize each connector, a sufficiently privileged Google Workspace&trade; Admin must make a Domain-wide Delegation grant to the Oauth Client you create, by pasting its numeric ID and a CSV of the required OAuth Scopes into the Google Workspace&trade; Admin console. This is a one-time setup step.
 
 If you use the provided Terraform modules (namely, `google-workspace-dwd-connection`), a TODO file with detailed instructions will be created for you, including the actual numeric ID and scopes required.
 
@@ -108,7 +108,7 @@ While not recommended, it is possible to set up Google API clients without Terra
 
 Then follow the steps in the next section to create the keys for the Oauth Clients.
 
-NOTE: if you are creating connections to multiple Google Workspace sources, you can use a single OAuth client and share it between all the proxy instances. You just need to authorize the entire superset of Oauth scopes required by those connnections for the OAuth Client via the Google Workspace Admin console.
+NOTE: if you are creating connections to multiple Google Workspace&trade; sources, you can use a single OAuth client and share it between all the proxy instances. You just need to authorize the entire superset of Oauth scopes required by those connnections for the OAuth Client via the Google Workspace&trade; Admin console.
 
 ### Provisioning API Keys without Terraform
 
@@ -144,8 +144,8 @@ If you remain uncomfortable with Domain-wide Delegation, a private Google Market
 
 Pros:
 
-- Google Workspace Admins may perform a single Marketplace installation, instead of multiple DWD grants via the admin console
-- "install" from the Google Workspace Marketplace is less error-prone/exploitable than copy-paste a  numeric service account ID
+- Google Workspace&trade; Admins may perform a single Marketplace installation, instead of multiple DWD grants via the admin console
+- "install" from the Google Workspace&trade; Marketplace is less error-prone/exploitable than copy-paste a  numeric service account ID
 - visual confirmation of the oauth scopes being granted by the install
 - ability to "install" for an Org Unit, rather than the entire domain
 
@@ -154,16 +154,16 @@ Cons:
 - you must use a dedicated GCP project for the Marketplace App; "installation" of a Google Marketplace App grants all the service accounts in the project access to the listed oauth scopes. You must understand the OAuth grant is to the project, not a specific service account.
 - you must enable additional APIs in the GCP project (marketplace SDK).
 - as of Dec 2023, Marketplace Apps cannot be completely managed by Terraform resources; so there are more out-of-band steps that someone must complete by hand to create the App; and a simple `terraform destroy` will not remove the associated infrastructure. In contrast, `terraform destroy` in the DWD approach will result in revocation of the access grants when the service account is deleted.
-- You must monitor how many service accounts exist in the project and ensure only the expected ons  are created. Note that all Google Workspace API access, as of Dec 2023, requires the service account to authenticate with a key; so any SA without a key provisioned cannot access your data.
+- You must monitor how many service accounts exist in the project and ensure only the expected ons  are created. Note that all Google Workspace&trade; API access, as of Dec 2023, requires the service account to authenticate with a key; so any SA without a key provisioned cannot access your data.
 
 
 ## Troubleshooting
 
-Google Workspace API errors/error codes are NOT exhaustively documented by Google, nor do they appear to be viewed as under the scope of API contract. So YMMV; below are some of our notes on errors we've seen in the past, and ideas on root causes of each in case you see them in the future.
+Google Workspace&trade; API errors/error codes are NOT exhaustively documented by Google, nor do they appear to be viewed as under the scope of API contract. So YMMV; below are some of our notes on errors we've seen in the past, and ideas on root causes of each in case you see them in the future.
 
 
 ### `"error": "invalid_grant"`
-A couple possible cause of `invalid_grant` errors being returned by Google Workspace APIs.  The error_description / HTTP response codes can provide additional clues.
+A couple possible cause of `invalid_grant` errors being returned by Google Workspace&trade; APIs.  The error_description / HTTP response codes can provide additional clues.
 
 #### 400
 ```
@@ -173,10 +173,14 @@ com.google.auth.oauth2.GoogleAuthException: Error getting access token for servi
 This indicates that the service account key (stored as a secret in your proxy instance) has been disabled/destroyed. Ensure that 1) a service account key is set on the service account for the connection, and 2) 
 
 #### 401
-If response code seen in your logs from google is a 401, check that Google Workspace Admin has done DWD grant, as described above.
+If response code seen in your logs from google is a 401, check that Google Workspace&trade; Admin has done DWD grant, as described above.
 
 #### 403
-If response code seen in your logs from Google is a 403, check that Google Workspace Admin has done DWD grant, as described above, **with the proper list of OAuth scopes**. Confirm that the list in the grant as shown in the Google Workspace Admin console MATCHES what is configured on the `OAUTH_SCOPES` environment variable of your proxy instance.  
+If response code seen in your logs from Google is a 403, check that Google Workspace&trade; Admin has done DWD grant, as described above, **with the proper list of OAuth scopes**. Confirm that the list in the grant as shown in the Google Workspace&trade; Admin console MATCHES what is configured on the `OAUTH_SCOPES` environment variable of your proxy instance.  
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
 
 
 
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/calendar/README.md
+++ b/docs/sources/google-workspace/calendar/README.md
@@ -1,6 +1,6 @@
-# Google Calendar
+# Google Calendar&trade;
 
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 
@@ -14,3 +14,8 @@ all Google Workspace connectors.
     [sanitized/event.json](example-api-responses/sanitized/event.json)
   - [original/events.json](example-api-responses/original/events.json) |
     [sanitized/events.json](example-api-responses/sanitized/events.json)
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/calendar/README.md
+++ b/docs/sources/google-workspace/calendar/README.md
@@ -1,7 +1,7 @@
 # Google Calendar&trade;
 
 Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
-all Google Workspace connectors.
+all Google Workspace&trade connectors.
 
 
 ## Examples

--- a/docs/sources/google-workspace/directory/README.md
+++ b/docs/sources/google-workspace/directory/README.md
@@ -1,6 +1,6 @@
-# Google Directory
+# Google Workspace&trade; Directory
 
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 
@@ -16,3 +16,8 @@ all Google Workspace connectors.
 
 See more examples in the `docs/sources/google-workspace/gdrive/example-api-responses` folder
 of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/gdrive/README.md
+++ b/docs/sources/google-workspace/gdrive/README.md
@@ -1,6 +1,6 @@
-# Google Drive
+# Google Drive&trade;
 
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 
@@ -15,3 +15,8 @@ all Google Workspace connectors.
 
 See more examples in the `docs/sources/google-workspace/gdrive/example-api-responses` folder
 of the [Psoxy repository](https://github.com/Worklytics/psoxy).
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/gemini-in-workspace-apps/README.md
+++ b/docs/sources/google-workspace/gemini-in-workspace-apps/README.md
@@ -1,6 +1,6 @@
 # Gemini in Workspace Apps
 **beta**
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 This connector pulls Gemini-events from the Google Workspace audit log.
@@ -12,3 +12,8 @@ This connector pulls Gemini-events from the Google Workspace audit log.
 - Example Data:
     - [original/admin_reports_v1_activity_users_{userKey}_applications_gemini_in_workspace_apps.json](example-api-responses/original/admin_reports_v1_activity_users_{userKey}_applications_gemini_in_workspace_apps.json) |
       [sanitized/admin_reports_v1_activity_users_{userKey}_applications_gemini_in_workspace_apps.json](example-api-responses/sanitized/admin_reports_v1_activity_users_{userKey}_applications_gemini_in_workspace_apps.json)
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/gemini-usage-bulk/README.md
+++ b/docs/sources/google-workspace/gemini-usage-bulk/README.md
@@ -1,15 +1,15 @@
-# Gemini Usage
+# Gemini&trade; Usage
 
-Worklytics supports the import of Gemini Usage reports to analyze AI adoption in your organization.
+Worklytics&trade; supports the import of Gemini&trade; Usage reports to analyze AI adoption in your organization.
 
-As of Feb 2025, these reports must be downloaded periodically by a sufficiently privileged user from the Google Workspace Admin Console.
+As of Feb 2025, these reports must be downloaded periodically by a sufficiently privileged user from the Google Workspace&trade; Admin Console.
 The reports cover ~4 weeks of history; we recommend downloading them at least weekly to provide granular insights into AI adoption.
 
 More information:
 https://support.google.com/a/answer/14564320
 
 The CSV report file must then be uploaded to a proxy `-input` bucket for your connector, which will then be processed by the pseudonymization proxy to prepare it
-for import to Worklytics.
+for import to Worklytics&trade;.
 
 
 ## Data Inventory
@@ -18,24 +18,24 @@ As of Feb 2025, the report includes the following fields, providing per-user usa
 | Field Name    | Description                                           |
 |---------------|-------------------------------------------------------|
 | Email         | The email address of the user                         |
-| Overall usage | Sum of all Gemini usage across Google Workspace apps  |
-| Active days   | The number of days when user used Gemini              |
-| Gmail         | Count of instances of Gemini usage in Gmail           |
-| Docs          | Count of instances of Gemini usage in Docs            |
-| Sheets        | Count of instances of Gemini usage in Sheets          |
-| Slides        | Count of instances of Gemini usage in Slides          |
-| Drive         | Count of instances of Gemini usage in Drive           |
-| Meet          | Count of instances of Gemini usage in Meet            |
-| Gemini app    | Count of instances of Gemini usage in the Gemini app  |
+| Overall usage | Sum of all Gemini&trade; usage across Google Workspace&trade; apps  |
+| Active days   | The number of days when user used Gemini&trade;              |
+| Gmail&trade;         | Count of instances of Gemini&trade; usage in Gmail&trade;           |
+| Google Docs&trade;          | Count of instances of Gemini&trade; usage in Docs            |
+| Google Sheets&trade;        | Count of instances of Gemini&trade; usage in Sheets          |
+| Google Slides&trade;        | Count of instances of Gemini&trade; usage in Slides          |
+| Google Drive&trade;         | Count of instances of Gemini&trade; usage in Drive           |
+| Google Meet&trade;          | Count of instances of Gemini&trade; usage in Meet            |
+| Gemini&trade; app    | Count of instances of Gemini&trade; usage in the Gemini&trade; app  |
 
 
 ## Instructions to Connect
 
   1. Add `gemini-usage` to your list of `custom_bulk_connector_rules` in your `terraform.tfvars` file for your proxy configuration then `terraform apply`.
   2. Review your terraform plan/output; find the `-input` bucket name for your connector.
-  3. Download the Gemini Usage report from the Google Workspace Admin Console (or ask a sufficiently privileged Google Workspace admin to do so). see `TODO 1 - gemini-usage` file that your `terraform apply` generated.
+  3. Download the Gemini&trade; Usage report from the Google Workspace&trade; Admin Console (or ask a sufficiently privileged Google Workspace&trade; admin to do so). see `TODO 1 - gemini-usage` file that your `terraform apply` generated.
   4. Upload the usage report to the `-input` bucket (via AWS/GCP console, using `gsutil`/`s3` CLI, etc).
-  5. Create the a `Bulk Import - Psoxy` connection in Worklytics with `gemini-bulk` as parser; see `TODO 3 - gemini-usage` file that your `terraform apply` generated.
+  5. Create the a `Bulk Import - Psoxy` connection in Worklytics&trade; with `gemini-bulk` as parser; see `TODO 3 - gemini-usage` file that your `terraform apply` generated.
   6. Repeat steps 3-4 as needed, to provide granular insights into AI adoption in your organization.  We recommend weekly uploads.
 
 ```hcl
@@ -59,3 +59,8 @@ custom_bulk_connector_rules = {
 ```
 
 ![gemini-usage-admin-console.png](gemini-usage-admin-console.png)
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/gmail/README.md
+++ b/docs/sources/google-workspace/gmail/README.md
@@ -1,6 +1,6 @@
-# Gmail
+# Gmail&trade;
 
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 ## Examples
@@ -10,3 +10,8 @@ all Google Workspace connectors.
   - [original/message.json](example-api-responses/original/message.json) |
     [sanitized/message.json](example-api-responses/sanitized/message.json)
 
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/google-chat/README.md
+++ b/docs/sources/google-workspace/google-chat/README.md
@@ -1,6 +1,6 @@
-# Google Chat
+# Google Chat&trade;
 
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 
@@ -10,3 +10,8 @@ all Google Workspace connectors.
 - Example Data:
   - [original/chat-activities.json](example-api-responses/original/chat-activities.json) |
     [sanitized/chat-activities.json](example-api-responses/sanitized/chat-activities.json)
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.

--- a/docs/sources/google-workspace/meet/README.md
+++ b/docs/sources/google-workspace/meet/README.md
@@ -1,6 +1,6 @@
-# Google Meet
+# Google Meet&trade;
 
-Please review the [Google Workspace README](../README.md) for general information applicable to
+Please review the [Google Workspace&trade; README](../README.md) for general information applicable to
 all Google Workspace connectors.
 
 
@@ -10,3 +10,8 @@ all Google Workspace connectors.
 - Example Data:
   - [original/meet-activities.json](example-api-responses/original/meet-activities.json) |
     [sanitized/meet-activities.json](example-api-responses/sanitized/meet-activities.json)
+
+
+---
+Google Workspace&trade; and related marks are trademarks of Google LLC.
+Worklytics&trade; is a trademark of Worklytics, Corp.


### PR DESCRIPTION
### Features
- add Google trademarks
- add Worklytics trademarks


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? **no**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and attribution updates; no runtime, configuration, or dependency changes.
> 
> **Overview**
> Updates the Google Workspace connector documentation to consistently use trademarked product names (eg `Google Workspace™`, `Gmail™`, `Google Drive™`, `Gemini™`) and clarifies connector labels accordingly.
> 
> Adds trademark attribution footers for Google and Worklytics across the Google Workspace docs, including the main `docs/sources/google-workspace/README.md` and each connector README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb591079608c5578d59ca7fe9d99f02554f0dd8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->