### PR TITLE
avoid bucket write to caller in testing case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ in each release's notes.
 Changes to be including in future/planned release notes will be added here.
 
 ## Next
-- `aws`: bulk connector test input bucket write goes to `caller_aws_arns`, not the proxy Caller role.
+- `aws`: add `test_aws_principal_arns` for testing (defaults to Terraform runner when `provision_testing_infra` is true); grants assume-Caller access and bulk input-bucket upload via S3 bucket policy, separate from production `caller_aws_arns`.
 - `gcp`: fix Terraform compatibility when upgrading to v0.6.x with an older `hashicorp/google` provider lock file; require provider `>= 7.0` in modules and use `detect_md5hash` for deployment bundle change detection.
 - `aws`: add explicit `filter {}` to S3 bucket lifecycle rules for compatibility with `hashicorp/aws` provider 6.x.
 - `aws`: require `hashicorp/aws` provider `>= 6.0` in AWS host and component modules (was `>= 5.0` or unconstrained).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ in each release's notes.
 Changes to be including in future/planned release notes will be added here.
 
 ## Next
-- `aws`: bulk connector test IAM grants input bucket write to `caller_aws_arns` (not the proxy Caller role), matching production where Worklytics never uploads to `-input` buckets; the test tool uploads with default credentials and assumes the Caller role only to read/delete from the `-sanitized` bucket.
+- `aws`: bulk connector test input bucket write goes to `caller_aws_arns`, not the proxy Caller role.
 - `gcp`: fix Terraform compatibility when upgrading to v0.6.x with an older `hashicorp/google` provider lock file; require provider `>= 7.0` in modules and use `detect_md5hash` for deployment bundle change detection.
 - `aws`: add explicit `filter {}` to S3 bucket lifecycle rules for compatibility with `hashicorp/aws` provider 6.x.
 - `aws`: require `hashicorp/aws` provider `>= 6.0` in AWS host and component modules (was `>= 5.0` or unconstrained).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ in each release's notes.
 Changes to be including in future/planned release notes will be added here.
 
 ## Next
+- `aws`: bulk connector test IAM grants input bucket write to `caller_aws_arns` (not the proxy Caller role), matching production where Worklytics never uploads to `-input` buckets; the test tool uploads with default credentials and assumes the Caller role only to read/delete from the `-sanitized` bucket.
 - `gcp`: fix Terraform compatibility when upgrading to v0.6.x with an older `hashicorp/google` provider lock file; require provider `>= 7.0` in modules and use `detect_md5hash` for deployment bundle change detection.
 - `aws`: add explicit `filter {}` to S3 bucket lifecycle rules for compatibility with `hashicorp/aws` provider 6.x.
 - `aws`: require `hashicorp/aws` provider `>= 6.0` in AWS host and component modules (was `>= 5.0` or unconstrained).

--- a/infra/examples-dev/aws/kms-cmek.tf
+++ b/infra/examples-dev/aws/kms-cmek.tf
@@ -18,7 +18,7 @@
 #      "Sid": "Allow Test Principals to Encrypt for Input Upload",
 #      "Effect": "Allow",
 #      "Principal": {
-#        "AWS": var.caller_aws_arns
+#        "AWS": coalesce(var.test_aws_principal_arns, [])
 #      },
 #      "Action": [
 #        "kms:Encrypt",

--- a/infra/examples-dev/aws/kms-cmek.tf
+++ b/infra/examples-dev/aws/kms-cmek.tf
@@ -13,15 +13,17 @@
 #locals {
 #  key_arn = aws_kms_key.example_key.arn # alternatively, use ar.project_aws_kms_key_arn
 #
-#  # TODO: can eliminate this if test tool doesn't assume role when uploading to bucket
-#  testing_policy_statements = var.provision_testing_infra ? [
+#  upload_testing_policy_statements = var.provision_testing_infra ? [
 #    {
-#      "Sid": "Allow Test Users to Use Key",
+#      "Sid": "Allow Test Principals to Encrypt for Input Upload",
 #      "Effect": "Allow",
-#      "Principal": { # tests
-#        "AWS": "arn:aws:iam::${var.aws_account_id}:role/${module.psoxy.caller_role_name}"
+#      "Principal": {
+#        "AWS": var.caller_aws_arns
 #      },
