### PR TITLE
java 25 runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes to be including in future/planned release notes will be added here.
 - performance: optimized `redactExceptPhrases` rule to use non-reluctant matchers.
 
 ## [0.6.0](https://github.com/Worklytics/psoxy/releases/tag/v0.6.0)
+- **AWS / GCP**: Upgraded deployment runtime environments to Java 25, while maintaining Java 21 byte-code and language-level compatibility.
 - `gcp`: Dedicated `proxy_builder_sa` service account is now provisioned and used for Cloud Build operations when provisioning Cloud Functions, eliminating project-level IAM dependencies on the default Compute Engine service account.
 - `zoom`: Default rules for Zoom have been updated, removing fields and endpoints not required.
 - `pseudonymizeRegexMatches`: apply the pseudonymization to any match found in the field instead of the first one.

--- a/infra/modules/aws-proxy-lambda/main.tf
+++ b/infra/modules/aws-proxy-lambda/main.tf
@@ -53,7 +53,7 @@ resource "aws_lambda_function" "instance" {
   function_name                  = local.function_name
   role                           = aws_iam_role.iam_for_lambda.arn
   architectures                  = ["arm64"] # 20% cheaper per ms exec time than x86_64
-  runtime                        = "java21"
+  runtime                        = "java25"
   filename                       = local.bundle_from_s3 ? null : var.path_to_function_zip
   s3_bucket                      = local.s3_bucket # null if local file
   s3_key                         = local.s3_key    # null if local file

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -200,7 +200,7 @@ resource "google_cloudfunctions2_function" "function" {
   location = var.region
 
   build_config {
-    runtime           = "java21"
+    runtime           = "java25"
     docker_repository = var.artifact_repository_id
     entry_point       = "co.worklytics.psoxy.Route"
     service_account   = var.builder_sa_id

--- a/infra/modules/gcp-proxy-bulk/main.tf
+++ b/infra/modules/gcp-proxy-bulk/main.tf
@@ -175,7 +175,7 @@ resource "google_cloudfunctions2_function" "function" {
   location    = var.region
 
   build_config {
-    runtime         = "java21"
+    runtime         = "java25"
     entry_point     = "co.worklytics.psoxy.GCSFileEvent"
     service_account = var.builder_sa_id
 

--- a/infra/modules/gcp-webhook-collector/main.tf
+++ b/infra/modules/gcp-webhook-collector/main.tf
@@ -277,7 +277,7 @@ resource "google_cloudfunctions2_function" "function" {
   location = var.region
 
   build_config {
-    runtime           = "java21"
+    runtime           = "java25"
     docker_repository = var.artifact_repository_id
     entry_point       = "co.worklytics.psoxy.GcpWebhookCollectorRoute"
     service_account   = var.builder_sa_id


### PR DESCRIPTION
### Features
- go to java25 runtime; was strongly suggested by friends at AWS java/lambda teams, as risk-free perf improvement.

### Change implications

 - dependencies added/changed? **yes - java25 runtime from java21**
 - something important to note in future release notes? **yes**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214428923612153