### PR TITLE
fix NPE when content is null

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProcessedContent.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProcessedContent.java
@@ -60,7 +60,7 @@ public class ProcessedContent implements Serializable {
      */
     public String getContentAsString() {
         if (getContent() == null) {
-            return "";
+            return null;
         } else {
             return new String(getContent(), contentCharset);
         }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProcessedContent.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProcessedContent.java
@@ -59,6 +59,10 @@ public class ProcessedContent implements Serializable {
      * @return the content as a string, using the specified contentCharset
      */
     public String getContentAsString() {
-        return new String(getContent(), contentCharset);
+        if (getContent() == null) {
+            return "";
+        } else {
+            return new String(getContent(), contentCharset);
+        }
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/output/ApiDataOutputUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/output/ApiDataOutputUtils.java
@@ -114,7 +114,7 @@ public class ApiDataOutputUtils {
                                                           HttpResponse sourceApiResponse) throws IOException {
         ProcessedContent.ProcessedContentBuilder builder = ProcessedContent.builder()
             .contentType(sourceApiResponse.getContentType())
-            .contentCharset(sourceApiResponse.getContentCharset());
+            .contentCharset(Objects.requireNonNullElse(sourceApiResponse.getContentCharset(), StandardCharsets.UTF_8));
 
         // sourceApiResponse will not have content for 'HEAD' requests (or potentially even GET, in some cases - 204 No Content, 304 Not Modified, etc.)
         if (sourceApiResponse.getContent() != null) {

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/output/ApiDataOutputUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/output/ApiDataOutputUtilsTest.java
@@ -110,6 +110,38 @@ class ApiDataOutputUtilsTest {
         assertNotNull(metadata.get("REQUEST_BODY"));
     }
 
+    @Test
+    void responseAsRawProcessedContent_nullCharsetDoesNotThrow() throws Exception {
+        HttpRequest mockRequest = mock(HttpRequest.class);
+        when(mockRequest.getUrl()).thenReturn(new com.google.api.client.http.GenericUrl("https://api.example.com/v1/resource"));
+        when(mockRequest.getRequestMethod()).thenReturn("GET");
+        HttpResponse mockResponse = mock(HttpResponse.class);
+        when(mockResponse.getContentType()).thenReturn("application/json");
+        when(mockResponse.getContentCharset()).thenReturn(null); // error responses often omit charset
+        byte[] contentBytes = "{\"error\":\"Forbidden\"}".getBytes(StandardCharsets.UTF_8);
+        when(mockResponse.getContent()).thenReturn(new ByteArrayInputStream(contentBytes));
+
+        ProcessedContent processed = utils.responseAsRawProcessedContent(mockRequest, mockResponse);
+
+        assertDoesNotThrow(processed::getContentAsString);
+        assertEquals("{\"error\":\"Forbidden\"}", processed.getContentAsString());
+    }
+
+    @Test
+    void responseAsRawProcessedContent_nullContentDoesNotThrow() throws Exception {
+        HttpRequest mockRequest = mock(HttpRequest.class);
+        when(mockRequest.getUrl()).thenReturn(new com.google.api.client.http.GenericUrl("https://api.example.com/v1/resource"));
+        when(mockRequest.getRequestMethod()).thenReturn("GET");
+        HttpResponse mockResponse = mock(HttpResponse.class);
+        when(mockResponse.getContentType()).thenReturn(null);
+        when(mockResponse.getContentCharset()).thenReturn(null);
+        when(mockResponse.getContent()).thenReturn(null); // HEAD / 204 / 304 — no body
+
+        ProcessedContent processed = utils.responseAsRawProcessedContent(mockRequest, mockResponse);
+
+        assertNull(processed.getContentAsString());
+    }
+
     @ValueSource(
         strings = {
             "Authorization",


### PR DESCRIPTION
When content is null, during converting bytes to String it was failing, causing psoxy to throw a NPE and an error to the caller.

### Fixes
[NPE when handling response with null content](https://app.asana.com/1/27145998307022/project/1201039336231823/task/1215192487734411)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
