### PR TITLE
S221 handle reversible email

### DIFF
--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
@@ -1,56 +1,5 @@
 package co.worklytics.psoxy.gateway.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.time.Clock;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Stream;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import org.apache.hc.core5.http.HttpHeaders;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import com.avaulta.gateway.pseudonyms.Pseudonym;
-import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
-import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
-import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
-import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
-import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
-import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpRequestFactory;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.LowLevelHttpRequest;
-import com.google.api.client.http.LowLevelHttpResponse;
-import com.google.api.client.json.Json;
-import com.google.api.client.testing.http.HttpTesting;
-import com.google.api.client.testing.http.MockHttpTransport;
-import com.google.api.client.testing.http.MockLowLevelHttpRequest;
-import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import co.worklytics.psoxy.ConfigRulesModule;
 import co.worklytics.psoxy.ControlHeader;
 import co.worklytics.psoxy.Pseudonymizer;
@@ -69,23 +18,69 @@ import co.worklytics.psoxy.rules.msft.PrebuiltSanitizerRules;
 import co.worklytics.test.MockModules;
 import co.worklytics.test.TestModules;
 import co.worklytics.test.TestUtils;
+import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
+import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
+import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
+import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
+import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
+import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.Json;
+import com.google.api.client.testing.http.HttpTesting;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import dagger.Component;
 import lombok.SneakyThrows;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class ApiDataRequestHandlerTest {
 
     @Singleton
     @Component(modules = {
-        PsoxyModule.class, 
+        PsoxyModule.class,
         MockModules.ForConfigService.class,
-        MockModules.ForSecretStore.class, 
+        MockModules.ForSecretStore.class,
         MockModules.ForRules.class,
         MockModules.ForSourceAuthStrategySet.class,
-        MockModules.ForHttpTransportFactory.class, 
+        MockModules.ForHttpTransportFactory.class,
         MockModules.ForSideOutputs.class,
         MockModules.ForAsyncApiDataRequestHandler.class,
         TestModules.ForWebhookCollectorModeConfig.class,
-        TestModules.ForFixedUUID.class, 
+        TestModules.ForFixedUUID.class,
         TestModules.ForFixedClock.class,})
     public interface Container {
         void inject(ApiDataRequestHandlerTest test);
@@ -496,6 +491,61 @@ class ApiDataRequestHandlerTest {
         }
 
         verify(spy, times(1)).reverseRequestBodyTokenization(anyString(), anyString());
+    }
+
+    @Test
+    @SneakyThrows
+    void handleShouldReverseReversibleEmailInPostBody() {
+        setup("azure-ad", "graph.microsoft.com");
+
+        ApiDataRequestHandler spy = spy(handler);
+
+        String originalEmail = "user@example.com";
+        String encodedEmail = pseudonymEncoder.encode(Pseudonym.builder()
+            .hash(deterministicTokenizationStrategy.getToken(originalEmail, Function.identity()))
+            .domain("example.com")
+            .reversible(reversibleTokenizationStrategy
+                .getReversibleToken(originalEmail, Function.identity()))
+            .build());
+        String requestBody = String.format("{\"email\":\"%s\",\"status\":\"active\"}", encodedEmail);
+
+        HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
+        when(request.getHeader(ControlHeader.PSEUDONYM_IMPLEMENTATION.getHttpHeader()))
+            .thenReturn(Optional.of(PseudonymImplementation.DEFAULT.getHttpHeaderValue()));
+        when(request.getHttpMethod()).thenReturn("POST");
+        when(request.getHeader(HttpHeaders.CONTENT_TYPE))
+            .thenReturn(Optional.of("application/json"));
+        when(request.getPath()).thenReturn("/graphql");
+        when(request.getQuery()).thenReturn(Optional.empty());
+        when(request.getBody()).thenReturn(requestBody.getBytes(StandardCharsets.UTF_8));
+
+        HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
+        HttpRequest mockSourceApiRequest = mock(HttpRequest.class);
+        com.google.api.client.http.HttpHeaders headers = new com.google.api.client.http.HttpHeaders();
+        when(mockSourceApiRequest.getHeaders()).thenReturn(headers);
+        when(requestFactory.buildRequest(anyString(), any(), any())).thenReturn(mockSourceApiRequest);
+        doReturn(requestFactory).when(spy).getRequestFactory(any());
+
+        RESTApiSanitizerImpl sanitizer = mock(RESTApiSanitizerImpl.class);
+        when(sanitizer.isAllowed(anyString(), any(), anyString(), any())).thenReturn(true);
+        spy.sanitizer = sanitizer;
+
+        try {
+            spy.handle(request, ApiDataRequestHandler.ProcessingContext.builder()
+                .async(false).requestId("r")
+                .requestReceivedAt(clock.instant()).build());
+        } catch (Exception ignored) {
+            // request execution is not fully mocked; capture forwarded body before failure
+        }
+
+        ArgumentCaptor<HttpContent> contentCaptor = ArgumentCaptor.forClass(HttpContent.class);
+        verify(requestFactory).buildRequest(eq("POST"), any(), contentCaptor.capture());
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        contentCaptor.getValue().writeTo(output);
+
+        assertEquals("{\"email\":\"user@example.com\",\"status\":\"active\"}",
+            output.toString(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoder.java
@@ -1,14 +1,15 @@
 package com.avaulta.gateway.pseudonyms.impl;
 
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import com.avaulta.gateway.pseudonyms.Pseudonym;
 import com.avaulta.gateway.pseudonyms.PseudonymEncoder;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
 import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
 import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 //NOTE: coupled to fixed-length hash function
 public class UrlSafeTokenPseudonymEncoder implements PseudonymEncoder {
@@ -38,9 +39,26 @@ public class UrlSafeTokenPseudonymEncoder implements PseudonymEncoder {
     Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     Base64.Decoder decoder = Base64.getUrlDecoder();
 
+    // Match the reversible token prefix literally, eg `p~` + 43 chars of base64url.
+    // Then match the base64url body of the reversible token.
+    // The length is at least the encoded reversible payload length.
+    static final String REVERSIBLE_PSEUDONYM_REGEX =
+        Pattern.quote(REVERSIBLE_PREFIX) + "[a-zA-Z0-9_-]{"
+            + REVERSIBLE_PSEUDONYM_LENGTH_WITHOUT_PREFIX + ",}";
+
+    // Match only the reversible pseudonym token itself.
     public static final Pattern REVERSIBLE_PSEUDONYM_PATTERN =
-        //Pattern.compile("p\\~[a-zA-Z0-9_-]{43,}"); //not clear to me why this doesn't work
-        Pattern.compile(Pattern.quote(REVERSIBLE_PREFIX) + "[a-zA-Z0-9_-]{" + REVERSIBLE_PSEUDONYM_LENGTH_WITHOUT_PREFIX + ",}");
+        Pattern.compile(REVERSIBLE_PSEUDONYM_REGEX);
+
+    // group 1: reversible pseudonym
+    // group 2: optional domain, if any (emails have it, but domain is included in encoded)
+    public static final Pattern REVERSIBLE_PSEUDONYM_WITH_OPTIONAL_DOMAIN_PATTERN =
+        Pattern.compile(
+            // Capture the reversible pseudonym token as group 1.
+            "(" + REVERSIBLE_PSEUDONYM_REGEX + ")"
+                // Capture an optional email-style domain suffix as group 2.
+                // This is the trailing `@domain.tld` portion when present.
+                + "((?:@[A-Za-z0-9.-]+)?)");
 
     @Override
     public String encode(Pseudonym pseudonym) {
@@ -104,8 +122,8 @@ public class UrlSafeTokenPseudonymEncoder implements PseudonymEncoder {
      */
     public String decodeAndReverseAllContainedKeyedPseudonyms(String containsKeyedPseudonyms,
                                                               ReversibleTokenizationStrategy reidentifier) throws AESReversibleTokenizationStrategy.InvalidTokenException {
-        return REVERSIBLE_PSEUDONYM_PATTERN.matcher(containsKeyedPseudonyms).replaceAll(m -> {
-            String keyedPseudonym = m.group();
+        return REVERSIBLE_PSEUDONYM_WITH_OPTIONAL_DOMAIN_PATTERN.matcher(containsKeyedPseudonyms).replaceAll(m -> {
+            String keyedPseudonym = m.group(1);
 
             //q: if this fails, just return 'm.group()' as-is?? to consider possibility that pattern matched
             // something it shouldn't

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
@@ -1,7 +1,7 @@
 package com.avaulta.gateway.pseudonyms.impl;
 
-import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.pseudonyms.Pseudonym;
+import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
 import com.avaulta.gateway.tokens.impl.AESReversibleTokenizationStrategy;
 import com.avaulta.gateway.tokens.impl.Sha256DeterministicTokenizationStrategy;
@@ -53,6 +53,28 @@ public class UrlSafeTokenPseudonymEncoderTest {
         Pseudonym decoded = pseudonymEncoder.decode(encoded);
         assertArrayEquals(decoded.getHash(), pseudonym.getHash());
         assertArrayEquals(decoded.getReversible(), pseudonym.getReversible());
+    }
+
+    @Test
+    void reversibleDomain() {
+        String expected = "p~FLIM5xLgQ5m5vrONCMIiijaoUeFSBBLdaKBXGHqa5OQcZWU39HniZ3phdmegLotuacdckYPaf9zpKnrv9Ez-SQ@worklytics.co";
+        String original = "juan@worklytics.co";
+        Pseudonym pseudonym = Pseudonym.builder()
+            .hash(deterministicTokenizationStrategy.getToken(original, Function.identity()))
+            .domain("worklytics.co")
+            .reversible(pseudonymizationStrategy.getReversibleToken(original, Function.identity()))
+            .build();
+
+        String encoded = pseudonymEncoder.encode(pseudonym);
+
+        assertEquals(expected, encoded);
+        assertArrayEquals(deterministicTokenizationStrategy.getToken(original, Function.identity()), pseudonym.getHash());
+
+        Pseudonym decoded = pseudonymEncoder.decode(encoded);
+        assertArrayEquals(decoded.getHash(), pseudonym.getHash());
+        assertArrayEquals(decoded.getReversible(), pseudonym.getReversible());
+        assertEquals("worklytics.co", decoded.getDomain());
+        assertEquals(original, pseudonymizationStrategy.getOriginalDatum(decoded.getReversible()));
     }
 
     @ParameterizedTest

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
@@ -9,10 +9,12 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Base64;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -55,13 +57,15 @@ public class UrlSafeTokenPseudonymEncoderTest {
         assertArrayEquals(decoded.getReversible(), pseudonym.getReversible());
     }
 
-    @Test
-    void reversibleDomain() {
-        String expected = "p~FLIM5xLgQ5m5vrONCMIiijaoUeFSBBLdaKBXGHqa5OQcZWU39HniZ3phdmegLotuacdckYPaf9zpKnrv9Ez-SQ@worklytics.co";
-        String original = "juan@worklytics.co";
+    @CsvSource(value = {
+        "juan, worklytics.co, p~FLIM5xLgQ5m5vrONCMIiijaoUeFSBBLdaKBXGHqa5OQcZWU39HniZ3phdmegLotuacdckYPaf9zpKnrv9Ez-SQ@worklytics.co",
+        "juan, internal.worklytics.co, p~b3L-lcamqefZ4pvw0gqJ2KJRVQ2H8XlW4y2QMm5ATWeQDc1khHNTXbikRg2I86-lLYcFuLJdUNdgWYGxjaf3Jw@internal.worklytics.co"})
+    @ParameterizedTest
+    void reversibleDomain(String username, String domain, String expected) {
+        String original = username + "@" + domain;
         Pseudonym pseudonym = Pseudonym.builder()
             .hash(deterministicTokenizationStrategy.getToken(original, Function.identity()))
-            .domain("worklytics.co")
+            .domain(domain)
             .reversible(pseudonymizationStrategy.getReversibleToken(original, Function.identity()))
             .build();
 
@@ -73,8 +77,20 @@ public class UrlSafeTokenPseudonymEncoderTest {
         Pseudonym decoded = pseudonymEncoder.decode(encoded);
         assertArrayEquals(decoded.getHash(), pseudonym.getHash());
         assertArrayEquals(decoded.getReversible(), pseudonym.getReversible());
-        assertEquals("worklytics.co", decoded.getDomain());
+        assertEquals(domain, decoded.getDomain());
         assertEquals(original, pseudonymizationStrategy.getOriginalDatum(decoded.getReversible()));
+    }
+
+    @CsvSource(value = {
+        "juan, worklytics.co, p~FLIM5xLgQ5m5vrONCMIiijaoUeFSBBLdaKBXGHqa5OQcZWU39HniZ3phdmegLotuacdckYPaf9zpKnrv9Ez-SQ@worklytics.co",
+        "juan, internal.worklytics.co, p~b3L-lcamqefZ4pvw0gqJ2KJRVQ2H8XlW4y2QMm5ATWeQDc1khHNTXbikRg2I86-lLYcFuLJdUNdgWYGxjaf3Jw@internal.worklytics.co"})
+    @ParameterizedTest
+    void reversiblePatternCapturesTokenAndDomainSeparately(String username, String domain, String value) {
+        Matcher matcher = UrlSafeTokenPseudonymEncoder.REVERSIBLE_PSEUDONYM_WITH_OPTIONAL_DOMAIN_PATTERN.matcher(value);
+
+        assertTrue(matcher.find());
+        assertEquals(value.substring(0, value.indexOf('@')), matcher.group(1));
+        assertEquals("@" + domain, matcher.group(2));
     }
 
     @ParameterizedTest
@@ -101,6 +117,22 @@ public class UrlSafeTokenPseudonymEncoderTest {
             pseudonymizationStrategy);
 
         assertEquals(String.format(template, original, original), r);
+    }
+
+    @Test
+    @SneakyThrows
+    void reverseAll_reversibleEmailWithDomainSuffixMatched() {
+        String original = "juan@worklytics.co";
+        String encodedPseudonym = pseudonymEncoder.encode(Pseudonym.builder()
+            .hash(deterministicTokenizationStrategy.getToken(original, Function.identity()))
+            .domain("worklytics.co")
+            .reversible(pseudonymizationStrategy.getReversibleToken(original, Function.identity()))
+            .build());
+
+        String reversed = pseudonymEncoder.decodeAndReverseAllContainedKeyedPseudonyms(
+            "user=" + encodedPseudonym, pseudonymizationStrategy);
+
+        assertEquals("user=" + original, reversed);
     }
 
     @Test

--- a/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
+++ b/java/gateway-core/src/test/java/com/avaulta/gateway/pseudonyms/impl/UrlSafeTokenPseudonymEncoderTest.java
@@ -82,10 +82,10 @@ public class UrlSafeTokenPseudonymEncoderTest {
     }
 
     @CsvSource(value = {
-        "juan, worklytics.co, p~FLIM5xLgQ5m5vrONCMIiijaoUeFSBBLdaKBXGHqa5OQcZWU39HniZ3phdmegLotuacdckYPaf9zpKnrv9Ez-SQ@worklytics.co",
-        "juan, internal.worklytics.co, p~b3L-lcamqefZ4pvw0gqJ2KJRVQ2H8XlW4y2QMm5ATWeQDc1khHNTXbikRg2I86-lLYcFuLJdUNdgWYGxjaf3Jw@internal.worklytics.co"})
+        "worklytics.co, p~FLIM5xLgQ5m5vrONCMIiijaoUeFSBBLdaKBXGHqa5OQcZWU39HniZ3phdmegLotuacdckYPaf9zpKnrv9Ez-SQ@worklytics.co",
+        "internal.worklytics.co, p~b3L-lcamqefZ4pvw0gqJ2KJRVQ2H8XlW4y2QMm5ATWeQDc1khHNTXbikRg2I86-lLYcFuLJdUNdgWYGxjaf3Jw@internal.worklytics.co"})
     @ParameterizedTest
-    void reversiblePatternCapturesTokenAndDomainSeparately(String username, String domain, String value) {
+    void reversiblePatternCapturesTokenAndDomainSeparately(String domain, String value) {
         Matcher matcher = UrlSafeTokenPseudonymEncoder.REVERSIBLE_PSEUDONYM_WITH_OPTIONAL_DOMAIN_PATTERN.matcher(value);
 
         assertTrue(matcher.find());


### PR DESCRIPTION
### Fixes
Handle reversible email tokens with domain suffixes

[Psoxy not reversing emails properly](https://app.asana.com/1/27145998307022/project/1201603071257597/task/1213735472795644)

### Change implications

- dependencies added/changed? **no**
- something important to note in future release notes?
  - Reversible email tokens now decode correctly when the encoded value preserves a trailing domain suffix.
