### PR TITLE
Schema tool fixes

### DIFF
--- a/tools/schema-tool/README.md
+++ b/tools/schema-tool/README.md
@@ -1,8 +1,8 @@
 # Schema Tool
 
-Node.js CLI tool that infers the [JSON Schema] of an HTTP API endpoint response.
+Node.js CLI tool that infers the [JSON Schema] of an HTTP API endpoint response — or of a local JSON/JSONL file.
 
-Given an endpoint URL and a Bearer token, it makes a GET request and prints the inferred schema of the response body alongside the response headers. Useful for exploring unfamiliar APIs and documenting their response shapes.
+Given an endpoint URL and a Bearer token it makes a GET request and prints the inferred schema of the response body alongside the response headers. Alternatively, pass a local file (or pipe JSON to stdin) to infer a schema without making any network request. Useful for exploring unfamiliar APIs and documenting their response shapes.
 
 Requirements: [Node.js] (version >=18) and [npm]. Install dependencies first:
 
@@ -12,24 +12,50 @@ npm i
 
 ## Usage
 
+### Endpoint mode
+
 ```shell
-node cli-schema.js -e <url> -a <token> [options]
+node cli-schema.js -e "<url>" -a <token> [options]
 ```
+
+> **Important:** always quote URLs that contain query parameters (`?key=value`) to
+> prevent the shell from interpreting `?` as a glob wildcard.
 
 | Option | Description |
 |---|---|
-| `-e, --endpoint <url>` | Endpoint URL to call (required) |
-| `-a, --auth <token>` | Bearer token for authentication (required) |
+| `-e, --endpoint <url>` | Endpoint URL to fetch (required in this mode) |
+| `-a, --auth <token>` | Bearer token for authentication (required in this mode) |
 | `--skip-headers` | Exclude response headers from output |
-| `--raw` | Print raw response body instead of inferred schema |
+| `--raw` | Print raw response body instead of inferring a schema |
 | `-v, --verbose` | Print response status and headers to stderr |
 
+### Input mode
+
+```shell
+node cli-schema.js -i <file|json|-> [--raw]
+```
+
+Infers the schema from local content without making any HTTP request. `--auth` is not needed. The value passed to `--input` is resolved in this order:
+
+1. **`-`** — read from stdin
+2. **file path** — read the file if it exists
+3. **inline JSON/JSONL string** — treat the value itself as content
+
+| Option | Description |
+|---|---|
+| `-i, --input <value>` | File path, inline JSON/JSONL string, or `-` for stdin |
+| `--raw` | Print the raw content as-is instead of inferring a schema |
+
+`--endpoint` and `--input` are mutually exclusive.
+
 ## Output
+
+### Endpoint mode
 
 By default the output is a JSON object with two keys: `headers` (the raw response headers) and `schema` (the inferred JSON Schema of the response body).
 
 ```shell
-node cli-schema.js -e https://app.asana.com/api/1.0/workspaces -a $TOKEN
+node cli-schema.js -e "https://app.asana.com/api/1.0/workspaces" -a $TOKEN
 ```
 
 ```json
@@ -60,30 +86,112 @@ node cli-schema.js -e https://app.asana.com/api/1.0/workspaces -a $TOKEN
 Use `--skip-headers` to omit the headers section when only the schema is needed:
 
 ```shell
-node cli-schema.js -e https://app.asana.com/api/1.0/workspaces -a $TOKEN --skip-headers
+node cli-schema.js -e "https://app.asana.com/api/1.0/workspaces" -a $TOKEN --skip-headers
 ```
 
 Use `--raw` to print the unparsed response body, bypassing schema inference:
 
 ```shell
