### PR TITLE
S220 health check fix

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandler.java
@@ -3,7 +3,13 @@ package co.worklytics.psoxy.gateway.impl;
 import co.worklytics.psoxy.ControlHeader;
 import co.worklytics.psoxy.HashUtils;
 import co.worklytics.psoxy.HealthCheckResult;
-import co.worklytics.psoxy.gateway.*;
+import co.worklytics.psoxy.gateway.ApiModeConfigProperty;
+import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.psoxy.gateway.HttpEventRequest;
+import co.worklytics.psoxy.gateway.HttpEventResponse;
+import co.worklytics.psoxy.gateway.ProxyConfigProperty;
+import co.worklytics.psoxy.gateway.SecretStore;
+import co.worklytics.psoxy.gateway.SourceAuthStrategy;
 import co.worklytics.psoxy.gateway.impl.oauth.OAuthRefreshTokenSourceAuthStrategy;
 import co.worklytics.psoxy.rules.RulesUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,7 +24,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -186,8 +191,9 @@ public class HealthCheckRequestHandler {
         // if SALT configured, as a hash of it to the health check, to enable detection of changes
         // (if salt changes, client needs to know; as all subsequent pseudonyms produced by proxy instance from that point
         // will be inconsistent with the prior ones)
-        config.getConfigPropertyAsOptional(ProxyConfigProperty.PSOXY_SALT)
-                .ifPresent(salt -> healthCheckResult.saltSha256Hash(hashUtils.hash(salt, SALT_FOR_SALT)));
+        Optional.of(piiSaltHash())
+            .filter(StringUtils::isNotBlank)
+            .ifPresent(healthCheckResult::saltSha256Hash);
 
         try {
             sourceAuthStrategy.get().validateConfigValues().forEach(healthCheckResult::warningMessage);
@@ -218,7 +224,7 @@ public class HealthCheckRequestHandler {
      */
     public String piiSaltHash() {
         if (piiSaltHash == null) {
-            piiSaltHash = config.getConfigPropertyAsOptional(ProxyConfigProperty.PSOXY_SALT)
+            piiSaltHash = secretStore.getConfigPropertyAsOptional(ProxyConfigProperty.PSOXY_SALT)
                 .map(salt -> hashUtils.hash(salt, SALT_FOR_SALT)).orElse("");
         }
         return piiSaltHash;

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/HealthCheckRequestHandlerTest.java
@@ -1,6 +1,7 @@
 package co.worklytics.psoxy.gateway.impl;
 
 import co.worklytics.psoxy.ControlHeader;
+import co.worklytics.psoxy.HealthCheckResult;
 import co.worklytics.psoxy.PsoxyModule;
 import co.worklytics.psoxy.gateway.ApiModeConfigProperty;
 import co.worklytics.psoxy.gateway.HttpEventRequest;
@@ -8,18 +9,20 @@ import co.worklytics.psoxy.gateway.HttpEventResponse;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.test.MockModules;
 import dagger.Component;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class HealthCheckRequestHandlerTest {
@@ -56,7 +59,7 @@ public class HealthCheckRequestHandlerTest {
     HttpEventRequest request;
 
     @Test
-    void handleIfHealthCheck_should_serialize_response() {
+    void handleIfHealthCheck_should_serialize_response() throws IOException {
         when(request.getHeader(ControlHeader.HEALTH_CHECK.getHttpHeader()))
                 .thenReturn(Optional.of(""));
 
@@ -66,6 +69,13 @@ public class HealthCheckRequestHandlerTest {
         Optional<HttpEventResponse> response = handler.handleIfHealthCheck(request);
 
         assertTrue(response.isPresent());
+        HealthCheckResult result = handler.objectMapper.readValue(response.get().getBody(), HealthCheckResult.class);
+        assertEquals("something", result.getConfiguredSource());
+        assertEquals("host", result.getConfiguredHost());
+        assertTrue(result.getNonDefaultSalt());
+        assertEquals(Collections.emptySet(), result.getMissingConfigProperties());
+        assertTrue(StringUtils.isNotBlank(result.getSaltSha256Hash()));
+        assertTrue(result.passed());
 
         assertEquals(HttpStatus.SC_OK, response.get().getStatusCode());
     }


### PR DESCRIPTION
### Fixes
- [psoxy healtcheck does not show salt hash if using AWS Secret Store](https://app.asana.com/1/27145998307022/project/1213457449259792/task/1213569868602897)
- Reading SALT from configService, not secretStore for health check / piiSaltSha

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? no
 - breaking changes? no