### PR TITLE
Update max time for GCP Bulk case

### DIFF
--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -360,7 +360,7 @@ module "bulk_connector" {
   todos_as_local_files              = var.todos_as_local_files
   tf_runner_iam_principal           = module.tf_runner.iam_principal
   available_memory_mb               = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 512)
-  timeout_seconds                   = min(coalesce(try(var.custom_bulk_connector_arguments[each.key].timeout_seconds, null), try(each.value.timeout_seconds, null), 540), 540)
+  timeout_seconds                   = coalesce(try(var.custom_bulk_connector_arguments[each.key].timeout_seconds, null), try(each.value.timeout_seconds, null), 540)
   gcp_principals_authorized_to_test = var.gcp_principals_authorized_to_test
   bucket_force_destroy              = var.bucket_force_destroy
   enable_versioning                 = var.version_sanitized_buckets

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -360,7 +360,7 @@ module "bulk_connector" {
   todos_as_local_files              = var.todos_as_local_files
   tf_runner_iam_principal           = module.tf_runner.iam_principal
   available_memory_mb               = coalesce(try(var.custom_bulk_connector_arguments[each.key].available_memory_mb, null), try(each.value.available_memory_mb, null), 512)
-  timeout_seconds                   = coalesce(try(var.custom_bulk_connector_arguments[each.key].timeout_seconds, null), try(each.value.timeout_seconds, null), 1800)
+  timeout_seconds                   = min(coalesce(try(var.custom_bulk_connector_arguments[each.key].timeout_seconds, null), try(each.value.timeout_seconds, null), 540), 540)
   gcp_principals_authorized_to_test = var.gcp_principals_authorized_to_test
   bucket_force_destroy              = var.bucket_force_destroy
   enable_versioning                 = var.version_sanitized_buckets

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -271,6 +271,7 @@ variable "bulk_connectors" {
     instructions_template = optional(string)
     settings_to_provide   = optional(map(string), {})
     available_memory_mb   = optional(number)
+    timeout_seconds       = optional(number)
   }))
 
   description = "map of connector id  => bulk connectors to provision"

--- a/infra/modules/gcp-proxy-bulk/variables.tf
+++ b/infra/modules/gcp-proxy-bulk/variables.tf
@@ -100,8 +100,13 @@ variable "available_memory_mb" {
 
 variable "timeout_seconds" {
   type        = number
-  description = "Timeout (in seconds) for the function. Default value is 1800 (30 minutes)."
-  default     = 1800
+  description = "Timeout (in seconds) for the function. GCP Cloud Functions v2 with an event trigger are hard-capped at 540s; HTTP-triggered functions allow up to 3600s. Bulk connectors use event triggers, so the effective maximum is 540."
+  default     = 540
+
+  validation {
+    condition     = var.timeout_seconds <= 540
+    error_message = "GCP Cloud Functions v2 with an event trigger cannot exceed 540 seconds."
+  }
 }
 
 variable "example_file" {


### PR DESCRIPTION
Limit for 2th generation of GCP functions in case of event triggered -our bulk case- is [540 seconds](https://docs.cloud.google.com/functions/quotas#time_limits), not 1800

Error will only apply to new functions, not the existing ones.

### Fixes
[GCP Bulk timeout to 540](https://app.asana.com/1/27145998307022/project/1213797956438900/task/1214798053965935)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
