### PR TITLE
Gong api fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes to be including in future/planned release notes will be added here.
 - `pseudonymizeRegexMatches`: apply the pseudonymization to any match found in the field instead of the first one.
 - `Atlassian Organization API`: added new connector for fetching audit events from Atlassian Organization API, which provides access to audit events from users and tools like Rovo.
 - `GitLab`: added support for GitLab (gitlab.com) and Self-Managed/Dedicated instances
+- `Gong Metrics`: fixed how endpoint and auth is used
 
 ## [0.5.18](https://github.com/Worklytics/psoxy/releases/tag/v0.5.18)
 - `aws`: updated IAM policy for invoking lambda functions, to reflect AWS perm changes; anyone deploying NEW api connectors on AWS will have to use this version or later, or backport similar change. (See https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html)

--- a/docs/sources/gong/gong-metrics/README.md
+++ b/docs/sources/gong/gong-metrics/README.md
@@ -31,7 +31,8 @@ See the [official Gong OAuth documentation](https://help.gong.io/docs/create-an-
 
 ### Required Configuration
 
-1. **Terraform Variables**: Set `gong_instance_subdomain` in your `terraform.tfvars` file (e.g., if your Gong URL is `acme.gong.io`, set `gong_instance_subdomain = "acme"`)
+1. **Terraform Variables**: Set `gong_instance_subdomain` in your `terraform.tfvars` file. When generating the token setup for the connecor you will get
+something as `acme.api.gong.io`; the value you should use for this variable set is `gong_instance_subdomain = "acme"
 
 2. **Secret Manager Parameters**:
    - `PSOXY_GONG_METRICS_CLIENT_ID` - OAuth Client ID from Gong app

--- a/docs/sources/gong/gong-metrics/README.md
+++ b/docs/sources/gong/gong-metrics/README.md
@@ -31,8 +31,8 @@ See the [official Gong OAuth documentation](https://help.gong.io/docs/create-an-
 
 ### Required Configuration
 
-1. **Terraform Variables**: Set `gong_instance_subdomain` in your `terraform.tfvars` file. When generating the token setup for the connecor you will get
-something as `acme.api.gong.io`; the value you should use for this variable set is `gong_instance_subdomain = "acme"
+1. **Terraform Variables**: Set `gong_instance_subdomain` in your `terraform.tfvars` file (e.g., if your Gong URL is `acme.gong.io`, set `gong_instance_subdomain = "acme"`).
+When doing the setup of the connector you should double check this value with the one provided by Gong to ensure the API endpoint will match the one of your Gong instance.
 
 2. **Secret Manager Parameters**:
    - `PSOXY_GONG_METRICS_CLIENT_ID` - OAuth Client ID from Gong app

--- a/infra/modules/worklytics-connector-specs/auth_config.tftest.hcl
+++ b/infra/modules/worklytics-connector-specs/auth_config.tftest.hcl
@@ -36,8 +36,8 @@ run "oauth_refresh_token_locks" {
 run "oauth_refresh_token_access_tokens" {
 
   assert {
-    error_message = "all 18 oauth connectors use ACCESS_TOKEN (all except dropbox??)"
-    condition = 18 == length([for k, v in output.available_oauth_data_source_connectors :
+    error_message = "all 19 oauth connectors use ACCESS_TOKEN (all except dropbox??)"
+    condition = 19 == length([for k, v in output.available_oauth_data_source_connectors :
       v if anytrue([for var in v.secured_variables : var.name == "ACCESS_TOKEN"])
     ])
   }

--- a/infra/modules/worklytics-connector-specs/docs/gong/metrics.tftpl
+++ b/infra/modules/worklytics-connector-specs/docs/gong/metrics.tftpl
@@ -73,6 +73,8 @@ Then proceed with creating your Gong OAuth app:
    }
    ```
 
+   Following this example, review the value you have for `gong_instance_subdomain` and in this case it should be `your-instance` to match the `api_base_url_for_customer` returned in the token response.
+
 7. Store the OAuth credentials in your proxy's secret manager:
    - `${path_to_instance_parameters}CLIENT_ID` with the Client ID from step 5
    - `${path_to_instance_parameters}CLIENT_SECRET` with the Client Secret from step 5

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -47,7 +47,7 @@ locals {
   gitlab_example_project_id                = coalesce(var.gitlab_example_project_id, "YOUR_GITLAB_PROJECT_ID")
   # Normalize gitlab_url by stripping protocol prefix (https:// or http://) and trailing slash
   gitlab_url                    = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
-  gong_instance_subdomain       = coalesce(replace(var.gong_instance_subdomain, ".api", ""), "YOUR_GONG_INSTANCE_SUBDOMAIN")
+  gong_instance_subdomain       = coalesce(try(replace(var.gong_instance_subdomain, ".api", "")), "YOUR_GONG_INSTANCE_SUBDOMAIN")
   glean_instance_subdomain      = coalesce(var.glean_instance_subdomain, "YOUR_GLEAN_INSTANCE_SUBDOMAIN")
   salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -46,7 +46,7 @@ locals {
   gitlab_example_group_id                  = coalesce(var.gitlab_example_group_id, "YOUR_GITLAB_GROUP_ID")
   gitlab_example_project_id                = coalesce(var.gitlab_example_project_id, "YOUR_GITLAB_PROJECT_ID")
   # Normalize gitlab_url by stripping protocol prefix (https:// or http://) and trailing slash
-  gitlab_url                    = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
+  gitlab_url = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
   gong_instance_subdomain = (
     endswith(coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN"), ".api")
     ? coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN")

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -46,12 +46,8 @@ locals {
   gitlab_example_group_id                  = coalesce(var.gitlab_example_group_id, "YOUR_GITLAB_GROUP_ID")
   gitlab_example_project_id                = coalesce(var.gitlab_example_project_id, "YOUR_GITLAB_PROJECT_ID")
   # Normalize gitlab_url by stripping protocol prefix (https:// or http://) and trailing slash
-  gitlab_url = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
-  gong_instance_subdomain = (
-    endswith(coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN"), ".api")
-    ? coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN")
-    : "${coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN")}.api"
-  )
+  gitlab_url                    = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
+  gong_instance_subdomain       = coalesce(replace(var.gong_instance_subdomain, ".api", ""), "YOUR_GONG_INSTANCE_SUBDOMAIN")
   glean_instance_subdomain      = coalesce(var.glean_instance_subdomain, "YOUR_GLEAN_INSTANCE_SUBDOMAIN")
   salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -527,7 +527,7 @@ EOT
       display_name : "Gong"
       worklytics_connector_name : "Gong Metrics via Psoxy"
       target_host : "${local.gong_instance_subdomain}.api.gong.io"
-      source_auth_strategy : "basic_auth"
+      source_auth_strategy : "oauth2_refresh_token"
       secured_variables : [
         {
           name : "ACCESS_TOKEN"

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -47,7 +47,7 @@ locals {
   gitlab_example_project_id                = coalesce(var.gitlab_example_project_id, "YOUR_GITLAB_PROJECT_ID")
   # Normalize gitlab_url by stripping protocol prefix (https:// or http://) and trailing slash
   gitlab_url                    = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
-  gong_instance_subdomain       = coalesce(try(replace(var.gong_instance_subdomain, ".api", "")), "YOUR_GONG_INSTANCE_SUBDOMAIN")
+  gong_instance_subdomain       = trimsuffix(coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN"), ".api")
   glean_instance_subdomain      = coalesce(var.glean_instance_subdomain, "YOUR_GLEAN_INSTANCE_SUBDOMAIN")
   salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -47,7 +47,11 @@ locals {
   gitlab_example_project_id                = coalesce(var.gitlab_example_project_id, "YOUR_GITLAB_PROJECT_ID")
   # Normalize gitlab_url by stripping protocol prefix (https:// or http://) and trailing slash
   gitlab_url                    = replace(trimsuffix(var.gitlab_url, "/"), "/^https?:\\/\\//", "")
-  gong_instance_subdomain       = coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN")
+  gong_instance_subdomain = (
+    endswith(coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN"), ".api")
+    ? coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN")
+    : "${coalesce(var.gong_instance_subdomain, "YOUR_GONG_INSTANCE_SUBDOMAIN")}.api"
+  )
   glean_instance_subdomain      = coalesce(var.glean_instance_subdomain, "YOUR_GLEAN_INSTANCE_SUBDOMAIN")
   salesforce_example_account_id = coalesce(var.salesforce_example_account_id, "{ANY ACCOUNT ID}")
 
@@ -522,7 +526,7 @@ EOT
       worklytics_connector_id : "gong-metrics-psoxy"
       display_name : "Gong"
       worklytics_connector_name : "Gong Metrics via Psoxy"
-      target_host : "${local.gong_instance_subdomain}.gong.io"
+      target_host : "${local.gong_instance_subdomain}.api.gong.io"
       source_auth_strategy : "basic_auth"
       secured_variables : [
         {


### PR DESCRIPTION
Couple of issues spotted with Gong:
1) APi endpoint should have `instance.api.gong.io`; that `api` part was missing when adding the URL. Now it will be provided handle if missing or included.
2) Auth strategy was wrong; it should be `oauth2_refresh_token` instead of `basic_auth`

Docs updated.

### Fixes
[bug: gong subdomain issues](https://app.asana.com/1/27145998307022/project/1213797956438900/task/1214359291881725)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
