### PR TITLE
Reuse cached OAuth token to avoid redundant same-instance refresh

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -444,18 +444,17 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
          * @return a non-expired token to reuse, or empty if a refresh exchange is required
          */
         private Optional<AccessToken> findReusableAccessToken() {
-            AccessToken freshToken = sourceAuthStrategy.getCachedToken();
-            if (!sourceAuthStrategy.shouldRefresh(freshToken, clock.instant())) {
-                DevLogUtils.info(envVarsConfigService, log, "Token already refreshed " + freshToken.getExpirationTime());
-                return Optional.of(freshToken);
+            AccessToken cachedToken = sourceAuthStrategy.getCachedToken();
+            if (!sourceAuthStrategy.shouldRefresh(cachedToken, clock.instant())) {
+                return Optional.of(cachedToken);
             }
 
-            freshToken = sourceAuthStrategy.getSharedAccessTokenIfSupported().orElse(null);
-            if (sourceAuthStrategy.shouldRefresh(freshToken, clock.instant())) {
+            AccessToken sharedToken =
+                sourceAuthStrategy.getSharedAccessTokenIfSupported().orElse(null);
+            if (sourceAuthStrategy.shouldRefresh(sharedToken, clock.instant())) {
                 return Optional.empty();
-            } else if (freshToken != null) {
-                DevLogUtils.info(envVarsConfigService, log, "Token already refreshed " + freshToken.getExpirationTime());
-                return Optional.of(freshToken);
+            } else if (sharedToken != null) {
+                return Optional.of(sharedToken);
             }
             return Optional.empty();
         }
@@ -490,7 +489,9 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                     storeRefreshTokenIfRotated(tokenResponse);
 
                 } else {
-                    DevLogUtils.info(envVarsConfigService, log, "Token already refreshed");
+                    DevLogUtils.info(envVarsConfigService, log,
+                        "Reusing access token, expires: %s",
+                        reusableToken.get().getExpirationTime());
                     token = reusableToken.get();
                 }
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -169,7 +169,7 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
      */
     @Setter
     @Getter
-    private AccessToken cachedToken = null;
+    private volatile AccessToken cachedToken = null;
 
 
     @Override
@@ -439,7 +439,13 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
          * @return
          */
         private Optional<AccessToken> checkIfAlreadyRefreshed() {
-            AccessToken freshToken = sourceAuthStrategy.getSharedAccessTokenIfSupported().orElse(null);
+            AccessToken freshToken = sourceAuthStrategy.getCachedToken();
+            if (!sourceAuthStrategy.shouldRefresh(freshToken, clock.instant())) {
+                DevLogUtils.info(envVarsConfigService, log, "Token already refreshed " + freshToken.getExpirationTime());
+                return Optional.of(freshToken);
+            }
+
+            freshToken = sourceAuthStrategy.getSharedAccessTokenIfSupported().orElse(null);
             if (sourceAuthStrategy.shouldRefresh(freshToken, clock.instant())) {
                 return Optional.empty();
             } else if (freshToken != null) {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategy.java
@@ -162,10 +162,10 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
     RandomNumberGenerator randomNumberGenerator;
 
     /**
-     * -- SETTER --
-     *  Sets the local copy of the token, assumes valid until expiration.
+     * In-memory access token shared across concurrent requests on this instance.
      *
-     * @param token
+     * <p>Volatile for visibility on unsynchronized reads in {@link #getCredentials}; writes
+     * occur from {@code getCredentials} and from the synchronized refresh handler.
      */
     @Setter
     @Getter
@@ -434,11 +434,16 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
         }
 
         /**
-         * On shared-token scenarios, check if the token has been refreshed on another instance
-         * before attempting to refresh it locally.
-         * @return
+         * Return a still-valid access token if one was already obtained by another thread or
+         * instance, avoiding a refresh-token exchange.
+         *
+         * <p>Checks the in-memory cache first (same-instance refreshes), then the shared token
+         * store when {@link OAuthRefreshTokenSourceAuthStrategy#useSharedToken()} is true
+         * (cross-instance refreshes).
+         *
+         * @return a non-expired token to reuse, or empty if a refresh exchange is required
          */
-        private Optional<AccessToken> checkIfAlreadyRefreshed() {
+        private Optional<AccessToken> findReusableAccessToken() {
             AccessToken freshToken = sourceAuthStrategy.getCachedToken();
             if (!sourceAuthStrategy.shouldRefresh(freshToken, clock.instant())) {
                 DevLogUtils.info(envVarsConfigService, log, "Token already refreshed " + freshToken.getExpirationTime());
@@ -469,8 +474,8 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
             AccessToken token;
             if (acquired) {
                 DevLogUtils.info(envVarsConfigService, log, "Acquired lock to refresh token");
-                Optional<AccessToken> refreshedToken = checkIfAlreadyRefreshed();
-                if (refreshedToken.isEmpty()) {
+                Optional<AccessToken> reusableToken = findReusableAccessToken();
+                if (reusableToken.isEmpty()) {
                     // token still expired, refresh with lock acquired
                     DevLogUtils.info(envVarsConfigService, log, "Token refresh in progress");
 
@@ -486,7 +491,7 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
 
                 } else {
                     DevLogUtils.info(envVarsConfigService, log, "Token already refreshed");
-                    token = refreshedToken.get();
+                    token = reusableToken.get();
                 }
 
                 sourceAuthStrategy.setCachedToken(token);
@@ -500,11 +505,10 @@ public class OAuthRefreshTokenSourceAuthStrategy implements SourceAuthStrategy {
                 }
             } else {
                 // re-try recursively, w/ linear backoff
-                // this exec path should only happen when different instances (VMs) are attempting
-                // to refresh. 2+ threads of same VM can never hit this as the whole recursive call
-                // is synchronized (see #refreshAccessToken). So on same VM, this will block until
-                // A) acquires lock and refreshes
-                // B) checks already refreshed token and exits
+                // this path is for cross-instance lock contention only. Same-instance threads
+                // serialize on synchronized #refreshAccessToken; the second thread should reuse
+                // the first thread's token via findReusableAccessToken (in-memory cache, then
+                // shared token store).
                 Uninterruptibles.sleepUninterruptibly(WAIT_AFTER_FAILED_LOCK_ATTEMPTS
                         .plusMillis(randomNumberGenerator.nextInt(250)).multipliedBy(attempt + 1));
 

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
@@ -2,6 +2,7 @@ package co.worklytics.psoxy.gateway.impl.oauth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,10 +33,10 @@ import co.worklytics.psoxy.PsoxyModule;
 import co.worklytics.psoxy.SourceAuthModule;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.SecretStore;
+import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import co.worklytics.psoxy.utils.RandomNumberGenerator;
 import co.worklytics.psoxy.utils.RandomNumberGeneratorImpl;
 import co.worklytics.test.MockModules;
-import co.worklytics.test.TestModules;
 import dagger.Component;
 import lombok.SneakyThrows;
 
@@ -50,7 +51,6 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
     @Singleton
     @Component(modules = {
         PsoxyModule.class,
-        TestModules.ForApiModeConfig.class,
         SourceAuthModule.class,
         MockModules.ForConfigService.class,
         MockModules.ForRandomNumberGenerator.class,
@@ -202,6 +202,30 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
         assertTrue(accessToken.isPresent());
         assertEquals("my-token", accessToken.get().getTokenValue());
         assertEquals(1639526410000L, accessToken.get().getExpirationTime().getTime());
+    }
+
+    @SneakyThrows
+    @Test
+    public void refreshAccessTokenReturnsFreshCachedTokenWithoutExchange() {
+        Instant now = Instant.parse("2025-01-01T00:00:00Z");
+
+        OAuthRefreshTokenSourceAuthStrategy strategy = new OAuthRefreshTokenSourceAuthStrategy();
+        strategy.config = MockModules.provideMock(ConfigService.class);
+        strategy.randomNumberGenerator = this.randomNumberGenerator;
+        AccessToken cachedToken =
+            new AccessToken("cached-token", Date.from(now.plus(1, ChronoUnit.HOURS)));
+        strategy.setCachedToken(cachedToken);
+
+        when(strategy.config.getConfigPropertyAsOptional(OAuthRefreshTokenSourceAuthStrategy.ConfigProperty.USE_SHARED_TOKEN))
+            .thenReturn(Optional.of("false"));
+
+        OAuthRefreshTokenSourceAuthStrategy.TokenRefreshHandlerImpl tokenRefreshHandler =
+            new OAuthRefreshTokenSourceAuthStrategy.TokenRefreshHandlerImpl();
+        tokenRefreshHandler.envVarsConfigService = MockModules.provideMock(EnvVarsConfigService.class);
+        tokenRefreshHandler.sourceAuthStrategy = strategy;
+        tokenRefreshHandler.clock = Clock.fixed(now, ZoneOffset.UTC);
+
+        assertSame(cachedToken, tokenRefreshHandler.refreshAccessToken());
     }
 
     @SneakyThrows

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/oauth/OAuthRefreshTokenSourceAuthStrategyTest.java
@@ -204,9 +204,13 @@ class OAuthRefreshTokenSourceAuthStrategyTest {
         assertEquals(1639526410000L, accessToken.get().getExpirationTime().getTime());
     }
 
+    /**
+     * Non-shared-token connectors ({@code USE_SHARED_TOKEN=false}) rely on in-memory cache for
+     * same-instance dedupe; the cross-instance lock does not apply.
+     */
     @SneakyThrows
     @Test
-    public void refreshAccessTokenReturnsFreshCachedTokenWithoutExchange() {
+    public void refreshAccessTokenReusesInMemoryCacheWithoutExchange() {
         Instant now = Instant.parse("2025-01-01T00:00:00Z");
 
         OAuthRefreshTokenSourceAuthStrategy strategy = new OAuthRefreshTokenSourceAuthStrategy();


### PR DESCRIPTION
## Summary

Fixes redundant refresh-token exchanges when multiple requests on the **same proxy instance** need a fresh access token at the same time.

- **Primary case (non-shared tokens):** `USE_SHARED_TOKEN=false` connectors do not use the cross-instance lock. `refreshAccessToken()` is `synchronized`, so threads serialize, but the second thread previously still performed another exchange because `checkIfAlreadyRefreshed` only consulted the shared token store (always empty here). Now `findReusableAccessToken()` checks the in-memory cache first.
- **Secondary case (shared tokens):** cross-instance dedupe is already handled by the distributed lock + secret-store re-read. Checking the in-memory cache first is defense in depth when the store read lags.
- `cachedToken` is documented as instance-shared state and marked `volatile` so unsynchronized reads in `getCredentials()` see updates promptly.

Split out from #1216 for independent review.

## Test plan
- [x] `mvn -pl core -am -Dtest=OAuthRefreshTokenSourceAuthStrategyTest -Dsurefire.failIfNoSpecifiedTests=false test`