-#      "Action": "kms:*",
+#      "Action": [
+#        "kms:Encrypt",
+#        "kms:GenerateDataKey",
+#      ],
 #      "Resource": local.key_arn
 #    }
 #  ] : []
@@ -93,7 +95,7 @@
 #          }
 #      ],
 #      local.bulk_writer_policy_statements,
-#      local.testing_policy_statements,
+#      local.upload_testing_policy_statements,
 #      local.proxy_caller_policy_statements
 #      )
 #    })

--- a/infra/examples-dev/aws/kms-cmek.tf
+++ b/infra/examples-dev/aws/kms-cmek.tf
@@ -13,12 +13,12 @@
 #locals {
 #  key_arn = aws_kms_key.example_key.arn # alternatively, use ar.project_aws_kms_key_arn
 #
-#  upload_testing_policy_statements = var.provision_testing_infra ? [
+#  upload_testing_policy_statements = length(module.psoxy.test_aws_principal_arns) > 0 ? [
 #    {
 #      "Sid": "Allow Test Principals to Encrypt for Input Upload",
 #      "Effect": "Allow",
 #      "Principal": {
-#        "AWS": coalesce(var.test_aws_principal_arns, [])
+#        "AWS": module.psoxy.test_aws_principal_arns
 #      },
 #      "Action": [
 #        "kms:Encrypt",

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -133,6 +133,7 @@ module "psoxy" {
   force_bundle                         = var.force_bundle
   caller_gcp_service_account_ids       = var.caller_gcp_service_account_ids
   caller_aws_arns                      = var.caller_aws_arns
+  test_aws_principal_arns              = var.test_aws_principal_arns
   non_production_connectors            = var.non_production_connectors
   custom_api_connector_rules           = var.custom_api_connector_rules
   lookup_table_builders                = var.lookup_table_builders

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -141,6 +141,14 @@ variable "caller_aws_arns" {
 }
 
 
+variable "test_aws_principal_arns" {
+  type        = list(string)
+  description = "AWS principal ARNs allowed to test the deployment. When null and provision_testing_infra is true, defaults to the IAM principal running Terraform."
+  default     = null
+  nullable    = true
+}
+
+
 variable "connector_display_name_suffix" {
   type        = string
   description = "suffix to append to display_names of connector SAs; helpful to distinguish between various ones in testing/dev scenarios"

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -13,6 +13,12 @@ terraform {
 # is provisioned, and that's implicit in the provider - so we should just infer from the provider
 data "aws_region" "current" {}
 
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
 module "env_id" {
   source = "../../modules/env-id"
 
@@ -29,6 +35,12 @@ locals {
 
   has_enabled_webhook_collectors = length(keys(var.webhook_collectors)) > 0
   enable_webhook_testing         = var.provision_testing_infra && local.has_enabled_webhook_collectors
+
+  terraform_principal_arn = can(regex(":assumed-role/", data.aws_caller_identity.current.arn)) ? data.aws_iam_session_context.current.issuer_arn : data.aws_caller_identity.current.arn
+
+  test_aws_principal_arns = var.provision_testing_infra ? (
+    var.test_aws_principal_arns != null ? var.test_aws_principal_arns : [local.terraform_principal_arn]
+  ) : []
 
   api_connector_rules_files = merge(var.custom_api_connector_rules, { for k, v in var.api_connectors : k => v.rules_file if v.rules_file != null })
 
@@ -82,6 +94,7 @@ module "psoxy" {
   region                             = data.aws_region.current.id
   psoxy_base_dir                     = var.psoxy_base_dir
   caller_aws_arns                    = var.caller_aws_arns
+  test_aws_principal_arns            = local.test_aws_principal_arns
   caller_gcp_service_account_ids     = var.caller_gcp_service_account_ids
   deployment_bundle                  = var.deployment_bundle
   deployment_bundle_hash             = var.deployment_bundle_hash
@@ -352,7 +365,7 @@ module "bulk_connector" {
   source = "../../modules/aws-proxy-bulk"
 
   aws_account_id                   = var.aws_account_id
-  caller_aws_arns                  = var.caller_aws_arns
+  test_aws_principal_arns            = local.test_aws_principal_arns
   provision_iam_policy_for_testing = var.provision_testing_infra
   aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy.api_caller_role_arn : null
   environment_name                 = var.environment_name

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -352,6 +352,7 @@ module "bulk_connector" {
   source = "../../modules/aws-proxy-bulk"
 
   aws_account_id                   = var.aws_account_id
+  caller_aws_arns                  = var.caller_aws_arns
   provision_iam_policy_for_testing = var.provision_testing_infra
   aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy.api_caller_role_arn : null
   environment_name                 = var.environment_name

--- a/infra/modules/aws-host/output.tf
+++ b/infra/modules/aws-host/output.tf
@@ -22,6 +22,11 @@ output "caller_role_arn" {
   value = module.psoxy.api_caller_role_arn
 }
 
+output "test_aws_principal_arns" {
+  description = "AWS principal ARNs allowed to test the deployment when provision_testing_infra is enabled."
+  value       = local.test_aws_principal_arns
+}
+
 output "api_connector_instances" {
   value = local.api_instances
 }

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -152,6 +152,13 @@ variable "provision_testing_infra" {
   default     = false
 }
 
+variable "test_aws_principal_arns" {
+  type        = list(string)
+  description = "AWS principal ARNs allowed to test the deployment (invoke APIs, upload bulk test files, etc.). When null and `provision_testing_infra` is true, defaults to the IAM principal running Terraform."
+  default     = null
+  nullable    = true
+}
+
 variable "install_test_tool" {
   type        = bool
   description = "whether to install the test tool (can be 'false' if Terraform not running from a machine where you intend to run tests of your Psoxy deployment)"

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -300,11 +300,11 @@ resource "aws_ssm_parameter" "rules" {
   }
 }
 
-resource "aws_iam_policy" "testing" {
+resource "aws_iam_policy" "testing_input_write" {
   count = var.provision_iam_policy_for_testing ? 1 : 0
 
-  name_prefix = "${local.iam_policy_prefix}Testing"
-  description = "Allow to write to input bucket, read from sanitized bucket to test Lambda's behavior"
+  name_prefix = "${local.iam_policy_prefix}TestingInputWrite"
+  description = "Allow principals in caller_aws_arns to write test files to the input bucket"
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -317,17 +317,26 @@ resource "aws_iam_policy" "testing" {
           "${aws_s3_bucket.input.arn}",
           "${aws_s3_bucket.input.arn}/*"
         ]
-      },
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "testing_sanitized_cleanup" {
+  count = var.provision_iam_policy_for_testing ? 1 : 0
+
+  name_prefix = "${local.iam_policy_prefix}TestingSanitizedCleanup"
+  description = "Allow the proxy caller role to delete sanitized test files after verification"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
         "Action" : [
-          "s3:GetObject",
-          "s3:ListBucket",
           "s3:DeleteObject",
           "s3:DeleteObjectVersion"
         ],
         "Effect" : "Allow",
         "Resource" : [
-          "${aws_s3_bucket.sanitized.arn}",
           "${aws_s3_bucket.sanitized.arn}/*"
         ]
       }
@@ -335,16 +344,37 @@ resource "aws_iam_policy" "testing" {
   })
 }
 
+locals {
+  caller_role_names_for_testing = var.provision_iam_policy_for_testing ? toset([
+    for arn in var.caller_aws_arns : element(split("role/", arn), 1)
+    if can(regex(":role/", arn))
+  ]) : toset([])
 
+  caller_user_names_for_testing = var.provision_iam_policy_for_testing ? toset([
+    for arn in var.caller_aws_arns : element(split("user/", arn), 1)
+    if can(regex(":user/", arn))
+  ]) : toset([])
+}
 
-resource "aws_iam_policy_attachment" "testing_policy_to_testing_role" {
+resource "aws_iam_role_policy_attachment" "testing_input_write_to_caller_roles" {
+  for_each = local.caller_role_names_for_testing
+
+  role       = each.key
+  policy_arn = aws_iam_policy.testing_input_write[0].arn
+}
+
+resource "aws_iam_user_policy_attachment" "testing_input_write_to_caller_users" {
+  for_each = local.caller_user_names_for_testing
+
+  user       = each.key
+  policy_arn = aws_iam_policy.testing_input_write[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "testing_sanitized_cleanup_to_caller_role" {
   count = var.provision_iam_policy_for_testing ? 1 : 0
 
-  name       = "${aws_iam_policy.testing[count.index].name}_to_${var.instance_id}TestingRole"
-  policy_arn = aws_iam_policy.testing[count.index].arn
-  roles = [
-    element(split("role/", var.aws_role_to_assume_when_testing), 1)
-  ]
+  role       = element(split("role/", var.aws_role_to_assume_when_testing), 1)
+  policy_arn = aws_iam_policy.testing_sanitized_cleanup[0].arn
 }
 
 locals {

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -351,7 +351,7 @@ locals {
   ]) : toset([])
 
   caller_user_names_for_testing = var.provision_iam_policy_for_testing ? toset([
-    for arn in var.caller_aws_arns : element(split("user/", arn), 1)
+    for arn in var.caller_aws_arns : element(reverse(split("/", arn)), 0)
     if can(regex(":user/", arn))
   ]) : toset([])
 }

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -300,23 +300,24 @@ resource "aws_ssm_parameter" "rules" {
   }
 }
 
-resource "aws_iam_policy" "testing_input_write" {
+resource "aws_s3_bucket_policy" "testing_input_upload" {
   count = var.provision_iam_policy_for_testing ? 1 : 0
 
-  name_prefix = "${local.iam_policy_prefix}TestingInputWrite"
-  description = "Allow to write to input bucket for testing"
+  bucket = aws_s3_bucket.input.id
+
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
       {
+        "Sid" : "AllowTestUploadPrincipals",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : var.test_aws_principal_arns
+        },
         "Action" : [
           "s3:PutObject"
-        ]
-        "Effect" : "Allow",
-        "Resource" : [
-          "${aws_s3_bucket.input.arn}",
-          "${aws_s3_bucket.input.arn}/*"
-        ]
+        ],
+        "Resource" : "${aws_s3_bucket.input.arn}/*"
       }
     ]
   })
@@ -342,32 +343,6 @@ resource "aws_iam_policy" "testing_sanitized_cleanup" {
       }
     ]
   })
-}
-
-locals {
-  caller_role_names_for_testing = var.provision_iam_policy_for_testing ? toset([
-    for arn in var.caller_aws_arns : element(reverse(split("/", arn)), 0)
-    if can(regex(":role/", arn))
-  ]) : toset([])
-
-  caller_user_names_for_testing = var.provision_iam_policy_for_testing ? toset([
-    for arn in var.caller_aws_arns : element(reverse(split("/", arn)), 0)
-    if can(regex(":user/", arn))
-  ]) : toset([])
-}
-
-resource "aws_iam_role_policy_attachment" "testing_input_write_to_caller_roles" {
-  for_each = local.caller_role_names_for_testing
-
-  role       = each.key
-  policy_arn = aws_iam_policy.testing_input_write[0].arn
-}
-
-resource "aws_iam_user_policy_attachment" "testing_input_write_to_caller_users" {
-  for_each = local.caller_user_names_for_testing
-
-  user       = each.key
-  policy_arn = aws_iam_policy.testing_input_write[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "testing_sanitized_cleanup_to_caller_role" {

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -304,7 +304,7 @@ resource "aws_iam_policy" "testing_input_write" {
   count = var.provision_iam_policy_for_testing ? 1 : 0
 
   name_prefix = "${local.iam_policy_prefix}TestingInputWrite"
-  description = "Allow principals in caller_aws_arns to write test files to the input bucket"
+  description = "Allow to write to input bucket for testing"
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -326,7 +326,7 @@ resource "aws_iam_policy" "testing_sanitized_cleanup" {
   count = var.provision_iam_policy_for_testing ? 1 : 0
 
   name_prefix = "${local.iam_policy_prefix}TestingSanitizedCleanup"
-  description = "Allow the proxy caller role to delete sanitized test files after verification"
+  description = "Allow to delete from sanitized bucket for testing"
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -373,7 +373,7 @@ resource "aws_iam_user_policy_attachment" "testing_input_write_to_caller_users" 
 resource "aws_iam_role_policy_attachment" "testing_sanitized_cleanup_to_caller_role" {
   count = var.provision_iam_policy_for_testing ? 1 : 0
 
-  role       = element(split("role/", var.aws_role_to_assume_when_testing), 1)
+  role       = element(reverse(split("/", var.aws_role_to_assume_when_testing)), 0)
   policy_arn = aws_iam_policy.testing_sanitized_cleanup[0].arn
 }
 

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -346,7 +346,7 @@ resource "aws_iam_policy" "testing_sanitized_cleanup" {
 
 locals {
   caller_role_names_for_testing = var.provision_iam_policy_for_testing ? toset([
-    for arn in var.caller_aws_arns : element(split("role/", arn), 1)
+    for arn in var.caller_aws_arns : element(reverse(split("/", arn)), 0)
     if can(regex(":role/", arn))
   ]) : toset([])
 

--- a/infra/modules/aws-proxy-bulk/variables.tf
+++ b/infra/modules/aws-proxy-bulk/variables.tf
@@ -115,9 +115,9 @@ variable "function_zip_hash" {
 }
 
 
-variable "caller_aws_arns" {
+variable "test_aws_principal_arns" {
   type        = list(string)
-  description = "ARNs of AWS principals authorized to assume the proxy caller role."
+  description = "AWS principal ARNs allowed to upload test files to the bulk connector input bucket. Populated by the host module when provision_iam_policy_for_testing is enabled."
   default     = []
 }
 

--- a/infra/modules/aws-proxy-bulk/variables.tf
+++ b/infra/modules/aws-proxy-bulk/variables.tf
@@ -115,9 +115,15 @@ variable "function_zip_hash" {
 }
 
 
+variable "caller_aws_arns" {
+  type        = list(string)
+  description = "ARNs of AWS principals authorized to assume the proxy caller role. When `provision_iam_policy_for_testing` is true, these principals receive S3 write access to the input bucket for bulk connector testing."
+  default     = []
+}
+
 variable "aws_role_to_assume_when_testing" {
   type        = string
-  description = "ARN of role to assume when testing instance. Leave blank to use default credentials of location from which you'll run tests (which must be for a principal with sufficient privileges, or use `provision_iam_policy_for_testing`)."
+  description = "ARN of proxy caller role to assume when reading/deleting from the sanitized bucket during bulk connector tests. Uploads use the caller's default AWS credentials (must be listed in `caller_aws_arns` when `provision_iam_policy_for_testing` is true)."
   default     = null
 
   validation {
@@ -128,7 +134,7 @@ variable "aws_role_to_assume_when_testing" {
 
 variable "provision_iam_policy_for_testing" {
   type        = bool
-  description = "Whether to provision IAM policy and attach it to `aws_role_to_assume_when_testing`."
+  description = "Whether to provision IAM policies to support bulk connector testing: grants S3 input bucket write to `caller_aws_arns`, and S3 sanitized bucket delete to `aws_role_to_assume_when_testing`."
   default     = false
 }
 

--- a/infra/modules/aws-proxy-bulk/variables.tf
+++ b/infra/modules/aws-proxy-bulk/variables.tf
@@ -117,13 +117,13 @@ variable "function_zip_hash" {
 
 variable "caller_aws_arns" {
   type        = list(string)
-  description = "ARNs of AWS principals authorized to assume the proxy caller role. When `provision_iam_policy_for_testing` is true, these principals receive S3 write access to the input bucket for bulk connector testing."
+  description = "ARNs of AWS principals authorized to assume the proxy caller role."
   default     = []
 }
 
 variable "aws_role_to_assume_when_testing" {
   type        = string
-  description = "ARN of proxy caller role to assume when reading/deleting from the sanitized bucket during bulk connector tests. Uploads use the caller's default AWS credentials (must be listed in `caller_aws_arns` when `provision_iam_policy_for_testing` is true)."
+  description = "ARN of role to assume when testing instance. Leave blank to use default credentials of location from which you'll run tests (which must be for a principal with sufficient privileges, or use `provision_iam_policy_for_testing`)."
   default     = null
 
   validation {
@@ -134,7 +134,7 @@ variable "aws_role_to_assume_when_testing" {
 
 variable "provision_iam_policy_for_testing" {
   type        = bool
-  description = "Whether to provision IAM policies to support bulk connector testing: grants S3 input bucket write to `caller_aws_arns`, and S3 sanitized bucket delete to `aws_role_to_assume_when_testing`."
+  description = "Whether to provision IAM policies for bulk connector testing."
   default     = false
 }
 

--- a/infra/modules/aws-proxy-lambda/main.tf
+++ b/infra/modules/aws-proxy-lambda/main.tf
@@ -315,7 +315,7 @@ locals {
     Action = [
       "s3:GetObject",
     ]
-    Effect = "Allow"
+    Effect   = "Allow"
     Resource = length(local.remote_resource_s3_object_arns) > 0 ? local.remote_resource_s3_object_arns : ["arn:aws:s3:::${var.remote_resource_bucket}/*"]
   }] : []
 

--- a/infra/modules/aws-proxy-lambda/remote_resource_iam.tftest.hcl
+++ b/infra/modules/aws-proxy-lambda/remote_resource_iam.tftest.hcl
@@ -42,7 +42,7 @@ run "empty_instance_path_grants_bucket_root" {
 
   assert {
     error_message = "empty instance path should grant bucket root objects"
-    condition = toset(one([for s in jsondecode(aws_iam_policy.required_resource_access.policy).Statement : s.Resource if s.Sid == "ReadRemoteResourceBucket"])) == toset(["arn:aws:s3:::my-artifacts/*"])
+    condition     = toset(one([for s in jsondecode(aws_iam_policy.required_resource_access.policy).Statement : s.Resource if s.Sid == "ReadRemoteResourceBucket"])) == toset(["arn:aws:s3:::my-artifacts/*"])
   }
 }
 
@@ -57,7 +57,7 @@ run "no_paths_grants_bucket_root" {
 
   assert {
     error_message = "no path prefixes should grant bucket root objects"
-    condition = toset(one([for s in jsondecode(aws_iam_policy.required_resource_access.policy).Statement : s.Resource if s.Sid == "ReadRemoteResourceBucket"])) == toset(["arn:aws:s3:::my-artifacts/*"])
+    condition     = toset(one([for s in jsondecode(aws_iam_policy.required_resource_access.policy).Statement : s.Resource if s.Sid == "ReadRemoteResourceBucket"])) == toset(["arn:aws:s3:::my-artifacts/*"])
   }
 }
 
@@ -90,6 +90,6 @@ run "duplicate_prefixes_dedupe_to_one_arn" {
 
   assert {
     error_message = "identical instance and shared prefixes should dedupe to a single ARN"
-    condition = toset(one([for s in jsondecode(aws_iam_policy.required_resource_access.policy).Statement : s.Resource if s.Sid == "ReadRemoteResourceBucket"])) == toset(["arn:aws:s3:::my-artifacts/shared/*"])
+    condition     = toset(one([for s in jsondecode(aws_iam_policy.required_resource_access.policy).Statement : s.Resource if s.Sid == "ReadRemoteResourceBucket"])) == toset(["arn:aws:s3:::my-artifacts/shared/*"])
   }
 }

--- a/infra/modules/aws/main.tf
+++ b/infra/modules/aws/main.tf
@@ -13,8 +13,10 @@ terraform {
 locals {
   api_function_name_prefix = coalesce(var.api_function_name_prefix, "${lower(var.deployment_id)}-")
 
+  caller_and_test_aws_arns = distinct(concat(var.caller_aws_arns, var.test_aws_principal_arns))
+
   aws_caller_statements = [
-    for arn in var.caller_aws_arns :
+    for arn in local.caller_and_test_aws_arns :
     merge({
       Action : "sts:AssumeRole"
       Effect : "Allow"
@@ -51,7 +53,7 @@ locals {
   ]
 
   webhook_aws_caller_statements = [
-    for arn in var.caller_aws_arns :
+    for arn in local.caller_and_test_aws_arns :
     merge({
       Action : "sts:AssumeRole"
       Effect : "Allow"

--- a/infra/modules/aws/variables.tf
+++ b/infra/modules/aws/variables.tf
@@ -78,6 +78,12 @@ variable "caller_aws_arns" {
   #  }
 }
 
+variable "test_aws_principal_arns" {
+  type        = list(string)
+  description = "AWS principal ARNs allowed to test the deployment (assume Caller role, etc.). Populated by the host module when provision_testing_infra is enabled."
+  default     = []
+}
+
 variable "psoxy_version" {
   type        = string
   description = "IGNORED; version of psoxy to deploy"

--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -28,7 +28,7 @@ const { version } = require('./package.json');
     .requiredOption('-i, --input <bucketName>', 'Input bucket\'s name')
     .requiredOption('-f, --file <path/to/file>', 'Path of the file to be processed')
     .requiredOption('-o, --output <bucketName>', 'Output bucket\'s name')
-    .option('-r, --role <arn>', 'ARN of AWS role to assume; if omitted, AWS CLI must be authenticated as a principal with perms to write to input bucket and read from output bucket')
+    .option('-r, --role <arn>', 'ARN of proxy Caller role to assume when reading from the output bucket; uploads use your default AWS credentials')
     .option('--region <region>', 'AWS region of the buckets (input/output)',
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)

--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -28,7 +28,7 @@ const { version } = require('./package.json');
     .requiredOption('-i, --input <bucketName>', 'Input bucket\'s name')
     .requiredOption('-f, --file <path/to/file>', 'Path of the file to be processed')
     .requiredOption('-o, --output <bucketName>', 'Output bucket\'s name')
-    .option('-r, --role <arn>', 'ARN of proxy Caller role to assume when reading from the output bucket; uploads use your default AWS credentials')
+    .option('-r, --role <arn>', 'ARN of AWS role to assume; if omitted, AWS CLI must be authenticated as a principal with perms to write to input bucket and read from output bucket')
     .option('--region <region>', 'AWS region of the buckets (input/output)',
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -32,7 +32,7 @@ async function testAWS(options, logger) {
   const uploadClient = await aws.createS3Client(null, options.region);
   let downloadClient = uploadClient;
   if (options.role) {
-    logger.verbose(`Assuming role ${options.role} to read from output bucket`);
+    logger.verbose(`Assuming role ${options.role}`);
     downloadClient = await aws.createS3Client(options.role, options.region);
   }
 

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -29,10 +29,12 @@ async function testAWS(options, logger) {
   const parsedPath = path.parse(options.file);
   const filenameWithTimestamp = addFilenameSuffix(parsedPath.base, TIMESTAMP);
 
+  const uploadClient = await aws.createS3Client(null, options.region);
+  let downloadClient = uploadClient;
   if (options.role) {
-    logger.verbose(`Assuming role ${options.role}`);
+    logger.verbose(`Assuming role ${options.role} to read from output bucket`);
+    downloadClient = await aws.createS3Client(options.role, options.region);
   }
-  const client = await aws.createS3Client(options.role, options.region);
 
   const parsedBucketInputOption = parseBucketOption(options.input);
   // not destructuring to avoid variable name collision with path module
@@ -42,9 +44,8 @@ async function testAWS(options, logger) {
   logger.info(`Uploading "${inputPath + parsedPath.base}" as "${inputKey}" to input bucket: ${inputBucket}`);
 
   const uploadResult = await aws.upload(inputBucket, inputKey, options.file, {
-      role: options.role,
       region: options.region,
-    }, client);
+    }, uploadClient);
 
   if (uploadResult['$metadata'].httpStatusCode !== httpCodes.HTTP_STATUS_OK) {
     throw new Error('Unable to upload file', { cause: uploadResult });
@@ -64,7 +65,7 @@ async function testAWS(options, logger) {
   const file = await aws.download(outputBucket, outputKey, destination, {
       role: options.role,
       region: options.region,
-    }, client, logger);
+    }, downloadClient, logger);
   logger.success('File downloaded');
 
   if (file?.metadata) {
@@ -79,7 +80,10 @@ async function testAWS(options, logger) {
       // the default "null" version of the object, but:
       // > If there isn't a null version, Amazon S3 does not remove any objects
       //   but will still respond that the command was successful.
-      await aws.deleteObject(outputBucket, outputKey, options, client);
+      await aws.deleteObject(outputBucket, outputKey, {
+        role: options.role,
+        region: options.region,
+      }, downloadClient);
     } catch (error) {
       logger.error(`Error deleting sanitized file: ${error.message}`, {
         additional: error,


### PR DESCRIPTION
### Fixes
- Updated permission logic to grant bulk test input writes to `caller_aws_arns` instead of the `Caller` role, enhancing security and flexibility in access management.


### Change implications

- dependencies added/changed? **no**
- something important to note in future release notes?
  - No major changes expected in `CHANGELOG.md` or `terraform plan`/`apply`.
  - breaking changes? No breaking changes anticipated.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204918934280708