### PR TITLE
Propagate error info to caller

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/ProcessedDataMetadataFields.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ProcessedDataMetadataFields.java
@@ -25,11 +25,6 @@ public enum ProcessedDataMetadataFields {
     ERROR("Error"),
 
     /**
-     * a specific error code while processing the request, complements ERROR (optional)
-     */
-    ERROR_CODE("Error-Code"),
-
-    /**
      * a warning code while processing the request
      */
     WARNING("Warning"),

--- a/java/core/src/main/java/co/worklytics/psoxy/ProcessedDataMetadataFields.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ProcessedDataMetadataFields.java
@@ -25,6 +25,11 @@ public enum ProcessedDataMetadataFields {
     ERROR("Error"),
 
     /**
+     * a specific error code while processing the request, complements ERROR (optional)
+     */
+    ERROR_CODE("Error-Code"),
+
+    /**
      * a warning code while processing the request
      */
     WARNING("Warning"),

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -236,11 +236,9 @@ public class ApiDataRequestHandler {
             // InvalidTokenException extends RuntimeException
             if (e instanceof ReversibleTokenizationStrategy.InvalidTokenException ite) {
                 return HttpEventResponse.builder()
-                    // should this be a 500? Maybe 422 Unprocessable Content?
-                    .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                    .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
                     .header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
-                        ErrorCauses.FAILED_TO_BUILD_URL.name())
-                    .header(ProcessedDataMetadataFields.ERROR_CODE.getHttpHeader(), ite.getErrorCode().getCode())
+                        ite.getErrorCode().name())
                     .build();
             }
 
@@ -397,11 +395,9 @@ public class ApiDataRequestHandler {
             log.log(Level.WARNING, e.getMessage(), e);
             return builder.build();
         } catch (ReversibleTokenizationStrategy.InvalidTokenException e) {
-            // should this be 422 Unprocessable Content, rather than conflict?
-            builder.statusCode(HttpStatus.SC_CONFLICT);
+            builder.statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
             builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
-                ErrorCauses.TOKENIZED_REQUEST_PARAMETER_INVALID.name());
-            builder.header(ProcessedDataMetadataFields.ERROR_CODE.getHttpHeader(), e.getErrorCode().getCode());
+                e.getErrorCode().name());
 
             log.log(Level.WARNING, e.getMessage(), e);
             return builder.build();

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -1,39 +1,31 @@
 package co.worklytics.psoxy.gateway.impl;
 
-import java.io.IOException;
-import java.net.ConnectException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Provider;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.classic.methods.HttpHead;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.NameValuePair;
-import org.apache.hc.core5.http.message.BasicNameValuePair;
-import org.apache.hc.core5.net.WWWFormCodec;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.utils.URIBuilder;
+import co.worklytics.psoxy.ControlHeader;
+import co.worklytics.psoxy.ErrorCauses;
+import co.worklytics.psoxy.ProcessedDataMetadataFields;
+import co.worklytics.psoxy.Pseudonymizer;
+import co.worklytics.psoxy.PseudonymizerImplFactory;
+import co.worklytics.psoxy.RESTApiSanitizer;
+import co.worklytics.psoxy.RESTApiSanitizerFactory;
+import co.worklytics.psoxy.gateway.ApiModeConfigProperty;
+import co.worklytics.psoxy.gateway.AsyncApiDataRequestHandler;
+import co.worklytics.psoxy.gateway.ConfigService;
+import co.worklytics.psoxy.gateway.HttpEventRequest;
+import co.worklytics.psoxy.gateway.HttpEventResponse;
+import co.worklytics.psoxy.gateway.ProcessedContent;
+import co.worklytics.psoxy.gateway.ProxyConstants;
+import co.worklytics.psoxy.gateway.SecretStore;
+import co.worklytics.psoxy.gateway.SourceAuthStrategy;
+import co.worklytics.psoxy.gateway.impl.output.OutputUtils;
+import co.worklytics.psoxy.gateway.output.ApiDataOutputUtils;
+import co.worklytics.psoxy.gateway.output.ApiDataSideOutput;
+import co.worklytics.psoxy.gateway.output.ApiSanitizedDataOutput;
+import co.worklytics.psoxy.gateway.output.Output;
+import co.worklytics.psoxy.rules.RESTRules;
+import co.worklytics.psoxy.rules.RulesUtils;
+import co.worklytics.psoxy.utils.ComposedHttpRequestInitializer;
+import co.worklytics.psoxy.utils.GzipedContentHttpRequestInitializer;
+import co.worklytics.psoxy.utils.URLUtils;
 import com.avaulta.gateway.pseudonyms.PseudonymImplementation;
 import com.avaulta.gateway.pseudonyms.impl.UrlSafeTokenPseudonymEncoder;
 import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
