### PR TITLE
Add missing perm on builder

### DIFF
--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -225,6 +225,10 @@ module "api_connector" {
     module.psoxy.secrets,
     module.psoxy.artifact_repository
   )
+
+  depends_on = [
+    module.psoxy
+  ]
 }
 
 module "custom_api_connector_rules" {
@@ -316,7 +320,9 @@ module "webhook_collector" {
 
   secret_bindings = module.psoxy.secrets
 
-
+  depends_on = [
+    module.psoxy
+  ]
 }
 
 # END WEBHOOK COLLECTORS

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -327,6 +327,14 @@ resource "google_service_account" "proxy_builder_sa" {
   project      = var.project_id
 }
 
+resource "google_project_iam_member" "grant_proxy_builder_as_storage_object_viewer" {
+  count = var.provision_project_level_iam ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.proxy_builder_sa.email}"
+}
+
 # Grant Cloud Build builder role to the custom builder service account
 # Required for Cloud Functions Gen2 deployment to build the function
 # See: https://cloud.google.com/functions/docs/troubleshooting#build-service-account

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -327,7 +327,7 @@ resource "google_service_account" "proxy_builder_sa" {
   project      = var.project_id
 }
 
-resource "google_storage_bucket_iam_member" "grant_proxy_builder_as_storage_object_viewer" {
+resource "google_storage_bucket_iam_member" "grant_proxy_builder_object_viewer_on_artifacts" {
   count = local.is_remote_bundle ? 0 : 1
 
   bucket = google_storage_bucket.artifacts[0].name

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -328,11 +328,11 @@ resource "google_service_account" "proxy_builder_sa" {
 }
 
 resource "google_project_iam_member" "grant_proxy_builder_as_storage_object_viewer" {
-  count = var.provision_project_level_iam ? 1 : 0
+  count = var.provision_project_level_iam && var.builder_sa_email == null ? 1 : 0
 
   project = var.project_id
   role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.proxy_builder_sa.email}"
+  member  = "serviceAccount:${google_service_account.proxy_builder_sa[0].email}"
 }
 
 # Grant Cloud Build builder role to the custom builder service account

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -327,12 +327,12 @@ resource "google_service_account" "proxy_builder_sa" {
   project      = var.project_id
 }
 
-resource "google_project_iam_member" "grant_proxy_builder_as_storage_object_viewer" {
-  count = var.provision_project_level_iam && var.builder_sa_email == null ? 1 : 0
+resource "google_storage_bucket_iam_member" "grant_proxy_builder_as_storage_object_viewer" {
+  count = local.is_remote_bundle ? 0 : 1
 
-  project = var.project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.proxy_builder_sa[0].email}"
+  bucket = google_storage_bucket.artifacts[0].name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${local.builder_sa_email}"
 }
 
 # Grant Cloud Build builder role to the custom builder service account


### PR DESCRIPTION
After #1145, builder-sa requires `storageViewer` role; otherwise it cannot access to the bucket to check the status of the function during deployment

### Fixes
[Missing role for builder-sa in GCP](https://app.asana.com/1/27145998307022/project/1213638267413355/task/1213802944713819)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