-node cli-schema.js -e https://app.asana.com/api/1.0/workspaces -a $TOKEN --raw
+node cli-schema.js -e "https://app.asana.com/api/1.0/workspaces" -a $TOKEN --raw
+```
+
+Query parameters are passed through correctly:
+
+```shell
+node cli-schema.js -e "https://app.asana.com/api/1.0/workspaces?limit=10" -a $TOKEN
+```
+
+### Input mode
+
+The output contains only a `schema` key — there are no response headers because no HTTP request was made.
+
+```shell
+node cli-schema.js --input response.json
+```
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "id":   { "type": "integer" },
+      "name": { "type": "string" }
+    }
+  }
+}
+```
+
+Pass an inline JSON string directly without creating a file:
+
+```shell
+node cli-schema.js -i '{"data":[{"gid":"1234"}]}'
+```
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "gid": {
+              "type": "string",
+              "format": "time"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+> On shells that expand special characters (zsh, bash) use single quotes around
+> the JSON string. If you must use double quotes, escape the inner quotes:
+> `node cli-schema.js -i "{\"data\":[{\"gid\":\"1234\"}]}"`.
+
+Read from stdin by passing `-`:
+
+```shell
+cat response.json | node cli-schema.js --input -
+```
+
+Pass `--raw` to print the content unchanged (works with files, inline strings, and stdin):
+
+```shell
+node cli-schema.js --input response.json --raw
 ```
 
 ## JSONL support
 
-Endpoints that return newline-delimited JSON (one JSON value per line) are detected automatically. When standard JSON parsing fails, the tool falls back to JSONL mode: each non-empty line is parsed individually and the resulting array of values is used for inference.
+Endpoints and files that use newline-delimited JSON (one value per line) are detected automatically. When standard JSON parsing fails, the tool falls back to JSONL mode: each non-empty line is parsed individually and the resulting array is used for inference.
 
 ```shell
-node cli-schema.js -e https://api.example.com/v1/audit-log -a $TOKEN --skip-headers
+# From an endpoint
+node cli-schema.js -e "https://api.example.com/v1/audit-log" -a $TOKEN --skip-headers
+
+# From a local file
+node cli-schema.js --input audit-log.jsonl
 ```
 
 The inferred schema will have `"type": "array"` at the top level, with `items` describing the shape of a single log line.
+
+## Error handling
+
+Non-2xx responses always print the HTTP status, all response headers, and the response body to stderr, then exit with code 1. This is particularly useful for:
+
+- **3xx redirects** — the `Location` header and a hint to re-run with the redirect URL are shown.
+- **401 Unauthorized** — the `WWW-Authenticate` header is shown.
+- **429 Too Many Requests** — the `Retry-After` header is shown.
 
 ## Notes
 
 - Schema inference uses [`@jsonhero/schema-infer`] (JSON Schema 2020-12). It detects common string formats such as `date-time`, `date`, `uuid`, `email`, `uri`, `ipv4`, and `hostname`.
 - Fields that are `null` in some items and a concrete type in others produce a union type (e.g. `"type": ["string", "null"]`).
-- Non-2xx responses print the status and body to stderr and exit with code 1.
+- The inferred `required` list is stripped from the output because it reflects only what appeared in the sample payload, not the true API contract.
 
 [JSON Schema]: https://json-schema.org
 [Node.js]: https://nodejs.org/en/

--- a/tools/schema-tool/README.md
+++ b/tools/schema-tool/README.md
@@ -181,7 +181,7 @@ The inferred schema will have `"type": "array"` at the top level, with `items` d
 
 ## Error handling
 
-Non-2xx responses always print the HTTP status, all response headers, and the response body to stderr, then exit with code 1. This is particularly useful for:
+Non-2xx responses always print the HTTP status and all response headers to stderr, followed by the response body when one is present, then exit with code 1. This is particularly useful for:
 
 - **3xx redirects** — the `Location` header and a hint to re-run with the redirect URL are shown.
 - **401 Unauthorized** — the `WWW-Authenticate` header is shown.

--- a/tools/schema-tool/cli-schema.js
+++ b/tools/schema-tool/cli-schema.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
 import { Command } from 'commander';
+import { readFile } from 'fs/promises';
 import { createRequire } from 'module';
 import { fetchEndpoint, inferSchema, removeRequired, parseBody } from './lib/schema.js';
 
@@ -15,6 +16,41 @@ const log = {
   verbose: (msg, opts) => opts?.verbose && console.error(msg),
 };
 
+/** Read all data from stdin as a UTF-8 string. */
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+/**
+ * Resolve the value of --input to a string of JSON/JSONL content.
+ *
+ * Resolution order:
+ *   1. '-'        → read from stdin
+ *   2. file path  → read the file (any readable path)
+ *   3. otherwise  → treat the value itself as inline JSON/JSONL content
+ *
+ * This means you can pass either a file path or a raw JSON string directly
+ * without any extra quoting or flags.
+ */
+async function readInputContent(pathOrDashOrJson) {
+  if (pathOrDashOrJson === '-') return readStdin();
+  try {
+    return await readFile(pathOrDashOrJson, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      // Not a file path — treat the value itself as inline content.
+      return pathOrDashOrJson;
+    }
+    throw err;
+  }
+}
+
 (async function () {
   const program = new Command();
 
@@ -22,10 +58,11 @@ const log = {
     .name('cli-schema.js')
     .version(version)
     .description('Infer the JSON schema of an HTTP API endpoint response')
-    .requiredOption('-e, --endpoint <url>', 'Endpoint URL to call')
-    .requiredOption('-a, --auth <token>', 'Bearer token for authentication')
-    .option('--raw', 'Print raw response body instead of inferred schema', false)
-    .option('--skip-headers', 'Exclude response headers from output', false)
+    .option('-e, --endpoint <url>', 'Endpoint URL to fetch (mutually exclusive with --input)')
+    .option('-a, --auth <token>', 'Bearer token for authentication (required with --endpoint)')
+    .option('-i, --input <path>', 'Read JSON/JSONL from a file instead of fetching a URL (use - for stdin)')
+    .option('--raw', 'Print raw response body / file content instead of inferring a schema', false)
+    .option('--skip-headers', 'Exclude response headers from output (endpoint mode only)', false)
     .option('-v, --verbose', 'Verbose output', false)
     .configureOutput({
       outputError: (str, write) => write(chalk.bold.red(str)),
@@ -35,13 +72,71 @@ const log = {
     'after',
     `
 Example calls:
-  node cli-schema.js -e https://api.example.com/v1/users -a my-bearer-token
+  node cli-schema.js -e "https://api.example.com/v1/users" -a my-bearer-token
   node cli-schema.js --endpoint "https://api.example.com/v1/items?limit=10" --auth my-token --raw
+  node cli-schema.js --input response.json
+  node cli-schema.js --input response.jsonl
+  cat response.json | node cli-schema.js --input -
     `
   );
 
   program.parse(process.argv);
   const options = program.opts();
+
+  // ── Validate flag combinations ───────────────────────────────────────────
+
+  if (options.input && options.endpoint) {
+    log.error('--input and --endpoint are mutually exclusive');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options.input && !options.endpoint) {
+    log.error('Either --endpoint (-e) or --input (-i) is required');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.endpoint && !options.auth) {
+    log.error('--auth (-a) is required when using --endpoint');
+    process.exitCode = 1;
+    return;
+  }
+
+  // ── Input mode (no HTTP request) ─────────────────────────────────────────
+
+  if (options.input) {
+    let content;
+    try {
+      content = await readInputContent(options.input);
+    } catch (err) {
+      log.error(`Could not read input: ${err.message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    if (options.raw) {
+      // Pass-through: just print the raw content unchanged.
+      console.log(content);
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = parseBody(content);
+    } catch (err) {
+      log.error(`Content is not valid JSON or JSONL: ${err.message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const label = options.input === '-' ? 'stdin' : options.input;
+    log.info(`Schema for ${label}:`);
+    console.log(JSON.stringify({ schema: removeRequired(inferSchema(parsed)) }, null, 2));
+    return;
+  }
+
+  // ── Endpoint mode (HTTP request) ─────────────────────────────────────────
 
   let url;
   try {

--- a/tools/schema-tool/cli-schema.js
+++ b/tools/schema-tool/cli-schema.js
@@ -10,6 +10,7 @@ const { version } = require('./package.json');
 const log = {
   info:    (msg) => console.error(chalk.bold.blue(msg)),
   success: (msg) => console.error(chalk.bold.green(msg)),
+  warn:    (msg) => console.error(chalk.bold.yellow(msg)),
   error:   (msg) => console.error(chalk.bold.red(msg)),
   verbose: (msg, opts) => opts?.verbose && console.error(msg),
 };
@@ -79,7 +80,24 @@ Example calls:
       console.log(JSON.stringify(output, null, 2));
     } else {
       log.error(`HTTP ${result.status}: ${result.statusMessage || 'Unknown error'}`);
+
+      // Redirects (3xx) never carry a parseable schema — show the Location so
+      // the caller knows where to go instead.
+      if (result.status >= 300 && result.status < 400) {
+        const location = result.headers['location'];
+        if (location) {
+          log.warn(`Redirect location: ${location}`);
+        }
+        log.warn('This tool does not follow redirects. Re-run with the redirect URL.');
+      }
+
+      // Always print response headers for non-2xx so callers can diagnose the
+      // failure (e.g. WWW-Authenticate on 401, Retry-After on 429, Location on 3xx).
+      console.error('Response headers:');
+      console.error(JSON.stringify(result.headers, null, 2));
+
       if (result.body) {
+        console.error('Response body:');
         try {
           console.error(JSON.stringify(JSON.parse(result.body), null, 2));
         } catch {

--- a/tools/schema-tool/cli-schema.js
+++ b/tools/schema-tool/cli-schema.js
@@ -57,10 +57,10 @@ async function readInputContent(pathOrDashOrJson) {
   program
     .name('cli-schema.js')
     .version(version)
-    .description('Infer the JSON schema of an HTTP API endpoint response')
+    .description('Infer the JSON schema of an HTTP API endpoint response or local JSON/JSONL content')
     .option('-e, --endpoint <url>', 'Endpoint URL to fetch (mutually exclusive with --input)')
     .option('-a, --auth <token>', 'Bearer token for authentication (required with --endpoint)')
-    .option('-i, --input <path>', 'Read JSON/JSONL from a file instead of fetching a URL (use - for stdin)')
+    .option('-i, --input <file|json|->', 'JSON/JSONL source: a file path, an inline JSON string, or - for stdin (mutually exclusive with --endpoint)')
     .option('--raw', 'Print raw response body / file content instead of inferring a schema', false)
     .option('--skip-headers', 'Exclude response headers from output (endpoint mode only)', false)
     .option('-v, --verbose', 'Verbose output', false)

--- a/tools/schema-tool/lib/schema.js
+++ b/tools/schema-tool/lib/schema.js
@@ -69,20 +69,36 @@ export function parseBody(body) {
 /**
  * Fetch a URL with a Bearer token.
  *
+ * Query parameters are explicitly forwarded via `path: url.pathname + url.search`
+ * to avoid a Node.js quirk where passing a URL string + a separate options object
+ * can cause the search string to be dropped when the two are merged internally.
+ *
  * @param {URL} url
  * @param {string} token
  * @returns {Promise<{status: number, statusMessage: string, headers: Object, body: string}>}
  */
 export function fetchEndpoint(url, token) {
   const transport = url.protocol === 'https:' ? https : http;
+
+  // Build an explicit options object so that url.search (query string) is never
+  // silently dropped. url.search is '' when there are no params and '?...' otherwise.
+  const requestOptions = {
+    hostname: url.hostname,
+    path: url.pathname + url.search,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+    timeout: REQUEST_TIMEOUT_MS,
+  };
+  // Only set port when the URL explicitly specifies one; otherwise let the
+  // transport module use its default (80 for http, 443 for https).
+  if (url.port) {
+    requestOptions.port = parseInt(url.port, 10);
+  }
+
   return new Promise((resolve, reject) => {
-    const req = transport.get(url.toString(), {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/json',
-      },
-      timeout: REQUEST_TIMEOUT_MS,
-    }, (res) => {
+    const req = transport.get(requestOptions, (res) => {
       let body = '';
       res.on('data', (chunk) => (body += chunk));
       res.on('end', () =>

--- a/tools/schema-tool/test/cli.test.js
+++ b/tools/schema-tool/test/cli.test.js
@@ -1,0 +1,201 @@
+/**
+ * Integration tests for the CLI (cli-schema.js).
+ *
+ * These tests spawn the CLI as a child process so they exercise the full
+ * argument-parsing, validation, and output logic without mocking the
+ * internals of lib/schema.js.
+ */
+
+import test from 'ava';
+import { execFile } from 'node:child_process';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const CLI = fileURLToPath(new URL('../cli-schema.js', import.meta.url));
+
+/**
+ * Run the CLI with the given args. Returns { stdout, stderr, exitCode }.
+ * Never rejects — exit code 1 is a normal failure case we want to assert on.
+ */
+async function runCli(args, { stdin } = {}) {
+  return new Promise((resolve) => {
+    const child = execFile('node', [CLI, ...args]);
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+
+    if (stdin !== undefined) {
+      child.stdin.write(stdin);
+      child.stdin.end();
+    }
+
+    child.on('close', (code) => resolve({ stdout, stderr, exitCode: code ?? 0 }));
+  });
+}
+
+// ── Shared temp dir ───────────────────────────────────────────────────────
+
+let TMP_DIR;
+
+test.before(async () => {
+  TMP_DIR = join(tmpdir(), `schema-tool-cli-test-${process.pid}`);
+  await mkdir(TMP_DIR, { recursive: true });
+});
+
+test.after.always(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+// ── Validation errors ──────────────────────────────────────────────────────
+
+test('error: no --endpoint and no --input', async (t) => {
+  const { stderr, exitCode } = await runCli([]);
+  t.is(exitCode, 1);
+  t.true(stderr.includes('--endpoint') || stderr.includes('--input'));
+});
+
+test('error: --endpoint and --input are mutually exclusive', async (t) => {
+  const file = join(TMP_DIR, 'dummy.json');
+  await writeFile(file, '{}');
+
+  const { stderr, exitCode } = await runCli([
+    '--endpoint', 'https://api.example.com/',
+    '--auth', 'tok',
+    '--input', file,
+  ]);
+
+  t.is(exitCode, 1);
+  t.true(stderr.includes('mutually exclusive'));
+});
+
+test('error: --endpoint without --auth', async (t) => {
+  const { stderr, exitCode } = await runCli(['--endpoint', 'https://api.example.com/']);
+  t.is(exitCode, 1);
+  t.true(stderr.includes('--auth'));
+});
+
+// ── --input: file mode ─────────────────────────────────────────────────────
+
+test('--input: JSON object — outputs schema (no headers key)', async (t) => {
+  const file = join(TMP_DIR, 'obj.json');
+  await writeFile(file, JSON.stringify({ id: 1, name: 'Alice' }));
+
+  const { stdout, exitCode } = await runCli(['--input', file]);
+
+  t.is(exitCode, 0);
+  const output = JSON.parse(stdout);
+  // No headers key — we never made an HTTP request
+  t.false(Object.hasOwn(output, 'headers'));
+  t.truthy(output.schema);
+  t.is(output.schema.type, 'object');
+});
+
+test('--input: JSON array — outputs array schema', async (t) => {
+  const file = join(TMP_DIR, 'arr.json');
+  await writeFile(file, JSON.stringify([{ id: 1 }, { id: 2 }]));
+
+  const { stdout, exitCode } = await runCli(['--input', file]);
+
+  t.is(exitCode, 0);
+  const output = JSON.parse(stdout);
+  t.is(output.schema.type, 'array');
+});
+
+test('--input: JSONL file — outputs array schema', async (t) => {
+  const file = join(TMP_DIR, 'events.jsonl');
+  await writeFile(file, '{"ts":"2024-01-01","event":"login"}\n{"ts":"2024-01-02","event":"logout"}\n');
+
+  const { stdout, exitCode } = await runCli(['--input', file]);
+
+  t.is(exitCode, 0);
+  const output = JSON.parse(stdout);
+  t.is(output.schema.type, 'array');
+});
+
+test('--input --raw: prints raw file content unchanged', async (t) => {
+  const content = JSON.stringify({ id: 42, name: 'Bob' });
+  const file = join(TMP_DIR, 'raw.json');
+  await writeFile(file, content);
+
+  const { stdout, exitCode } = await runCli(['--input', file, '--raw']);
+
+  t.is(exitCode, 0);
+  // stdout should be the raw content (console.log adds a trailing newline)
+  t.is(stdout.trim(), content);
+});
+
+test('--input: invalid JSON — exits 1 with error message', async (t) => {
+  const file = join(TMP_DIR, 'bad.json');
+  await writeFile(file, 'not json at all');
+
+  const { stderr, exitCode } = await runCli(['--input', file]);
+
+  t.is(exitCode, 1);
+  t.true(stderr.includes('not valid JSON'));
+});
+
+test('--input: missing file — treated as inline content, fails with JSON error', async (t) => {
+  // A value that looks like a path but doesn't exist is treated as inline content.
+  // Since it isn't valid JSON it should fail with a parse error, not a file error.
+  const { stderr, exitCode } = await runCli(['--input', '/nonexistent/path/file.json']);
+  t.is(exitCode, 1);
+  t.true(stderr.includes('not valid JSON'));
+  t.false(stderr.includes('Could not read input'));
+});
+
+test('--input: inline JSON object string — outputs schema without needing a file', async (t) => {
+  const { stdout, exitCode } = await runCli(['--input', '{"id":1,"name":"Alice"}']);
+  t.is(exitCode, 0);
+  const output = JSON.parse(stdout);
+  t.is(output.schema.type, 'object');
+  t.false(Object.hasOwn(output, 'headers'));
+});
+
+test('--input: inline JSON array string — outputs array schema', async (t) => {
+  const { stdout, exitCode } = await runCli(['--input', '[{"x":1},{"x":2}]']);
+  t.is(exitCode, 0);
+  const output = JSON.parse(stdout);
+  t.is(output.schema.type, 'array');
+});
+
+test('--input: inline JSON string with --raw — passes content through unchanged', async (t) => {
+  const payload = '{"id":99}';
+  const { stdout, exitCode } = await runCli(['--input', payload, '--raw']);
+  t.is(exitCode, 0);
+  t.is(stdout.trim(), payload);
+});
+
+test('--input: invalid inline string — exits 1 with JSON error', async (t) => {
+  const { stderr, exitCode } = await runCli(['--input', 'this is not json']);
+  t.is(exitCode, 1);
+  t.true(stderr.includes('not valid JSON'));
+});
+
+// ── --input: stdin mode (path = '-') ──────────────────────────────────────
+
+test('--input -: reads JSON from stdin — outputs schema', async (t) => {
+  const payload = JSON.stringify([{ userId: 'u1', score: 99 }]);
+
+  const { stdout, exitCode } = await runCli(['--input', '-'], { stdin: payload });
+
+  t.is(exitCode, 0);
+  const output = JSON.parse(stdout);
+  t.is(output.schema.type, 'array');
+  t.false(Object.hasOwn(output, 'headers'));
+});
+
+test('--input - --raw: passes stdin content through unchanged', async (t) => {
+  const payload = '{"raw":true}';
+
+  const { stdout, exitCode } = await runCli(['--input', '-', '--raw'], { stdin: payload });
+
+  t.is(exitCode, 0);
+  t.is(stdout.trim(), payload);
+});

--- a/tools/schema-tool/test/cli.test.js
+++ b/tools/schema-tool/test/cli.test.js
@@ -12,15 +12,14 @@ import { writeFile, mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
-
-const execFileAsync = promisify(execFile);
 
 const CLI = fileURLToPath(new URL('../cli-schema.js', import.meta.url));
 
 /**
  * Run the CLI with the given args. Returns { stdout, stderr, exitCode }.
  * Never rejects — exit code 1 is a normal failure case we want to assert on.
+ * Spawn errors (e.g. node not found) resolve with exitCode 1 and the error
+ * message in stderr so tests fail deterministically rather than hanging.
  */
 async function runCli(args, { stdin } = {}) {
   return new Promise((resolve) => {
@@ -36,6 +35,7 @@ async function runCli(args, { stdin } = {}) {
       child.stdin.end();
     }
 
+    child.on('error', (err) => resolve({ stdout, stderr: stderr + err.message, exitCode: 1 }));
     child.on('close', (code) => resolve({ stdout, stderr, exitCode: code ?? 0 }));
   });
 }

--- a/tools/schema-tool/test/fetch.test.js
+++ b/tools/schema-tool/test/fetch.test.js
@@ -15,6 +15,8 @@ test.serial.beforeEach(async (t) => {
 
 test.serial.afterEach(() => td.reset());
 
+// fetchEndpoint now calls transport.get(requestOptions, callback) — two args only.
+// requestOptions = { hostname, path, headers, timeout, [port] }
 function stubGet(get, { statusCode = 200, statusMessage = 'OK', headers = {}, body = '' } = {}) {
   const res = new EventEmitter();
   res.statusCode = statusCode;
@@ -24,8 +26,8 @@ function stubGet(get, { statusCode = 200, statusMessage = 'OK', headers = {}, bo
   const req = new EventEmitter();
   req.destroy = td.func('req.destroy');
 
-  td.when(get(td.matchers.anything(), td.matchers.anything(), td.matchers.isA(Function)))
-    .thenDo((_url, _opts, callback) => {
+  td.when(get(td.matchers.anything(), td.matchers.isA(Function)))
+    .thenDo((_opts, callback) => {
       callback(res);
       setImmediate(() => {
         res.emit('data', body);
@@ -65,8 +67,8 @@ test.serial('fetchEndpoint: network error — rejects with the error', async (t)
   const req = new EventEmitter();
   req.destroy = td.func('req.destroy');
 
-  td.when(t.context.get(td.matchers.anything(), td.matchers.anything(), td.matchers.isA(Function)))
-    .thenDo((_url, _opts, _callback) => {
+  td.when(t.context.get(td.matchers.anything(), td.matchers.isA(Function)))
+    .thenDo((_opts, _callback) => {
       setImmediate(() => req.emit('error', new Error('ECONNREFUSED')));
       return req;
     });
@@ -75,4 +77,112 @@ test.serial('fetchEndpoint: network error — rejects with the error', async (t)
     () => t.context.fetchEndpoint(new URL('https://api.example.com/v1'), 'token'),
     { message: 'ECONNREFUSED' }
   );
+});
+
+// ── Query-parameter tests ──────────────────────────────────────────────────
+
+test.serial('fetchEndpoint: query params — included in request path', async (t) => {
+  stubGet(t.context.get, { statusCode: 200, body: '{"ok":true}' });
+
+  await t.context.fetchEndpoint(
+    new URL('https://api.example.com/v1/items?limit=10&offset=0'),
+    'token'
+  );
+
+  const [opts] = td.explain(t.context.get).calls[0].args;
+  t.is(opts.path, '/v1/items?limit=10&offset=0');
+});
+
+test.serial('fetchEndpoint: no query params — path has no trailing question mark', async (t) => {
+  stubGet(t.context.get, { statusCode: 200, body: '{"ok":true}' });
+
+  await t.context.fetchEndpoint(
+    new URL('https://api.example.com/v1/items'),
+    'token'
+  );
+
+  const [opts] = td.explain(t.context.get).calls[0].args;
+  t.is(opts.path, '/v1/items');
+  t.false(opts.path.includes('?'));
+});
+
+test.serial('fetchEndpoint: query params — hostname is set correctly', async (t) => {
+  stubGet(t.context.get, { statusCode: 200, body: '{}' });
+
+  await t.context.fetchEndpoint(
+    new URL('https://api.example.com/v1/data?foo=bar'),
+    'token'
+  );
+
+  const [opts] = td.explain(t.context.get).calls[0].args;
+  t.is(opts.hostname, 'api.example.com');
+  t.is(opts.path, '/v1/data?foo=bar');
+});
+
+test.serial('fetchEndpoint: explicit port in URL — forwarded to request options', async (t) => {
+  stubGet(t.context.get, { statusCode: 200, body: '{}' });
+
+  await t.context.fetchEndpoint(
+    new URL('https://api.example.com:8443/v1/data'),
+    'token'
+  );
+
+  const [opts] = td.explain(t.context.get).calls[0].args;
+  t.is(opts.port, 8443);
+});
+
+test.serial('fetchEndpoint: default port (no port in URL) — port not set in options', async (t) => {
+  stubGet(t.context.get, { statusCode: 200, body: '{}' });
+
+  await t.context.fetchEndpoint(
+    new URL('https://api.example.com/v1/data'),
+    'token'
+  );
+
+  const [opts] = td.explain(t.context.get).calls[0].args;
+  t.is(opts.port, undefined);
+});
+
+// ── 307 / redirect tests ───────────────────────────────────────────────────
+
+test.serial('fetchEndpoint: 307 — resolves (does not reject) with status, location header, and body', async (t) => {
+  const headers = {
+    'location': 'https://api.example.com/v2/items',
+    'content-length': '0',
+  };
+  stubGet(t.context.get, {
+    statusCode: 307,
+    statusMessage: 'Temporary Redirect',
+    headers,
+    body: '',
+  });
+
+  const result = await t.context.fetchEndpoint(
+    new URL('https://api.example.com/v1/items'),
+    'token'
+  );
+
+  t.is(result.status, 307);
+  t.is(result.statusMessage, 'Temporary Redirect');
+  // Location header must survive so callers can diagnose the redirect
+  t.is(result.headers['location'], 'https://api.example.com/v2/items');
+  t.is(result.body, '');
+});
+
+test.serial('fetchEndpoint: 301 — resolves with redirect status and location header', async (t) => {
+  const headers = { 'location': 'https://new.example.com/v1/items' };
+  stubGet(t.context.get, {
+    statusCode: 301,
+    statusMessage: 'Moved Permanently',
+    headers,
+    body: '',
+  });
+
+  const result = await t.context.fetchEndpoint(
+    new URL('https://api.example.com/v1/items'),
+    'token'
+  );
+
+  t.is(result.status, 301);
+  t.is(result.headers['location'], 'https://new.example.com/v1/items');
 });


### PR DESCRIPTION
Some fixes:
- Ensure query parameters are working
- Always putting the headers in the output despite the request result
Some improvements:
- Allow to pass a JSON instead of a request to generate the schema.
- Readme updated

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Schema tool fixes](https://app.asana.com/1/27145998307022/project/1201039336231823/task/1215117001327588)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
