### PR TITLE
Pseudonymize GitHub audit log numeric user IDs

### DIFF
--- a/docs/sources/github/copilot/README.md
+++ b/docs/sources/github/copilot/README.md
@@ -1,8 +1,6 @@
 # GitHub Copilot
 
-**Connector ID:** `github-copilot`
-
-**Availability:** Alpha
+Availability: **ALPHA**
 
 ## Authentication workflow
 

--- a/docs/sources/github/copilot/example-api-responses/sanitized/org_audit_log.json
+++ b/docs/sources/github/copilot/example-api-responses/sanitized/org_audit_log.json
@@ -34,7 +34,7 @@
     "_document_id":"wNeUMoUP4j8RgRjpMg6YaQ",
     "action":"pull_request.merge",
     "actor":"t~IAUEqSLLtP3EjjkzslH-S1ULJZRLQnH9hT54jiI1gbM",
-    "actor_id":13968776,
+    "actor_id":"t~S3Nh4slc2XnLp5Qy1CD-pQew9-j0cePbX3U7-DE56Co",
     "actor_location":{
       "country_code":"ES"
     },
@@ -66,7 +66,7 @@
     "data":{
       "public_repo":true,
       "started_by":"t~IAUEqSLLtP3EjjkzslH-S1ULJZRLQnH9hT54jiI1gbM",
-      "started_by_id":42,
+      "started_by_id":"t~znQ9uPAsipaRVgakqmpOA0f-KZDE8pvKpaeCR50hj5Y",
       "category_type":"Resource Management"
     }
   }

--- a/docs/sources/github/copilot/github-copilot.yaml
+++ b/docs/sources/github/copilot/github-copilot.yaml
@@ -523,9 +523,11 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$..actor"
+          - "$..actor_id"
           - "$..user"
           - "$..user_id"
           - "$..started_by"
+          - "$..started_by_id"
         encoding: "URL_SAFE_TOKEN"
     queryParamSchemas:
       phrase:
@@ -563,9 +565,11 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$..actor"
+          - "$..actor_id"
           - "$..user"
           - "$..user_id"
           - "$..started_by"
+          - "$..started_by_id"
         encoding: "URL_SAFE_TOKEN"
     queryParamSchemas:
       phrase:

--- a/docs/sources/github/enterprise-server/README.md
+++ b/docs/sources/github/enterprise-server/README.md
@@ -1,8 +1,6 @@
 # GitHub Enterprise Server
 
-**Connector ID:** `github-enterprise-server`
-
-**Availability:** GA
+Availability: **GA**
 
 ## Authentication workflow
 

--- a/docs/sources/github/enterprise-server/example-api-responses/sanitized/org_audit_log.json
+++ b/docs/sources/github/enterprise-server/example-api-responses/sanitized/org_audit_log.json
@@ -34,7 +34,7 @@
     "_document_id":"wNeUMoUP4j8RgRjpMg6YaQ",
     "action":"pull_request.merge",
     "actor":"t~IAUEqSLLtP3EjjkzslH-S1ULJZRLQnH9hT54jiI1gbM",
-    "actor_id":13968776,
+    "actor_id":"t~S3Nh4slc2XnLp5Qy1CD-pQew9-j0cePbX3U7-DE56Co",
     "actor_location":{
       "country_code":"ES"
     },
@@ -66,7 +66,7 @@
     "data":{
       "public_repo":true,
       "started_by":"t~IAUEqSLLtP3EjjkzslH-S1ULJZRLQnH9hT54jiI1gbM",
-      "started_by_id":42,
+      "started_by_id":"t~znQ9uPAsipaRVgakqmpOA0f-KZDE8pvKpaeCR50hj5Y",
       "category_type":"Resource Management"
     }
   }

--- a/docs/sources/github/enterprise-server/github-enterprise-server.yaml
+++ b/docs/sources/github/enterprise-server/github-enterprise-server.yaml
@@ -495,9 +495,11 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$..actor"
+          - "$..actor_id"
           - "$..user"
           - "$..user_id"
           - "$..started_by"
+          - "$..started_by_id"
         encoding: "URL_SAFE_TOKEN"
   - pathTemplate: "/api/{enterpriseServerVersion}/organizations/{installationId}/audit-log"
     allowedQueryParams:
@@ -526,9 +528,11 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$..actor"
+          - "$..actor_id"
           - "$..user"
           - "$..user_id"
           - "$..started_by"
+          - "$..started_by_id"
         encoding: "URL_SAFE_TOKEN"
   - pathTemplate: "/api/{enterpriseServerVersion}/orgs/{org}/repos"
     allowedQueryParams:
