### PR TITLE
Infer bulk Content-Type from extension when S3 console sets generic

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -15,9 +15,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
@@ -68,6 +70,34 @@ public class StorageHandler {
     public static final String CONTENT_ENCODING_GZIP = "gzip";
     public static final String EXTENSION_GZIP = ".gz";
 
+    private static final String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded";
+    private static final String CONTENT_TYPE_CSV = "text/csv";
+    private static final String CONTENT_TYPE_APPLICATION_CSV = "application/csv";
+    private static final String CONTENT_TYPE_JSON = "application/json";
+    private static final String CONTENT_TYPE_NDJSON = "application/x-ndjson";
+    private static final String CONTENT_TYPE_NDJSON_ALT = "application/ndjson";
+    private static final String CONTENT_TYPE_PARQUET = "application/vnd.apache.parquet";
+    private static final String CONTENT_TYPE_CSV_UTF8 = CONTENT_TYPE_CSV + "; charset=utf-8";
+
+    /**
+     * Well-defined Content-Types that cloud consoles often attach to bulk uploads, but that do not
+     * reflect the file format (e.g. AWS S3 console may use {@code application/x-www-form-urlencoded}
+     * for arbitrary objects). When the object path implies a bulk format, extension-inferred types
+     * are preferred over these values.
+     */
+    private static final Set<String> KNOWN_GENERIC_CONTENT_TYPES = Set.of(
+        CONTENT_TYPE_FORM_URLENCODED
+    );
+
+    private static final Set<String> SUPPORTED_BULK_CONTENT_TYPE_BASES = Set.of(
+        CONTENT_TYPE_CSV,
+        CONTENT_TYPE_APPLICATION_CSV,
+        CONTENT_TYPE_JSON,
+        CONTENT_TYPE_NDJSON,
+        CONTENT_TYPE_NDJSON_ALT,
+        CONTENT_TYPE_PARQUET
+    );
+
     // gzip magic number bytes (RFC 1952)
     private static final int GZIP_MAGIC_BYTE_1 = 0x1f;
     private static final int GZIP_MAGIC_BYTE_2 = 0x8b;
@@ -113,6 +143,79 @@ public class StorageHandler {
             && !Objects.equals(contentEncoding, CONTENT_ENCODING_GZIP)) {
             log.warning("Input filename ends with .gz, but 'Content-Encoding' metadata is not 'gzip'; is this correct? Decompression is based on object's 'Content-Encoding'");
         }
+    }
+
+    /**
+     * Resolves the Content-Type for bulk processing and for writing sanitized objects.
+     *
+     * <ol>
+     *   <li>Use object metadata when it is a supported bulk type (including parameters such as
+     *       {@code charset}).</li>
+     *   <li>When metadata is absent, or is a {@link #KNOWN_GENERIC_CONTENT_TYPES known generic}
+     *       upload type, prefer a type inferred from the file extension when recognized.</li>
+     *   <li>Otherwise use the metadata value when present.</li>
+     * </ol>
+     */
+    @Nullable
+    String effectiveContentType(@NonNull String sourceObjectPath, @Nullable String sourceContentType) {
+        String inferredContentType = inferContentTypeFromObjectPath(sourceObjectPath).orElse(null);
+
+        if (isKnownGenericContentType(sourceContentType)) {
+            if (inferredContentType != null) {
+                log.info(String.format(
+                    "Replacing generic Content-Type '%s' on %s with '%s' inferred from file extension",
+                    sourceContentType, sourceObjectPath, inferredContentType));
+                return inferredContentType;
+            }
+            return null;
+        }
+
+        if (StringUtils.isBlank(sourceContentType)) {
+            return inferredContentType;
+        }
+
+        if (matchesSupportedBulkContentType(sourceContentType)) {
+            return sourceContentType;
+        }
+
+        return sourceContentType;
+    }
+
+    private boolean isKnownGenericContentType(@Nullable String contentType) {
+        String base = baseContentType(contentType);
+        return base != null && KNOWN_GENERIC_CONTENT_TYPES.contains(base);
+    }
+
+    private boolean matchesSupportedBulkContentType(@Nullable String contentType) {
+        String base = baseContentType(contentType);
+        return base != null && SUPPORTED_BULK_CONTENT_TYPE_BASES.contains(base);
+    }
+
+    @Nullable
+    private String baseContentType(@Nullable String contentType) {
+        if (StringUtils.isBlank(contentType)) {
+            return null;
+        }
+        return StringUtils.trimToNull(contentType.split(";", 2)[0].toLowerCase(Locale.ROOT));
+    }
+
+    private Optional<String> inferContentTypeFromObjectPath(@NonNull String sourceObjectPath) {
+        String path = StringUtils.lowerCase(sourceObjectPath);
+        if (path.endsWith(EXTENSION_GZIP)) {
+            path = path.substring(0, path.length() - EXTENSION_GZIP.length());
+        }
+
+        String inferredContentType = null;
+        if (path.endsWith(".ndjson") || path.endsWith(".jsonl")) {
+            inferredContentType = CONTENT_TYPE_NDJSON;
+        } else if (path.endsWith(".csv")) {
+            inferredContentType = CONTENT_TYPE_CSV_UTF8;
+        } else if (path.endsWith(".json")) {
+            inferredContentType = CONTENT_TYPE_JSON;
+        } else if (path.endsWith(".parquet")) {
+            inferredContentType = CONTENT_TYPE_PARQUET;
+        }
+        return Optional.ofNullable(inferredContentType);
     }
 
     @RequiredArgsConstructor
