### PR TITLE
0.6.0 upgrade fixes

### DIFF
--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -116,7 +116,7 @@ resource "random_password" "pseudonym_salt" {
 resource "google_secret_manager_secret_version" "initial_version" {
   secret      = google_secret_manager_secret.pseudonym_salt.id
   secret_data = sensitive(random_password.pseudonym_salt.result)
-  # if accidental versioning happens is best to just disable, default behavior is DELETE
+  # if accidental versioning happens it is best to just disable, default behavior is DELETE
   # customer can manually DELETE later on if needed
   deletion_policy = "DISABLE"
 
@@ -288,7 +288,7 @@ resource "google_project_iam_custom_role" "bucket_write" {
 
 # on v0.5.x this was "${local.environment_id_role_prefix}PsoxyInstanceSecretHandler"
 # v0.6.x upgrades
-# - causes a lot of changes, all role grants to on writable secrets
+# - causes a lot of changes, all role grants on writable secrets
 # - can't just import the old one because the name is different
 resource "google_project_iam_custom_role" "psoxy_instance_secret_role" {
   project     = var.project_id

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -286,6 +286,10 @@ resource "google_project_iam_custom_role" "bucket_write" {
   ]
 }
 
+# on v0.5.x this was "${local.environment_id_role_prefix}PsoxyInstanceSecretHandler"
+# v0.6.x upgrades
+# - causes a lot of changes, all role grants to on writable secrets
+# - can't just import the old one because the name is different
 resource "google_project_iam_custom_role" "psoxy_instance_secret_role" {
   project     = var.project_id
   role_id     = "${local.environment_id_role_prefix}secretVersionManager"

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -116,11 +116,17 @@ resource "random_password" "pseudonym_salt" {
 resource "google_secret_manager_secret_version" "initial_version" {
   secret      = google_secret_manager_secret.pseudonym_salt.id
   secret_data = sensitive(random_password.pseudonym_salt.result)
+  # if accidental versioning happens is best to just disable, default behavior is DELETE
+  # customer can manually DELETE later on if needed
+  deletion_policy = "DISABLE"
 
   # if customer changes value outside TF, don't overwrite
   lifecycle {
     ignore_changes = [
-      secret_data
+      secret_data,
+      # forward compatibility fix with provider on 7.x
+      secret_data_wo,
+      secret_data_wo_version
     ]
   }
 }
@@ -162,12 +168,17 @@ resource "random_password" "pseudonym_encryption_key" {
 resource "google_secret_manager_secret_version" "pseudonym_encryption_key_initial_version" {
   secret      = google_secret_manager_secret.pseudonymization_key.id
   secret_data = sensitive(random_password.pseudonym_encryption_key.result)
-
+  # if accidental versioning happens is best to just disable, default behavior is DELETE
+  # customer can manually DELETE later on if needed
+  deletion_policy = "DISABLE"
 
   # if customer changes value outside TF, don't overwrite
   lifecycle {
     ignore_changes = [
-      secret_data
+      secret_data,
+      # forward compatibility fix with provider on 7.x
+      secret_data_wo,
+      secret_data_wo_version
     ]
   }
 }


### PR DESCRIPTION
### Fixes
- Prevent destroy of SALT/ENCRYPTION KEY on version changes, default to DISABLE, so in case it happens it is recoverable
- Ignore changes on new attributes introduced with google provider upgrade (7.x)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? no
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change - no