@@ -628,7 +632,6 @@ endpoints:
           - "$..description"
           - "$..body"
           - "$..title"
-          - "$..temp_clone_token"
       - !<pseudonymize>
         jsonPaths:
           - "$..author.email"
@@ -818,7 +821,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-          - "$..temp_clone_token"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"
@@ -848,7 +850,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-          - "$..temp_clone_token"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github-non-enterprise/README.md
+++ b/docs/sources/github/github-non-enterprise/README.md
@@ -1,8 +1,6 @@
 # GitHub Free/Pro/Teams
 
-**Connector ID:** `github-non-enterprise`
-
-**Availability:** GA
+Availability: **GA**
 
 ## Authentication workflow
 

--- a/docs/sources/github/github-non-enterprise/github-non-enterprise.yaml
+++ b/docs/sources/github/github-non-enterprise/github-non-enterprise.yaml
@@ -526,7 +526,6 @@ endpoints:
           - "$..description"
           - "$..body"
           - "$..title"
-          - "$..temp_clone_token"
       - !<pseudonymize>
         jsonPaths:
           - "$..author.email"
@@ -716,7 +715,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-          - "$..temp_clone_token"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"
@@ -746,7 +744,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-          - "$..temp_clone_token"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/docs/sources/github/github/README.md
+++ b/docs/sources/github/github/README.md
@@ -1,8 +1,6 @@
 # GitHub
 
-**Connector ID:** `github`
-
-**Availability:** GA
+Availability: **GA**
 
 ## Authentication workflow
 

--- a/docs/sources/github/github/example-api-responses/sanitized/org_audit_log.json
+++ b/docs/sources/github/github/example-api-responses/sanitized/org_audit_log.json
@@ -34,7 +34,7 @@
     "_document_id":"wNeUMoUP4j8RgRjpMg6YaQ",
     "action":"pull_request.merge",
     "actor":"t~IAUEqSLLtP3EjjkzslH-S1ULJZRLQnH9hT54jiI1gbM",
-    "actor_id":13968776,
+    "actor_id":"t~S3Nh4slc2XnLp5Qy1CD-pQew9-j0cePbX3U7-DE56Co",
     "actor_location":{
       "country_code":"ES"
     },
@@ -66,7 +66,7 @@
     "data":{
       "public_repo":true,
       "started_by":"t~IAUEqSLLtP3EjjkzslH-S1ULJZRLQnH9hT54jiI1gbM",
-      "started_by_id":42,
+      "started_by_id":"t~znQ9uPAsipaRVgakqmpOA0f-KZDE8pvKpaeCR50hj5Y",
       "category_type":"Resource Management"
     }
   }

--- a/docs/sources/github/github/github.yaml
+++ b/docs/sources/github/github/github.yaml
@@ -495,9 +495,11 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$..actor"
+          - "$..actor_id"
           - "$..user"
           - "$..user_id"
           - "$..started_by"
+          - "$..started_by_id"
         encoding: "URL_SAFE_TOKEN"
   - pathTemplate: "/organizations/{installationId}/audit-log"
     allowedQueryParams:
@@ -526,9 +528,11 @@ endpoints:
       - !<pseudonymize>
         jsonPaths:
           - "$..actor"
+          - "$..actor_id"
           - "$..user"
           - "$..user_id"
           - "$..started_by"
+          - "$..started_by_id"
         encoding: "URL_SAFE_TOKEN"
   - pathTemplate: "/orgs/{org}/repos"
     allowedQueryParams:
@@ -628,7 +632,6 @@ endpoints:
           - "$..description"
           - "$..body"
           - "$..title"
-          - "$..temp_clone_token"
       - !<pseudonymize>
         jsonPaths:
           - "$..author.email"
@@ -818,7 +821,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-          - "$..temp_clone_token"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"
@@ -848,7 +850,6 @@ endpoints:
           - "$..signature"
           - "$..payload"
           - "$..dismissalMessage"
-          - "$..temp_clone_token"
       - !<redact>
         jsonPaths:
           - "$..['author','committer','review_requester','owner','user','requested_reviewer','closed_by','assigner','actor','assignee','creator'].['avatar_url','gravatar_id','url','html_url','followers_url','following_url','gists_url','starred_url','subscriptions_url','organizations_url','repos_url','events_url','received_events_url','name','company','location','bio','twitter_username']"

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/github/PrebuiltSanitizerRules.java
@@ -263,9 +263,11 @@ public class PrebuiltSanitizerRules {
                     .build())
             .transform(Transform.Pseudonymize.builder()
                     .jsonPath("$..actor")
+                    .jsonPath("$..actor_id")
                     .jsonPath("$..user")
                     .jsonPath("$..user_id")
                     .jsonPath("$..started_by")
+                    .jsonPath("$..started_by_id")
                     .build())
             .build();
 