@@ -56,31 +48,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import co.worklytics.psoxy.ControlHeader;
-import co.worklytics.psoxy.ErrorCauses;
-import co.worklytics.psoxy.ProcessedDataMetadataFields;
-import co.worklytics.psoxy.Pseudonymizer;
-import co.worklytics.psoxy.PseudonymizerImplFactory;
-import co.worklytics.psoxy.RESTApiSanitizer;
-import co.worklytics.psoxy.RESTApiSanitizerFactory;
-import co.worklytics.psoxy.gateway.ApiModeConfigProperty;
-import co.worklytics.psoxy.gateway.AsyncApiDataRequestHandler;
-import co.worklytics.psoxy.gateway.ConfigService;
-import co.worklytics.psoxy.gateway.HttpEventRequest;
-import co.worklytics.psoxy.gateway.HttpEventResponse;
-import co.worklytics.psoxy.gateway.ProcessedContent;
-import co.worklytics.psoxy.gateway.SecretStore;
-import co.worklytics.psoxy.gateway.SourceAuthStrategy;
-import co.worklytics.psoxy.gateway.impl.output.OutputUtils;
-import co.worklytics.psoxy.gateway.output.ApiDataOutputUtils;
-import co.worklytics.psoxy.gateway.output.ApiDataSideOutput;
-import co.worklytics.psoxy.gateway.output.ApiSanitizedDataOutput;
-import co.worklytics.psoxy.gateway.output.Output;
-import co.worklytics.psoxy.rules.RESTRules;
-import co.worklytics.psoxy.rules.RulesUtils;
-import co.worklytics.psoxy.utils.ComposedHttpRequestInitializer;
-import co.worklytics.psoxy.utils.GzipedContentHttpRequestInitializer;
-import co.worklytics.psoxy.utils.URLUtils;
 import dagger.Lazy;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -90,7 +57,32 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.Value;
 import lombok.extern.java.Log;
-import co.worklytics.psoxy.gateway.ProxyConstants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.net.WWWFormCodec;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.utils.URIBuilder;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor(onConstructor_ = @Inject)
 @Log
@@ -241,6 +233,17 @@ public class ApiDataRequestHandler {
             // our canonicalization code for this to go wrong
             log.log(Level.WARNING, "Error parsing  / building request URL", e);
 
+            // InvalidTokenException extends RuntimeException
+            if (e instanceof ReversibleTokenizationStrategy.InvalidTokenException ite) {
+                return HttpEventResponse.builder()
+                    // should this be a 500? Maybe 422 Unprocessable Content?
+                    .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                    .header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
+                        ErrorCauses.FAILED_TO_BUILD_URL.name())
+                    .body("Error parsing request URL. Error " + ite.getErrorCode().getCode())
+                    .build();
+            }
+
             return HttpEventResponse.builder()
                     .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
                     .header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
@@ -375,7 +378,7 @@ public class ApiDataRequestHandler {
             if (isSocketTimeoutException(e)) {
                 return buildNetworkTimeoutErrorResponse(builder, e);
             }
-            
+
             builder.statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
             builder.body("Failed to parse request; review logs");
             builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
@@ -394,9 +397,10 @@ public class ApiDataRequestHandler {
             log.log(Level.WARNING, e.getMessage(), e);
             return builder.build();
         } catch (ReversibleTokenizationStrategy.InvalidTokenException e) {
+            // should this be 422 Unprocessable Content, rather than conflict?
             builder.statusCode(HttpStatus.SC_CONFLICT);
             builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
-                ErrorCauses.TOKENIZED_REQUEST_PARAMETER_INVALID.name());
+                ErrorCauses.TOKENIZED_REQUEST_PARAMETER_INVALID.name() + ":" + e.getErrorCode().getCode());
             log.log(Level.WARNING, e.getMessage(), e);
             return builder.build();
         }
