### PR TITLE
GCP fixes

### DIFF
--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -423,6 +423,7 @@ locals {
 FILE_PATH=$${1:-${try(local.example_files_csv, "")}}
 BLUE='\e[0;34m'
 NC='\e[0m'
+FAILED=0
 
 printf "Quick test of $${BLUE}${var.instance_id}$${NC} ...\n"
 
@@ -432,10 +433,21 @@ for FILE in "$${FILES[@]}"; do
   # trim whitespace
   FILE=$(echo "$FILE" | xargs)
   if [ -z "$FILE" ]; then continue; fi
+
+  if [ ! -f "$FILE" ]; then
+    printf "error: file not found: %s\n" "$FILE" >&2
+    FAILED=1
+    continue
+  fi
   
   printf "Testing file: $FILE\n"
   node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f "$FILE" -d "AWS" -i "${aws_s3_bucket.input.bucket}" -o "${aws_s3_bucket.sanitized.bucket}" ${local.role_option_for_tests} --region "${var.aws_region}"
+  if [ $? -ne 0 ]; then
+    FAILED=1
+  fi
 done
+
+exit $FAILED
 EOT
 }
 

--- a/infra/modules/gcp-proxy-bulk/main.tf
+++ b/infra/modules/gcp-proxy-bulk/main.tf
@@ -373,6 +373,7 @@ resource "local_file" "test_script" {
 FILE_PATH=$${1:-${try(local.example_files_csv, "")}}
 BLUE='\e[0;34m'
 NC='\e[0m'
+FAILED=0
 
 printf "Quick test of $${BLUE}${local.function_name}$${NC} ...\n"
 
@@ -382,9 +383,19 @@ for FILE in "$${FILES[@]}"; do
   # trim whitespace
   FILE=$(echo "$FILE" | xargs)
   if [ -z "$FILE" ]; then continue; fi
+
+  if [ ! -f "$FILE" ]; then
+    printf "error: file not found: %s\n" "$FILE" >&2
+    FAILED=1
+    continue
+  fi
   
   printf "Testing file: $FILE\n"
   node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f "$FILE" -d GCP -i ${google_storage_bucket.input_bucket.name} -o ${module.output_bucket.bucket_name}
+  if [ $? -ne 0 ]; then
+    FAILED=1
+    continue
+  fi
 
   if gzip -t "$FILE" 2>/dev/null; then
     printf "test file was compressed, so not testing compression as a separate case\n"
@@ -392,12 +403,23 @@ for FILE in "$${FILES[@]}"; do
     printf "testing with compressed input file ... \n"
     # extract the file name from the path
     TEST_FILE_NAME=/tmp/$(basename "$FILE").gz
-    
-    gzip -c "$FILE" > "$TEST_FILE_NAME"
+
+    if ! gzip -c "$FILE" > "$TEST_FILE_NAME"; then
+      printf "error: failed to compress file: %s\n" "$FILE" >&2
+      rm -f "$TEST_FILE_NAME"
+      FAILED=1
+      continue
+    fi
     node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f "$TEST_FILE_NAME" -d GCP -i ${google_storage_bucket.input_bucket.name} -o ${module.output_bucket.bucket_name}
-    rm "$TEST_FILE_NAME"
+    NODE_EXIT=$?
+    rm -f "$TEST_FILE_NAME"
+    if [ $NODE_EXIT -ne 0 ]; then
+      FAILED=1
+    fi
   fi
 done
+
+exit $FAILED
 EOT
 
 }

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -18,6 +18,10 @@ locals {
     "cloudscheduler.googleapis.com", # triggering batches
     "pubsub.googleapis.com",         # webhooks batched via pubsub
   ]
+
+  # Artifact Registry repository IDs must be unique within a project/location; prefix with
+  # environment_id_prefix so multiple psoxy instances can share a GCP project.
+  functions_repo_id = length(var.environment_id_prefix) > 0 ? "${var.environment_id_prefix}functions" : "psoxy-functions"
 }
 
 
@@ -52,7 +56,7 @@ resource "google_project_service" "gcp_infra_api" {
 resource "google_artifact_registry_repository" "psoxy-functions-repo" {
   location      = var.bucket_location
   project       = var.project_id
-  repository_id = "psoxy-functions"
+  repository_id = local.functions_repo_id
   description   = "Docker repository used on the cloud functions"
   format        = "DOCKER"
 
@@ -63,6 +67,13 @@ resource "google_artifact_registry_repository" "psoxy-functions-repo" {
     most_recent_versions {
       keep_count = 3
     }
+  }
+
+  lifecycle {
+    # TODO: remove in 0.7.x; retain for upgrades from pre-0.7.x deployments that used hardcoded "psoxy-functions"
+    ignore_changes = [
+      repository_id,
+    ]
   }
 
   depends_on = [

--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -69,7 +69,7 @@ const { version } = require('./package.json');
     result = await psoxyTestFileUpload(options);
   } catch (error) {
     logger.error(error.message);
-    process.exitCode = 1;
+    process.exit(1);
   }
   return result;
 })();

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -179,6 +179,14 @@ export default async function (options = {}) {
   const logger = getLogger(options.verbose);
   environmentCheck(logger);
 
+  if (!fs.existsSync(options.file)) {
+    throw new Error(`File not found: ${options.file}`);
+  }
+  const fileStat = fs.statSync(options.file);
+  if (!fileStat.isFile()) {
+    throw new Error(`Not a regular file: ${options.file}`);
+  }
+
   const deploymentTypeFn = options.deploy === 'AWS' ? testAWS : testGCP;
   const { original, sanitized } = await deploymentTypeFn(options, logger);
 


### PR DESCRIPTION
### Features
- prefixing the GCP Artifact Registry repository ID with `environment_id_prefix` to prevent collisions in projects with multiple instances.

### Logistics
- update to use `gcloud` rather than `gsutil`, where possible

### Change implications

- dependencies added/changed? **no**
- something important to note in future release notes?
  - No significant changes expected in `terraform plan`/`apply`.
  - breaking changes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215223178646843
  - https://app.asana.com/0/0/1215223178646849