### PR TITLE
v0.6.2 hotfixes

### DIFF
--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -141,11 +141,14 @@ resource "aws_iam_role_policy_attachment" "invoker_url_lambda_execution" {
 # access to async output buckets
 # this is independent of whether API connectors are otherwise invoked via API Gateway v2 or function urls
 locals {
-  async_output_buckets = [for k, v in module.api_connector : v.async_output_bucket_id if v.async_output_bucket_id != null]
+  api_connectors_with_async = {
+    for k, v in var.api_connectors : k => v
+    if try(v.enable_async_processing, false)
+  }
 }
 
 resource "aws_iam_policy" "async_output_access" {
-  count = length(local.async_output_buckets) > 0 ? 1 : 0
+  count = length(local.api_connectors_with_async) > 0 ? 1 : 0
 
   name        = "${module.env_id.id}AsyncOutputAccess"
   description = "Allow caller to read from async output buckets (sanitized output)"
@@ -157,13 +160,13 @@ resource "aws_iam_policy" "async_output_access" {
         "Action" : ["s3:GetObject", "s3:ListBucket"],
         "Effect" : "Allow",
         "Resource" : ["arn:aws:s3:::${v.async_output_bucket_id}", "arn:aws:s3:::${v.async_output_bucket_id}/*"]
-      } if v.async_output_bucket_id != null]
+      } if contains(keys(local.api_connectors_with_async), k)]
     }
   )
 }
 
 resource "aws_iam_role_policy_attachment" "async_output_access_to_caller" {
-  count = length(local.async_output_buckets) > 0 ? 1 : 0
+  count = length(local.api_connectors_with_async) > 0 ? 1 : 0
 
   role       = module.psoxy.api_caller_role_name
   policy_arn = aws_iam_policy.async_output_access[0].arn

--- a/infra/modules/aws-proxy-api/main.tf
+++ b/infra/modules/aws-proxy-api/main.tf
@@ -100,9 +100,12 @@ resource "aws_sqs_queue" "async_api_request_queue" {
   # Standard queue for better reliability
   fifo_queue = false
 
-  message_retention_seconds = 86400 # 1 day, max; tbh, prob could be shorter
+  # 1 day, max; tbh, prob could be shorter
+  message_retention_seconds = 86400
 
-  visibility_timeout_seconds = 120 # how long after attempt begins until message is visible to another consumer for re-processing
+  # how long after attempt begins until message is visible to another consumer for re-processing
+  # this CANNOT be shorter than the lambda timeout, or AWS gives 400 on apply
+  visibility_timeout_seconds = max(var.timeout_seconds, 120)
 
   # Receive message wait time: 20 seconds (long polling)
   receive_wait_time_seconds = 20


### PR DESCRIPTION
pushed to `v0.6.2` as hotfixes, but for review into mainline:


### Fixes
 - invalid-count when creating async connectors

```shell
│ Error: Invalid count argument
│ 
│   on .terraform/modules/psoxy/infra/modules/aws-host/main.tf line 148, in resource "aws_iam_policy" "async_output_access":
│  148:   count = length(local.async_output_buckets) > 0 ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined until
│ apply, so Terraform cannot predict how many instances will be created. To work
│ around this, use the -target argument to first apply only the resources that the
│ count depends on.
```

 - invalid timeout when creating async connectors
```
│ Error: creating Lambda Event Source Mapping (arn:aws:sqs:us-east-1:385575765955:psoxy-chatgpt-enterprise-async-request-queue): operation error Lambda: CreateEventSourceMapping, https response error StatusCode: 400, RequestID: 06754a04-f385-4a43-9754-c3fc7b3c97b3, InvalidParameterValueException: Queue visibility timeout: 120 seconds is less than Function timeout: 180 seconds
```


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - Added a constraint for Lambda and queue timeouts.
   - Fixed nondeterministic behavior in apply process.
   - breaking changes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215265048877030
  - https://app.asana.com/0/0/1215265048877028