@@ -288,9 +290,11 @@ public class PrebuiltSanitizerRules {
                     .build())
             .transform(Transform.Pseudonymize.builder()
                     .jsonPath("$..actor")
+                    .jsonPath("$..actor_id")
                     .jsonPath("$..user")
                     .jsonPath("$..user_id")
                     .jsonPath("$..started_by")
+                    .jsonPath("$..started_by_id")
                     .build())
             .build();
 
@@ -379,7 +383,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..signature")
                     .jsonPath("$..payload")
                     .jsonPath("$..dismissalMessage")
-                    .jsonPath("$..temp_clone_token")
                     .build())
             .transforms(generateUserTransformations("..", Arrays.asList(
                     // Owner can be a user or an organization user
@@ -410,7 +413,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..signature")
                     .jsonPath("$..payload")
                     .jsonPath("$..dismissalMessage")
-                    .jsonPath("$..temp_clone_token")
                     .build())
             .transforms(generateUserTransformations("..", Arrays.asList(
                     // Owner can be a user or an organization user
@@ -553,7 +555,6 @@ public class PrebuiltSanitizerRules {
                     .jsonPath("$..description")
                     .jsonPath("$..body")
                     .jsonPath("$..title")
-                    .jsonPath("$..temp_clone_token")
                     .build())
             .transform(Transform.Pseudonymize.builder()
                     .jsonPath("$..author.email")

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubCopilotTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubCopilotTests.java
@@ -213,6 +213,7 @@ public class GitHubCopilotTests extends JavaRulesTestBaseCase {
 
         Collection<String> PII = Arrays.asList(
                 "octocat",
+                "13968776",
                 "some-business"
         );
 
@@ -220,7 +221,7 @@ public class GitHubCopilotTests extends JavaRulesTestBaseCase {
 
         String sanitized = this.sanitize(endpoint, jsonString);
 
-        assertPseudonymized(sanitized, "octocat");
+        assertPseudonymized(sanitized, "octocat", "13968776");
 
         assertRedacted(sanitized,
                 "Update README.md",
@@ -246,6 +247,7 @@ public class GitHubCopilotTests extends JavaRulesTestBaseCase {
 
         Collection<String> PII = Arrays.asList(
             "octocat",
+            "13968776",
             "some-business"
         );
 
@@ -253,7 +255,7 @@ public class GitHubCopilotTests extends JavaRulesTestBaseCase {
 
         String sanitized = this.sanitize(endpoint, jsonString);
 
-        assertPseudonymized(sanitized, "octocat");
+        assertPseudonymized(sanitized, "octocat", "13968776");
 
         assertRedacted(sanitized,
             "Update README.md",

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubEnterpriseServerTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubEnterpriseServerTests.java
@@ -663,6 +663,7 @@ public class GitHubEnterpriseServerTests extends JavaRulesTestBaseCase {
 
         Collection<String> PII = Arrays.asList(
                 "octocat",
+                "13968776",
                 "some-business"
         );
 
@@ -670,7 +671,7 @@ public class GitHubEnterpriseServerTests extends JavaRulesTestBaseCase {
 
         String sanitized = this.sanitize(endpoint, jsonString);
 
-        assertPseudonymized(sanitized, "octocat");
+        assertPseudonymized(sanitized, "octocat", "13968776");
 
         assertRedacted(sanitized,
                 "Update README.md",

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/github/GitHubTests.java
@@ -71,6 +71,7 @@ public class GitHubTests extends GitHubNonEnterpriseTests {
 
         Collection<String> PII = Arrays.asList(
                 "octocat",
+                "13968776",
                 "some-business"
         );
 
@@ -78,7 +79,7 @@ public class GitHubTests extends GitHubNonEnterpriseTests {
 
         String sanitized = this.sanitize(endpoint, jsonString);
 
-        assertPseudonymized(sanitized, "octocat");
+        assertPseudonymized(sanitized, "octocat", "13968776");
 
         assertRedacted(sanitized,
                 "Update README.md",


### PR DESCRIPTION
## Summary
- Pseudonymize `actor_id` and `started_by_id` in GitHub, GitHub Copilot, and GitHub Enterprise Server audit-log responses (YAML rules, prebuilt sanitizer rules, fixtures, and tests).
- Split out from #1216 for independent review.

## Test plan
- [x] `mvn -pl core -am -Dtest=GitHubTests,GitHubEnterpriseServerTests,GitHubCopilotTests -Dsurefire.failIfNoSpecifiedTests=false test`


Made with [Cursor](https://cursor.com)