@@ -219,7 +322,7 @@ public class StorageHandler {
             .destinationObjectPath(transform.getPathWithinBucket() + sourceObjectPathWithinBase)
             .decompressInput(isSourceCompressed)
             .compressOutput(compressOutput)
-            .contentType(sourceContentType)
+            .contentType(effectiveContentType(sourceObjectPath, sourceContentType))
             .build();
 
         warnIfEncodingDoesNotMatchFilename(request, sourceContentEncoding);

--- a/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/storage/StorageHandler.java
@@ -167,7 +167,7 @@ public class StorageHandler {
                     sourceContentType, sourceObjectPath, inferredContentType));
                 return inferredContentType;
             }
-            return null;
+            return sourceContentType;
         }
 
         if (StringUtils.isBlank(sourceContentType)) {

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/StorageHandlerTest.java
@@ -426,4 +426,55 @@ class StorageHandlerTest {
 
         return Base64.getEncoder().encodeToString(compress(content.getBytes(StandardCharsets.UTF_8)));
     }
+
+    @Test
+    void buildRequest_replacesGenericContentTypeWithInferred() {
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.INPUT_BASE_PATH)))
+            .thenReturn(Optional.empty());
+        when(config.getConfigPropertyAsOptional(eq(BulkModeConfigProperty.OUTPUT_BASE_PATH)))
+            .thenReturn(Optional.empty());
+
+        StorageEventRequest request = handler.buildRequest(
+            "bucket-in",
+            "items.ndjson",
+            handler.buildDefaultTransform(),
+            null,
+            "application/x-www-form-urlencoded");
+
+        assertEquals("application/x-ndjson", request.getContentType());
+    }
+
+    @Test
+    void effectiveContentType_replacesGenericWithInferred() {
+        assertEquals(
+            "application/x-ndjson",
+            handler.effectiveContentType("items.ndjson", "application/x-www-form-urlencoded"));
+        assertEquals(
+            "text/csv; charset=utf-8",
+            handler.effectiveContentType("data.csv", "application/x-www-form-urlencoded"));
+        assertEquals(
+            "application/json",
+            handler.effectiveContentType("export/file.json", "application/x-www-form-urlencoded"));
+    }
+
+    @Test
+    void effectiveContentType_preservesSupportedSourceType() {
+        assertEquals(
+            "text/csv; charset=us-ascii",
+            handler.effectiveContentType("data.csv", "text/csv; charset=us-ascii"));
+    }
+
+    @Test
+    void effectiveContentType_preservesNonGenericNonSupportedSourceType() {
+        assertEquals(
+            "application/custom",
+            handler.effectiveContentType("items.ndjson", "application/custom"));
+    }
+
+    @Test
+    void effectiveContentType_infersWhenAbsent() {
+        assertEquals(
+            "application/x-ndjson",
+            handler.effectiveContentType("items.ndjson", null));
+    }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/storage/impl/RecordBulkDataSanitizerImplTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/storage/impl/RecordBulkDataSanitizerImplTest.java
@@ -328,6 +328,25 @@ class RecordBulkDataSanitizerImplTest {
     }
 
     @Test
