### PR TITLE
doc glean admin setting / header use

### DIFF
--- a/docs/sources/glean/README.md
+++ b/docs/sources/glean/README.md
@@ -18,6 +18,12 @@ Based on the endpoints used by this connector, the following scopes are required
 - **`INSIGHTS_READ`** - Required for the `/rest/api/v1/insights` endpoint to retrieve user activity insights
 - **`PEOPLE_READ`** - Required for the `/rest/api/v1/listentities` endpoint to list users and teams
 
+### Act-As Header
+
+Glean-issued global tokens require an `X-Glean-ActAs` request header with the email of a user in your Glean workspace on every API call. See [Glean Authentication - Glean-issued Tokens](https://developers.glean.com/api-info/client/authentication/glean-issued).
+
+Worklytics sends this header using the **Admin Email** (`ADMIN_EMAIL`) connector setting. Set it to the email address of the Global Admin who created the API credential. The proxy rules allow `X-Glean-ActAs` to pass through to Glean.
+
 ## Examples
 
 - [Example Rules](glean.yaml)
@@ -49,4 +55,6 @@ of the [Psoxy repository](https://github.com/Worklytics/psoxy).
 2. **API Token**: Follow the authentication instructions above to create a Glean-issued token with the required scopes (`INSIGHTS_READ`, `PEOPLE_READ`)
 
 3. **Deploy**: Deploy the proxy instance and configure the `ACCESS_TOKEN` secret with the token value from step 2
+
+4. **Worklytics Admin Email**: When connecting in Worklytics, set **Admin Email** (`ADMIN_EMAIL`) to the email of the Global Admin who created the API credential
 

--- a/infra/modules/worklytics-connector-specs/docs/glean/instructions.tftpl
+++ b/infra/modules/worklytics-connector-specs/docs/glean/instructions.tftpl
@@ -26,3 +26,5 @@ Then proceed with token creation:
 
 5. Copy the generated token immediately - you won't see it again; then paste it as the `${path_to_instance_parameters}ACCESS_TOKEN` parameter value in your proxy's host platform.
 
+6. When connecting this source in Worklytics, set **Admin Email** (`ADMIN_EMAIL`) to the email address of the Global Admin who created the API credential in step 1. Glean requires this value on every API request as the `X-Glean-ActAs` header when using a Glean-issued global token. Worklytics sends it automatically; the proxy forwards it to Glean.
+


### PR DESCRIPTION
### Features
- Updated Glean documentation to include details about the admin email configuration feature, enhancing clarity for admin setup.


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - None
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
