### PR TITLE
Glean reversible rules for id and email

### DIFF
--- a/docs/sources/glean/example-api-responses/sanitized/list-entities-response.json
+++ b/docs/sources/glean/example-api-responses/sanitized/list-entities-response.json
@@ -1,18 +1,18 @@
 {
   "results":[
     {
-      "obfuscatedId":"t~WO6ZqzuAlomZiWLfNpl4m2ubveZggJyxVxGZ6TdrQmQ",
+      "obfuscatedId":"p~WO6ZqzuAlomZiWLfNpl4m2ubveZggJyxVxGZ6TdrQmROjOZcZL7IlG8_yGsRyhpw",
       "metadata":{
-        "email":"t~pFwtup8U9udj9BUAJMyERjzE44BnFwV8xjcROXFJi5I@company.com",
+        "email":"p~pFwtup8U9udj9BUAJMyERjzE44BnFwV8xjcROXFJi5I82SaslrAp7hyfaJOcG35apl6t2NkCaBDXpWUZ7yaKgg@company.com",
         "timezone":"Pacific Standard Time",
         "timezoneIANA":"America/Los_Angeles",
         "timezoneOffset":-28800
       }
     },
     {
-      "obfuscatedId":"t~W1er0e5Mva6ieNnfrVGngARTnWwfxO_jgABfUGxX-to",
+      "obfuscatedId":"p~W1er0e5Mva6ieNnfrVGngARTnWwfxO_jgABfUGxX-toFQsv0Lhgo89vzC2NSMIjx",
       "metadata":{
-        "email":"t~4xUx9DR4XA_pv5eituW3A8vfh3rh6wIyX9syZYagtRg@company.com"
+        "email":"p~4xUx9DR4XA_pv5eituW3A8vfh3rh6wIyX9syZYagtRjykJa_hggdrk0jt0JncozKfu42xgBG_y1e139XwWRFGQ@company.com"
       }
     }
   ],
@@ -25,14 +25,14 @@
       "members":[
         {
           "person":{
-            "obfuscatedId":"t~WO6ZqzuAlomZiWLfNpl4m2ubveZggJyxVxGZ6TdrQmQ"
+            "obfuscatedId":"p~WO6ZqzuAlomZiWLfNpl4m2ubveZggJyxVxGZ6TdrQmROjOZcZL7IlG8_yGsRyhpw"
           },
           "relationship":"MEMBER",
           "joinDate":"2020-01-15T00:00:00.000Z"
         },
         {
           "person":{
-            "obfuscatedId":"t~McBhipEIT09F5M-6gcaE7l-gwXpLRl7MqxqsJKq1R2Y"
+            "obfuscatedId":"p~McBhipEIT09F5M-6gcaE7l-gwXpLRl7MqxqsJKq1R2Zte8haYy2f4JFmt2ZEsgeV"
           },
           "relationship":"MANAGER",
           "joinDate":"2018-03-01T00:00:00.000Z"

--- a/docs/sources/glean/glean.yaml
+++ b/docs/sources/glean/glean.yaml
@@ -30,9 +30,13 @@ endpoints:
     transforms:
       - !<pseudonymize>
         jsonPaths:
+          - "$..aliasEmails[*]"
+        encoding: "URL_SAFE_TOKEN"
+      - !<pseudonymize>
+        jsonPaths:
           - "$..email"
           - "$..obfuscatedId"
-          - "$..aliasEmails[*]"
+        includeReversible: true
         encoding: "URL_SAFE_TOKEN"
     responseSchema:
       type: "object"


### PR DESCRIPTION
Updated rules for supporting reversible in case of email and obfuscatedId when listing person entities

### Fixes
[Update psoxy rules](https://app.asana.com/1/27145998307022/task/1213912775305687) 

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213912775305687