+    void testAutoFormat_NdjsonWithUnreliableContentTypeUsesFileExtension() {
+        this.setUpWithRules("---\n" +
+            "format: \"AUTO\"\n" +
+            "transforms:\n" +
+            "- redact: \"foo\"\n" +
+            "- pseudonymize: \"bar\"\n");
+
+        final String objectPath = "export-20231128/items.ndjson";
+        storageHandler.handle(BulkDataTestUtils.request(objectPath)
+                .withContentType("application/x-www-form-urlencoded"),
+            BulkDataTestUtils.transform(rules),
+            BulkDataTestUtils.inputStreamSupplier("bulk/example.ndjson"),
+            outputStreamSupplier);
+
+        String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        assertEquals(new String(TestUtils.getData("bulk/example-sanitized.ndjson"), StandardCharsets.UTF_8), output);
+    }
+
+    @Test
     void testAutoFormat_JsonArrayWithoutContentTypeUsesFileExtension() {
         this.setUpWithRules("---\n" +
             "format: \"AUTO\"\n" +

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/S3Handler.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -37,15 +36,6 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
 
     @Inject
     S3Client s3Client;
-
-
-    List<String> EXPECTED_CONTENT_TYPES = Arrays.asList(
-        "text/csv; charset=utf-8",
-        "text/csv; charset=ascii",
-        "text/csv; charset=us-ascii"
-        //"text/csv; charset=iso-8859-1" // standardized latin-1, don't expect this
-    );
-
 
 
     @SneakyThrows
@@ -91,15 +81,6 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
             return null;
         }
 
-        // check content type here
-        if (sourceMetadata.contentType() != null
-                && !EXPECTED_CONTENT_TYPES.contains(sourceMetadata.contentType().toLowerCase())) {
-            // our code presumes a CSV, which is utf-8 encoded atm (or something like ascii, which is a subset of utf-8)
-            log.warning(String.format("S3 file content type for %s/%s is %s (content encoding: %s); this is not known to be compatible with UTF-8-encoded CSVs, so may not work as expected",
-                importBucket, sourceKey, sourceMetadata.contentType(), sourceMetadata.contentEncoding()));
-        }
-
-
         StorageEventRequest request =
             storageHandler.buildRequest(importBucket, sourceKey, transform, sourceMetadata.contentEncoding(), sourceMetadata.contentType());
 
@@ -133,8 +114,7 @@ public class S3Handler implements com.amazonaws.services.lambda.runtime.RequestH
                 .contentLength(tmpFile.length())
                 .metadata(destinationUserMetadata);
 
-            // set headers iff they're non-null on source object
-            Optional.ofNullable(sourceMetadata.contentType())
+            Optional.ofNullable(request.getContentType())
                 .ifPresent(putBuilder::contentType);
 
             if (request.getCompressOutput()) {

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GcsFileEventHandler.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GcsFileEventHandler.java
@@ -78,8 +78,10 @@ public class GcsFileEventHandler {
 
             Supplier<OutputStream> outputStreamSupplier = () -> {
                 BlobInfo.Builder blobInfoBuilder = BlobInfo.newBuilder(BlobId.of(request.getDestinationBucketName(), request.getDestinationObjectPath()))
-                    .setContentType(sourceBlobInfo.getContentType())
                     .setMetadata(storageHandler.buildObjectMetadata(importBucket, sourceName, transform));
+
+                Optional.ofNullable(request.getContentType())
+                    .ifPresent(blobInfoBuilder::setContentType);
 
                 if (request.getCompressOutput()) {
                     blobInfoBuilder.setContentEncoding(StorageHandler.CONTENT_ENCODING_GZIP);


### PR DESCRIPTION
### Fixes
 - `.ndjson` uploaded direct via AWS console don't process; so automatically infer the Content-Type from file extensions when the S3 console assigns generic MIME types

```
WARNING: S3 file content type for psxy-stbl-aws-workdata-generic-4st3jtuy-input/items.ndjson is application/x-www-form-urlencoded (content encoding: null); this is not known to be compatible with UTF-8-encoded CSVs, so may not work as expected
```

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NONE
   - breaking changes? no


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215390713189233