@@ -1045,7 +1049,7 @@ public class ApiDataRequestHandler {
      */
     private HttpEventResponse buildNetworkTimeoutErrorResponse(
             HttpEventResponse.HttpEventResponseBuilder builder, Throwable e) {
-        
+
         builder.statusCode(HttpStatus.SC_BAD_GATEWAY);
         builder.body("Network timeout: unable to connect to target API. " +
                 "This could indicate: " +
@@ -1054,12 +1058,12 @@ public class ApiDataRequestHandler {
                 "If using VPC connector, verify: VPC connector is active, CIDR range is correct, firewall allows egress, Cloud NAT is configured.");
         builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
                 ErrorCauses.NETWORK_EGRESS_BLOCKED.name());
-        
+
         log.log(Level.SEVERE, "SocketTimeoutException: Network timeout connecting to target API", e);
         log.log(Level.SEVERE, "Possible causes: " +
                 "1) Proxy network egress blocked - check VPC connector configuration, firewall rules, Cloud NAT; " +
                 "2) Target API unreachable or slow - check API status, DNS resolution");
-        
+
         return builder.build();
     }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -240,7 +240,7 @@ public class ApiDataRequestHandler {
                     .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
                     .header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
                         ErrorCauses.FAILED_TO_BUILD_URL.name())
-                    .body("Error parsing request URL. Error " + ite.getErrorCode().getCode())
+                    .header(ProcessedDataMetadataFields.ERROR_CODE.getHttpHeader(), ite.getErrorCode().getCode())
                     .build();
             }
 
@@ -400,7 +400,9 @@ public class ApiDataRequestHandler {
             // should this be 422 Unprocessable Content, rather than conflict?
             builder.statusCode(HttpStatus.SC_CONFLICT);
             builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
-                ErrorCauses.TOKENIZED_REQUEST_PARAMETER_INVALID.name() + ":" + e.getErrorCode().getCode());
+                ErrorCauses.TOKENIZED_REQUEST_PARAMETER_INVALID.name());
+            builder.header(ProcessedDataMetadataFields.ERROR_CODE.getHttpHeader(), e.getErrorCode().getCode());
+
             log.log(Level.WARNING, e.getMessage(), e);
             return builder.build();
         }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
@@ -1,5 +1,7 @@
 package com.avaulta.gateway.tokens;
 
+import lombok.Getter;
+
 import java.util.function.Function;
 
 /**
@@ -41,11 +43,32 @@ public interface ReversibleTokenizationStrategy {
 
     /**
      * Indicates that the token could not be reversed, likely because invalid
-     *
      */
     class InvalidTokenException extends RuntimeException {
-        public InvalidTokenException(String message, Throwable cause) {
-            super(message, cause);
+
+        @Getter
+        public enum ErrorCode {
+            ALGORITHM_PARAMETER_ERROR("ITE01", "Failed to decrypt token; some algorithm parameter, such as iv, is wrong"),
+            BAD_PADDING("ITE02", "Failed to decrypt token; token appears to be corrupted or invalid, due to mismatch between token's padding and the padding expected by the cipher mode"),
+            ILLEGAL_BLOCK_SIZE("ITE003", "Failed to decrypt token; token appears to be corrupted or invalid, as block size seems to differ from expected"),
+            DECRYPTION_FAILED("ITE004", "Failed to decrypt token; most likely because encryption key has been rotated");
+
+            private final String code;
+            private final String message;
+
+            ErrorCode(String code, String message) {
+                this.code = code;
+                this.message = message;
+            }
+
+        }
+
+        @Getter
+        private final ErrorCode errorCode;
+
+        public InvalidTokenException(ErrorCode errorCode, Throwable cause) {
+            super("[" + errorCode.getCode() + "] " + errorCode.getMessage(), cause);
+            this.errorCode = errorCode;
         }
     }
 }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
