### PR TITLE
Handle redirection with async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes to be including in future/planned release notes will be added here.
 - `textDigest` rule now accepts an optional list of `keywords` to tally the occurrence of specific keywords in the text.
 - `chatgpt-enterprise`: added `write` and `email` keyword tracking to prompt/title texts via `textDigest`.
 - performance: optimized `redactExceptPhrases` rule to use non-reluctant matchers.
-- supporting fetching redirection location in async mode for APIs that use 3xx responses to indicate async processing (e.g., Slack Analytics).
+- support fetching redirect locations in async mode for APIs that use 3xx responses to indicate async processing (e.g., Slack Analytics).
 
 
 ## [0.6.1](https://github.com/Worklytics/psoxy/releases/tag/v0.6.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes to be including in future/planned release notes will be added here.
 - `textDigest` rule now accepts an optional list of `keywords` to tally the occurrence of specific keywords in the text.
 - `chatgpt-enterprise`: added `write` and `email` keyword tracking to prompt/title texts via `textDigest`.
 - performance: optimized `redactExceptPhrases` rule to use non-reluctant matchers.
+- supporting fetching redirection location in async mode for APIs that use 3xx responses to indicate async processing (e.g., Slack Analytics).
 
 
 ## [0.6.1](https://github.com/Worklytics/psoxy/releases/tag/v0.6.1)

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -499,19 +499,31 @@ public class ApiDataRequestHandler {
 
         // In async mode, treat a 3xx response with a Location header as success by fetching content
         // from the Location URL (e.g., source returns 307 pointing to a pre-signed file download).
+        // Only applies to safe methods (GET/HEAD) — 307/308 with POST would require replaying the body.
         if (processingContext.getAsync()
                 && isRedirectFamily(sourceApiResponse.getStatusCode())
-                && sourceApiResponse.getHeaders().getLocation() != null) {
+                && sourceApiResponse.getHeaders().getLocation() != null
+                && isSafeMethod(requestToSourceApi.getRequestMethod())) {
             String locationUrl = sourceApiResponse.getHeaders().getLocation();
+            GenericUrl locationGenericUrl = new GenericUrl(locationUrl);
+            if (!"https".equalsIgnoreCase(locationGenericUrl.getScheme())) {
+                builder.statusCode(HttpStatus.SC_BAD_GATEWAY);
+                builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
+                        ErrorCauses.API_ERROR.name());
+                builder.body("Async redirect Location is not HTTPS; refusing to follow");
+                log.log(Level.WARNING, "Async redirect to non-HTTPS Location refused: {0}", locationUrl);
+                return builder.build();
+            }
             log.info("Async request received " + sourceApiResponse.getStatusCode()
                     + " redirect; fetching content from Location header");
             sourceApiResponse.disconnect();
             try {
                 com.google.api.client.http.HttpRequest locationRequest = httpTransportFactory.create()
                         .createRequestFactory()
-                        .buildGetRequest(new GenericUrl(locationUrl));
+                        .buildGetRequest(locationGenericUrl);
                 locationRequest
                         .setThrowExceptionOnExecuteError(false)
+                        .setFollowRedirects(false)
                         .setConnectTimeout(apiModeConfig.getSourceApiConnectTimeoutMs())
                         .setReadTimeout(apiModeConfig.getSourceApiReadTimeoutMs());
                 sourceApiResponse = locationRequest.execute();
@@ -809,6 +821,10 @@ public class ApiDataRequestHandler {
 
     boolean isRedirectFamily(int statusCode) {
         return statusCode >= 300 && statusCode < 400;
+    }
+
+    boolean isSafeMethod(String method) {
+        return "GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method);
     }
 
     @SneakyThrows

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -379,7 +379,10 @@ public class ApiDataRequestHandler {
             requestToSourceApi
                     .setThrowExceptionOnExecuteError(false)
                     .setConnectTimeout(apiModeConfig.getSourceApiConnectTimeoutMs())
-                    .setReadTimeout(apiModeConfig.getSourceApiReadTimeoutMs());
+                    .setReadTimeout(apiModeConfig.getSourceApiReadTimeoutMs())
+                    // disable automatic redirect following in async mode so that our redirect
+                    // handling block can intercept 3xx responses and fetch from Location manually
+                    .setFollowRedirects(!processingContext.getAsync());
 
         } catch (SocketTimeoutException e) {
             return buildConnectTimeoutErrorResponse(builder, e);
@@ -466,7 +469,7 @@ public class ApiDataRequestHandler {
         }
 
 
-        final com.google.api.client.http.HttpResponse sourceApiResponse;
+        com.google.api.client.http.HttpResponse sourceApiResponse;
         try {
             // q: add exception handlers for IOExceptions / HTTP error responses, so those retries
             // happen in proxy rather than on Worklytics-side?
@@ -493,6 +496,34 @@ public class ApiDataRequestHandler {
             return builder.build();
         }
 
+
+        // In async mode, treat a 3xx response with a Location header as success by fetching content
+        // from the Location URL (e.g., source returns 307 pointing to a pre-signed file download).
+        if (processingContext.getAsync()
+                && isRedirectFamily(sourceApiResponse.getStatusCode())
+                && sourceApiResponse.getHeaders().getLocation() != null) {
+            String locationUrl = sourceApiResponse.getHeaders().getLocation();
+            log.info("Async request received " + sourceApiResponse.getStatusCode()
+                    + " redirect; fetching content from Location header");
+            sourceApiResponse.disconnect();
+            try {
+                com.google.api.client.http.HttpRequest locationRequest = httpTransportFactory.create()
+                        .createRequestFactory()
+                        .buildGetRequest(new GenericUrl(locationUrl));
+                locationRequest
+                        .setThrowExceptionOnExecuteError(false)
+                        .setConnectTimeout(apiModeConfig.getSourceApiConnectTimeoutMs())
+                        .setReadTimeout(apiModeConfig.getSourceApiReadTimeoutMs());
+                sourceApiResponse = locationRequest.execute();
+            } catch (IOException e) {
+                builder.statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
+                        ErrorCauses.CONNECTION_TO_SOURCE.name());
+                builder.body("Error fetching content from redirect location: " + e.getMessage());
+                log.log(Level.SEVERE, "Error fetching content from redirect location", e);
+                return builder.build();
+            }
+        }
 
         String proxyResponseContent = "";
         try {
@@ -774,6 +805,10 @@ public class ApiDataRequestHandler {
 
     boolean isSuccessFamily(int statusCode) {
         return statusCode >= 200 && statusCode < 300;
+    }
+
+    boolean isRedirectFamily(int statusCode) {
+        return statusCode >= 300 && statusCode < 400;
     }
 
     @SneakyThrows

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
@@ -41,6 +41,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import dagger.Component;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -54,6 +55,7 @@ import javax.inject.Singleton;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.List;
@@ -818,5 +820,160 @@ class ApiDataRequestHandlerTest {
         Object actualHeader = headers.get(headerName);
         assertTrue(actualHeader instanceof List);
         assertEquals(List.of(originalValue1, originalValue2), actualHeader);
+    }
+
+    @Test
+    @SneakyThrows
+    void isRedirectFamily() {
+        setup("gmail", "google.apis.com");
+        assertFalse(handler.isRedirectFamily(200));
+        assertFalse(handler.isRedirectFamily(299));
+        assertTrue(handler.isRedirectFamily(300));
+        assertTrue(handler.isRedirectFamily(307));
+        assertTrue(handler.isRedirectFamily(399));
+        assertFalse(handler.isRedirectFamily(400));
+    }
+
+    @Test
+    @SneakyThrows
+    void handleShouldFollowRedirectManuallyInAsyncMode() {
+        setup("gmail", "google.apis.com");
+
+        ApiDataRequestHandler spy = spy(handler);
+
+        String locationUrl = "https://pre-signed.example.com/data.json";
+        String redirectedContent = "[{\"id\":\"user1\"}]";
+
+        HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
+        when(request.getHeader(ControlHeader.PSEUDONYM_IMPLEMENTATION.getHttpHeader()))
+            .thenReturn(Optional.empty());
+        when(request.getHttpMethod()).thenReturn("GET");
+        when(request.getPath()).thenReturn("/admin/directory/v1/users");
+        when(request.getQuery()).thenReturn(Optional.empty());
+
+        // Source API returns 307 redirect with Location header
+        MockHttpTransport redirectTransport = new MockHttpTransport() {
+            @Override
+            public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+                return new MockLowLevelHttpRequest() {
+                    @Override
+                    public LowLevelHttpResponse execute() throws IOException {
+                        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                        response.setStatusCode(307);
+                        response.addHeader("location", locationUrl);
+                        response.setContent("");
+                        return response;
+                    }
+                };
+            }
+        };
+        doReturn(redirectTransport.createRequestFactory()).when(spy).getRequestFactory(any());
+
+        // Redirect location transport — records the URL it was asked to build a request for
+        List<String> fetchedFromUrls = new ArrayList<>();
+        MockHttpTransport contentTransport = new MockHttpTransport() {
+            @Override
+            public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+                fetchedFromUrls.add(url);
+                return new MockLowLevelHttpRequest() {
+                    @Override
+                    public LowLevelHttpResponse execute() throws IOException {
+                        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                        response.setStatusCode(200);
+                        response.setContentType(Json.MEDIA_TYPE);
+                        response.setContent(redirectedContent);
+                        return response;
+                    }
+                };
+            }
+        };
+        when(spy.httpTransportFactory.create()).thenReturn(contentTransport);
+
+        RESTApiSanitizerImpl sanitizer = mock(RESTApiSanitizerImpl.class);
+        when(sanitizer.isAllowed(anyString(), any(), anyString(), any())).thenReturn(true);
+        spy.sanitizer = sanitizer;
+
+        HttpEventResponse response = spy.handle(request,
+            ApiDataRequestHandler.ProcessingContext.builder()
+                .async(true)
+                .requestId("r")
+                .asyncOutputLocation("gs://bucket/output.json")
+                .requestReceivedAt(clock.instant())
+                .build());
+
+        // redirect Location URL was the one actually fetched
+        assertEquals(1, fetchedFromUrls.size());
+        assertEquals(locationUrl, fetchedFromUrls.get(0));
+
+        // response status comes from the redirect target (200), not the original 307
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        // sanitizer received the body from the redirect target, not the empty 307 response
+        ArgumentCaptor<String> sanitizedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sanitizer).sanitize(eq("GET"), any(URL.class), sanitizedBodyCaptor.capture());
+        assertEquals(redirectedContent, sanitizedBodyCaptor.getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    void handleShouldLetHttpClientFollowRedirectInSyncMode() {
+        setup("gmail", "google.apis.com");
+
+        ApiDataRequestHandler spy = spy(handler);
+
+        String locationUrl = "https://pre-signed.example.com/data.json";
+        String redirectedContent = "[{\"id\":\"user1\"}]";
+
+        HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
+        when(request.getHeader(ControlHeader.PSEUDONYM_IMPLEMENTATION.getHttpHeader()))
+            .thenReturn(Optional.empty());
+        when(request.getHttpMethod()).thenReturn("GET");
+        when(request.getPath()).thenReturn("/admin/directory/v1/users");
+        when(request.getQuery()).thenReturn(Optional.empty());
+
+        // URL-aware transport: 307 for source API URL, 200 for the redirect target
+        MockHttpTransport sourceTransport = new MockHttpTransport() {
+            @Override
+            public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+                return new MockLowLevelHttpRequest() {
+                    @Override
+                    public LowLevelHttpResponse execute() throws IOException {
+                        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                        if (url.equals(locationUrl)) {
+                            response.setStatusCode(200);
+                            response.setContentType(Json.MEDIA_TYPE);
+                            response.setContent(redirectedContent);
+                        } else {
+                            response.setStatusCode(307);
+                            response.addHeader("location", locationUrl);
+                            response.setContent("");
+                        }
+                        return response;
+                    }
+                };
+            }
+        };
+        doReturn(sourceTransport.createRequestFactory()).when(spy).getRequestFactory(any());
+
+        RESTApiSanitizerImpl sanitizer = mock(RESTApiSanitizerImpl.class);
+        when(sanitizer.isAllowed(anyString(), any(), anyString(), any())).thenReturn(true);
+        spy.sanitizer = sanitizer;
+
+        HttpEventResponse response = spy.handle(request,
+            ApiDataRequestHandler.ProcessingContext.builder()
+                .async(false)
+                .requestId("r")
+                .requestReceivedAt(clock.instant())
+                .build());
+
+        // our manual redirect code must NOT run in sync mode
+        verify(spy.httpTransportFactory, never()).create();
+
+        // the HTTP client followed the redirect automatically; sanitizer got the redirect content
+        ArgumentCaptor<String> sanitizedBodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sanitizer).sanitize(eq("GET"), any(URL.class), sanitizedBodyCaptor.capture());
+        assertEquals(redirectedContent, sanitizedBodyCaptor.getValue());
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 }


### PR DESCRIPTION
In case of async, if a 3xx is received it will do the fetch on the location header if present

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[proxy-async support on Worklytics-side](https://app.asana.com/1/27145998307022/project/1213638267413355/task/1213638267413341)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
