### PR TITLE
TODO template documentation fixes

### DIFF
--- a/infra/modules/worklytics-connector-specs/docs/chatgpt/enterprise/instructions.tftpl
+++ b/infra/modules/worklytics-connector-specs/docs/chatgpt/enterprise/instructions.tftpl
@@ -1,9 +1,9 @@
-See Chat GPT documentation for the latest, but as of August 2025, you must create an API key and fill that as a secret in your host platform. The Proxy will then use Basic Authentication when connecting to Chat GPT.
+See Chat GPT documentation for the latest, but as of August 2025, you must create an API key and fill that as a secret in your host platform.
 
 1 - Create a new [OpenAI API Platform Portal](https://platform.openai.com/api-keys) on Settings ->  Default Project | All Permissions
   - Note that this must be a new key.  Once the Compliance API scopes are granted, all other scopes are revoked.
   - Reminder:  This key can only be viewed/copied once.
-2 - Copy the key immediately - you won’t see it again; then paste it as the `${path_to_instance_parameters}BASIC_AUTH_USER_ID` parameter value  in your proxy's host platform.
+2 - Copy the key immediately - you won’t see it again; then paste it as the `${path_to_instance_parameters}ACCESS_TOKEN` parameter value in the psoxy's Secret Manager.
 3- Send an email to [support@openai.com](mailto:support@openai.com) with:
   - (1) the last 4 digits of the API key
   - (2) the Key Name

--- a/infra/modules/worklytics-connector-specs/docs/chatgpt/enterprise/instructions.tftpl
+++ b/infra/modules/worklytics-connector-specs/docs/chatgpt/enterprise/instructions.tftpl
@@ -1,9 +1,9 @@
-See Chat GPT documentation for the latest, but as of August 2025, you must create an API key and fill that as a secret in your host platform.
+See ChatGPT documentation for the latest, but as of August 2025, you must create an API key and fill that as a secret in your host platform.
 
 1 - Create a new [OpenAI API Platform Portal](https://platform.openai.com/api-keys) on Settings ->  Default Project | All Permissions
   - Note that this must be a new key.  Once the Compliance API scopes are granted, all other scopes are revoked.
   - Reminder:  This key can only be viewed/copied once.
-2 - Copy the key immediately - you won’t see it again; then paste it as the `${path_to_instance_parameters}ACCESS_TOKEN` parameter value in the psoxy's Secret Manager.
+2 - Copy the key immediately - you won’t see it again; then paste it as the `${path_to_instance_parameters}ACCESS_TOKEN` parameter value in the proxy's Secret Manager.
 3- Send an email to [support@openai.com](mailto:support@openai.com) with:
   - (1) the last 4 digits of the API key
   - (2) the Key Name


### PR DESCRIPTION
ChatGPT uses OAuthAccessToken for authentication not basic auth.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes? no
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