@@ -48,8 +48,8 @@ public interface ReversibleTokenizationStrategy {
 
         @Getter
         public enum ErrorCode {
-            ALGORITHM_PARAMETER_ERROR("ITE01", "Failed to decrypt token; some algorithm parameter, such as iv, is wrong"),
-            BAD_PADDING("ITE02", "Failed to decrypt token; token appears to be corrupted or invalid, due to mismatch between token's padding and the padding expected by the cipher mode"),
+            ALGORITHM_PARAMETER_ERROR("ITE001", "Failed to decrypt token; some algorithm parameter, such as iv, is wrong"),
+            BAD_PADDING("ITE002", "Failed to decrypt token; token appears to be corrupted or invalid, due to mismatch between token's padding and the padding expected by the cipher mode"),
             ILLEGAL_BLOCK_SIZE("ITE003", "Failed to decrypt token; token appears to be corrupted or invalid, as block size seems to differ from expected"),
             DECRYPTION_FAILED("ITE004", "Failed to decrypt token; most likely because encryption key has been rotated");
 

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
@@ -48,16 +48,14 @@ public interface ReversibleTokenizationStrategy {
 
         @Getter
         public enum ErrorCode {
-            ALGORITHM_PARAMETER_ERROR("ITE001", "Failed to decrypt token; some algorithm parameter, such as iv, is wrong"),
-            BAD_PADDING("ITE002", "Failed to decrypt token; token appears to be corrupted or invalid, due to mismatch between token's padding and the padding expected by the cipher mode"),
-            ILLEGAL_BLOCK_SIZE("ITE003", "Failed to decrypt token; token appears to be corrupted or invalid, as block size seems to differ from expected"),
-            DECRYPTION_FAILED("ITE004", "Failed to decrypt token; most likely because encryption key has been rotated");
+            ALGORITHM_PARAMETER_ERROR("Failed to decrypt token; some algorithm parameter, such as iv, is wrong"),
+            BAD_PADDING("Failed to decrypt token; token appears to be corrupted or invalid, due to mismatch between token's padding and the padding expected by the cipher mode"),
+            ILLEGAL_BLOCK_SIZE("Failed to decrypt token; token appears to be corrupted or invalid, as block size seems to differ from expected"),
+            DECRYPTION_FAILED("Failed to decrypt token; most likely because encryption key has been rotated");
 
-            private final String code;
             private final String message;
 
-            ErrorCode(String code, String message) {
-                this.code = code;
+            ErrorCode(String message) {
                 this.message = message;
             }
 
@@ -67,7 +65,7 @@ public interface ReversibleTokenizationStrategy {
         private final ErrorCode errorCode;
 
         public InvalidTokenException(ErrorCode errorCode, Throwable cause) {
-            super("[" + errorCode.getCode() + "] " + errorCode.getMessage(), cause);
+            super(errorCode.name() + ": " + errorCode.getMessage(), cause);
             this.errorCode = errorCode;
         }
     }

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/ReversibleTokenizationStrategy.java
@@ -42,7 +42,7 @@ public interface ReversibleTokenizationStrategy {
 
 
     /**
-     * Indicates that the token could not be reversed, likely because invalid
+     * Indicates that the token could not be reversed, likely because it is invalid.
      */
     class InvalidTokenException extends RuntimeException {
 

--- a/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/impl/AESReversibleTokenizationStrategy.java
+++ b/java/gateway-core/src/main/java/com/avaulta/gateway/tokens/impl/AESReversibleTokenizationStrategy.java
@@ -1,12 +1,14 @@
 package com.avaulta.gateway.tokens.impl;
 
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.KeySpec;
-import java.util.Arrays;
-import java.util.function.Function;
+import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
+import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.Value;
+
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -16,14 +18,13 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
-import com.avaulta.gateway.tokens.DeterministicTokenizationStrategy;
-import com.avaulta.gateway.tokens.ReversibleTokenizationStrategy;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.Value;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+import java.util.function.Function;
 
 @Builder
 @RequiredArgsConstructor
@@ -130,13 +131,13 @@ public class AESReversibleTokenizationStrategy implements ReversibleTokenization
         } catch (InvalidKeyException e) {
             throw new RuntimeException("Invalid encryption key configuration", e);
         } catch (InvalidAlgorithmParameterException e) {
-            throw new InvalidTokenException("Failed to decrypt token; some algorithm parameter, such as iv, is wrong", e);
+            throw new InvalidTokenException(InvalidTokenException.ErrorCode.ALGORITHM_PARAMETER_ERROR, e);
         } catch (BadPaddingException e) {
-            throw new InvalidTokenException("Failed to decrypt token; token appears to be corrupted or invalid, due to mismatch between token's padding and the padding expected by the cipher mode", e);
+            throw new InvalidTokenException(InvalidTokenException.ErrorCode.BAD_PADDING, e);
         } catch (IllegalBlockSizeException e) {
-            throw new InvalidTokenException("Failed to decrypt token; token appears to be corrupted or invalid, as block size seems to differ from expected", e);
+            throw new InvalidTokenException(InvalidTokenException.ErrorCode.ILLEGAL_BLOCK_SIZE, e);
         } catch (RuntimeException e) {
-            throw new InvalidTokenException("Failed to decrypt token; most likely because encryption key has been rotated", e);
+            throw new InvalidTokenException(InvalidTokenException.ErrorCode.DECRYPTION_FAILED, e);
         }
     }
 


### PR DESCRIPTION
Try to propagate some info to the caller on the FAILED_TO_BUILD_URL error case.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? no
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change -> no
