### PR TITLE
Atlassian Organization: rules update

### DIFF
--- a/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-response.json
@@ -5,6 +5,7 @@
       "type": "events",
       "attributes": {
         "action": "rovo_agent_chat_started",
+        "actionCategory": "rovo",
         "time": "2024-01-15T10:30:00.000Z",
         "actor": {
           "id": "5b0c5b7a-1234-5678-90ab-cdef01234567",
@@ -40,6 +41,7 @@
       "type": "events",
       "attributes": {
         "action": "rovo_agent_created",
+        "actionCategory": "rovo",
         "time": "2024-01-15T11:00:00.000Z",
         "actor": {
           "id": "5b0c5b7a-1234-5678-90ab-cdef01234568",
@@ -60,6 +62,7 @@
       "type": "events",
       "attributes": {
         "action": "user_added",
+        "actionCategory": "user_management",
         "time": "2024-01-15T09:00:00.000Z",
         "actor": {
           "id": "5b0c5b7a-1234-5678-90ab-cdef01234569",

--- a/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-response.json
@@ -3,34 +3,32 @@
     {
       "id": "550e8400-e29b-41d4-a716-446655440001",
       "type": "events",
-      "time": "2024-01-15T10:30:00.000Z",
       "attributes": {
         "action": "rovo_agent_chat_started",
-        "actionCategory": "rovo",
-        "product": "rovo"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234567",
-        "type": "user",
-        "auth": {
-          "authType": "container-token"
+        "time": "2024-01-15T10:30:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234567",
+          "type": "user",
+          "auth": {
+            "authType": "container-token"
+          },
+          "onBehalfOf": {
+            "id": "5b0c5b7a-9999-5678-90ab-cdef01234567",
+            "email": "jane.doe@example.com"
+          },
+          "app": {
+            "id": "app-rovo-agent",
+            "type": "oauth2"
+          }
         },
-        "onBehalfOf": {
-          "id": "5b0c5b7a-9999-5678-90ab-cdef01234567",
-          "email": "jane.doe@example.com"
+        "context": {
+          "id": "site-123",
+          "type": "site"
         },
-        "app": {
-          "id": "app-rovo-agent",
-          "type": "oauth2"
+        "container": {
+          "id": "org-456",
+          "type": "organization"
         }
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
       },
       "message": {
         "content": "User started a chat with Rovo agent",
@@ -40,45 +38,41 @@
     {
       "id": "550e8400-e29b-41d4-a716-446655440002",
       "type": "events",
-      "time": "2024-01-15T11:00:00.000Z",
       "attributes": {
         "action": "rovo_agent_created",
-        "actionCategory": "rovo",
-        "product": "rovo"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234568",
-        "type": "user"
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
+        "time": "2024-01-15T11:00:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234568",
+          "type": "user"
+        },
+        "context": {
+          "id": "site-123",
+          "type": "site"
+        },
+        "container": {
+          "id": "org-456",
+          "type": "organization"
+        }
       }
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440003",
       "type": "events",
-      "time": "2024-01-15T09:00:00.000Z",
       "attributes": {
         "action": "user_added",
-        "actionCategory": "user_management",
-        "product": "admin"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234569",
-        "type": "user"
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
+        "time": "2024-01-15T09:00:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234569",
+          "type": "user"
+        },
+        "context": {
+          "id": "site-123",
+          "type": "site"
+        },
+        "container": {
+          "id": "org-456",
+          "type": "organization"
+        }
       }
     }
   ],
@@ -86,5 +80,3 @@
     "next": "https://api.atlassian.com/admin/v1/orgs/org-456/events?cursor=abc123"
   }
 }
-
-

--- a/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-stream-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-stream-response.json
@@ -3,34 +3,33 @@
     {
       "id": "550e8400-e29b-41d4-a716-446655440011",
       "type": "events",
-      "time": "2024-01-16T08:15:00.000Z",
       "attributes": {
         "action": "rovo_agent_chat_started",
         "actionCategory": "rovo",
-        "product": "rovo"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234567",
-        "type": "user",
-        "auth": {
-          "authType": "session"
+        "time": "2024-01-16T08:15:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234567",
+          "type": "user",
+          "auth": {
+            "authType": "session"
+          },
+          "onBehalfOf": {
+            "id": "5b0c5b7a-8888-5678-90ab-cdef01234567",
+            "email": "bob.smith@example.com"
+          },
+          "app": {
+            "id": "app-confluence",
+            "type": "first-party"
+          }
         },
-        "onBehalfOf": {
-          "id": "5b0c5b7a-8888-5678-90ab-cdef01234567",
-          "email": "bob.smith@example.com"
+        "context": {
+          "id": "site-123",
+          "type": "site"
         },
-        "app": {
-          "id": "app-confluence",
-          "type": "first-party"
+        "container": {
+          "id": "org-456",
+          "type": "organization"
         }
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
       },
       "message": {
         "content": "User initiated a Rovo agent chat session",
@@ -40,67 +39,62 @@
     {
       "id": "550e8400-e29b-41d4-a716-446655440012",
       "type": "events",
-      "time": "2024-01-16T09:30:00.000Z",
       "attributes": {
         "action": "rovo_search_performed",
-        "actionCategory": "rovo",
-        "product": "rovo"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234568",
-        "type": "user"
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
+        "time": "2024-01-16T09:30:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234568",
+          "type": "user"
+        },
+        "context": {
+          "id": "site-123",
+          "type": "site"
+        },
+        "container": {
+          "id": "org-456",
+          "type": "organization"
+        }
       }
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440013",
       "type": "events",
-      "time": "2024-01-16T10:45:00.000Z",
       "attributes": {
         "action": "rovo_agent_updated",
-        "actionCategory": "rovo",
-        "product": "rovo"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234569",
-        "type": "user"
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
+        "time": "2024-01-16T10:45:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234569",
+          "type": "user"
+        },
+        "context": {
+          "id": "site-123",
+          "type": "site"
+        },
+        "container": {
+          "id": "org-456",
+          "type": "organization"
+        }
       }
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440014",
       "type": "events",
-      "time": "2024-01-16T07:00:00.000Z",
       "attributes": {
         "action": "user_login",
         "actionCategory": "authentication",
-        "product": "admin"
-      },
-      "actor": {
-        "id": "5b0c5b7a-1234-5678-90ab-cdef01234570",
-        "type": "user"
-      },
-      "context": {
-        "id": "site-123",
-        "type": "site"
-      },
-      "container": {
-        "id": "org-456",
-        "type": "organization"
+        "time": "2024-01-16T07:00:00.000Z",
+        "actor": {
+          "id": "5b0c5b7a-1234-5678-90ab-cdef01234570",
+          "type": "user"
+        },
+        "context": {
+          "id": "site-123",
+          "type": "site"
+        },
+        "container": {
+          "id": "org-456",
+          "type": "organization"
+        }
       }
     }
   ],
@@ -108,5 +102,3 @@
     "next": "https://api.atlassian.com/admin/v1/orgs/org-456/events-stream?cursor=stream_cursor_123"
   }
 }
-
-

--- a/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-stream-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/original/get-audit-events-stream-response.json
@@ -41,6 +41,7 @@
       "type": "events",
       "attributes": {
         "action": "rovo_search_performed",
+        "actionCategory": "rovo",
         "time": "2024-01-16T09:30:00.000Z",
         "actor": {
           "id": "5b0c5b7a-1234-5678-90ab-cdef01234568",
@@ -61,6 +62,7 @@
       "type": "events",
       "attributes": {
         "action": "rovo_agent_updated",
+        "actionCategory": "rovo",
         "time": "2024-01-16T10:45:00.000Z",
         "actor": {
           "id": "5b0c5b7a-1234-5678-90ab-cdef01234569",

--- a/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-response.json
@@ -5,6 +5,7 @@
       "type":"events",
       "attributes":{
         "action":"rovo_agent_chat_started",
+        "actionCategory":"rovo",
         "time":"2024-01-15T10:30:00.000Z",
         "actor":{
           "id":"t~eIeVD4DZOhLhu3hIvHUuQpwXpb6G4wevlT5nU_7Yceo",
@@ -40,6 +41,7 @@
       "type":"events",
       "attributes":{
         "action":"rovo_agent_created",
+        "actionCategory":"rovo",
         "time":"2024-01-15T11:00:00.000Z",
         "actor":{
           "id":"t~HhRofKzxVuj5HdJum2jZJbTHlyxvUHG1SVSvgpTY4xg",
@@ -60,6 +62,7 @@
       "type":"events",
       "attributes":{
         "action":"user_added",
+        "actionCategory":"user_management",
         "time":"2024-01-15T09:00:00.000Z",
         "actor":{
           "id":"t~qhwrU1-PafU343ZHSkivJ2a3eIFrjBePeQVCtY_t40s",

--- a/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-response.json
@@ -3,34 +3,32 @@
     {
       "id":"550e8400-e29b-41d4-a716-446655440001",
       "type":"events",
-      "time":"2024-01-15T10:30:00.000Z",
       "attributes":{
         "action":"rovo_agent_chat_started",
-        "actionCategory":"rovo",
-        "product":"rovo"
-      },
-      "actor":{
-        "id":"t~eIeVD4DZOhLhu3hIvHUuQpwXpb6G4wevlT5nU_7Yceo",
-        "type":"user",
-        "auth":{
-          "authType":"container-token"
+        "time":"2024-01-15T10:30:00.000Z",
+        "actor":{
+          "id":"t~eIeVD4DZOhLhu3hIvHUuQpwXpb6G4wevlT5nU_7Yceo",
+          "type":"user",
+          "auth":{
+            "authType":"container-token"
+          },
+          "onBehalfOf":{
+            "id":"t~k2YFzWTmBwG97Myk1tJ-hJ7mqgEYTHNglOwu3SKJl2U",
+            "email":"t~kQ722c0ydyagstrsf2u6mjLp14ZidbEkX2-WNEZcwtQ@example.com"
+          },
+          "app":{
+            "id":"app-rovo-agent",
+            "type":"oauth2"
+          }
         },
-        "onBehalfOf":{
-          "id":"t~k2YFzWTmBwG97Myk1tJ-hJ7mqgEYTHNglOwu3SKJl2U",
-          "email":"t~kQ722c0ydyagstrsf2u6mjLp14ZidbEkX2-WNEZcwtQ@example.com"
+        "context":{
+          "id":"site-123",
+          "type":"site"
         },
-        "app":{
-          "id":"app-rovo-agent",
-          "type":"oauth2"
+        "container":{
+          "id":"org-456",
+          "type":"organization"
         }
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
       },
       "message":{
         "content":"",
@@ -40,45 +38,41 @@
     {
       "id":"550e8400-e29b-41d4-a716-446655440002",
       "type":"events",
-      "time":"2024-01-15T11:00:00.000Z",
       "attributes":{
         "action":"rovo_agent_created",
-        "actionCategory":"rovo",
-        "product":"rovo"
-      },
-      "actor":{
-        "id":"t~HhRofKzxVuj5HdJum2jZJbTHlyxvUHG1SVSvgpTY4xg",
-        "type":"user"
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
+        "time":"2024-01-15T11:00:00.000Z",
+        "actor":{
+          "id":"t~HhRofKzxVuj5HdJum2jZJbTHlyxvUHG1SVSvgpTY4xg",
+          "type":"user"
+        },
+        "context":{
+          "id":"site-123",
+          "type":"site"
+        },
+        "container":{
+          "id":"org-456",
+          "type":"organization"
+        }
       }
     },
     {
       "id":"550e8400-e29b-41d4-a716-446655440003",
       "type":"events",
-      "time":"2024-01-15T09:00:00.000Z",
       "attributes":{
         "action":"user_added",
-        "actionCategory":"user_management",
-        "product":"admin"
-      },
-      "actor":{
-        "id":"t~qhwrU1-PafU343ZHSkivJ2a3eIFrjBePeQVCtY_t40s",
-        "type":"user"
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
+        "time":"2024-01-15T09:00:00.000Z",
+        "actor":{
+          "id":"t~qhwrU1-PafU343ZHSkivJ2a3eIFrjBePeQVCtY_t40s",
+          "type":"user"
+        },
+        "context":{
+          "id":"site-123",
+          "type":"site"
+        },
+        "container":{
+          "id":"org-456",
+          "type":"organization"
+        }
       }
     }
   ],

--- a/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-stream-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-stream-response.json
@@ -5,6 +5,7 @@
       "type":"events",
       "attributes":{
         "action":"rovo_agent_chat_started",
+        "actionCategory":"rovo",
         "time":"2024-01-16T08:15:00.000Z",
         "actor":{
           "id":"t~eIeVD4DZOhLhu3hIvHUuQpwXpb6G4wevlT5nU_7Yceo",
@@ -40,6 +41,7 @@
       "type":"events",
       "attributes":{
         "action":"rovo_search_performed",
+        "actionCategory":"rovo",
         "time":"2024-01-16T09:30:00.000Z",
         "actor":{
           "id":"t~HhRofKzxVuj5HdJum2jZJbTHlyxvUHG1SVSvgpTY4xg",
@@ -60,6 +62,7 @@
       "type":"events",
       "attributes":{
         "action":"rovo_agent_updated",
+        "actionCategory":"rovo",
         "time":"2024-01-16T10:45:00.000Z",
         "actor":{
           "id":"t~qhwrU1-PafU343ZHSkivJ2a3eIFrjBePeQVCtY_t40s",
@@ -80,6 +83,7 @@
       "type":"events",
       "attributes":{
         "action":"user_login",
+        "actionCategory":"authentication",
         "time":"2024-01-16T07:00:00.000Z",
         "actor":{
           "id":"t~tAzEwJiwKniTTxR9FwXN2Hbb4erRF_WKRHR5-Wie7D0",

--- a/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-stream-response.json
+++ b/docs/sources/atlassian/organization/example-api-responses/sanitized/get-audit-events-stream-response.json
@@ -3,34 +3,32 @@
     {
       "id":"550e8400-e29b-41d4-a716-446655440011",
       "type":"events",
-      "time":"2024-01-16T08:15:00.000Z",
       "attributes":{
         "action":"rovo_agent_chat_started",
-        "actionCategory":"rovo",
-        "product":"rovo"
-      },
-      "actor":{
-        "id":"t~eIeVD4DZOhLhu3hIvHUuQpwXpb6G4wevlT5nU_7Yceo",
-        "type":"user",
-        "auth":{
-          "authType":"session"
+        "time":"2024-01-16T08:15:00.000Z",
+        "actor":{
+          "id":"t~eIeVD4DZOhLhu3hIvHUuQpwXpb6G4wevlT5nU_7Yceo",
+          "type":"user",
+          "auth":{
+            "authType":"session"
+          },
+          "onBehalfOf":{
+            "id":"t~701wuIroFRONDJ1Luve964DRSRFZ4jFr3blhxoE82Sk",
+            "email":"t~_8Z-MGIyxt5NnQdJg1j7GZMZrE4jIt4r1z6KDIMaPjo@example.com"
+          },
+          "app":{
+            "id":"app-confluence",
+            "type":"first-party"
+          }
         },
-        "onBehalfOf":{
-          "id":"t~701wuIroFRONDJ1Luve964DRSRFZ4jFr3blhxoE82Sk",
-          "email":"t~_8Z-MGIyxt5NnQdJg1j7GZMZrE4jIt4r1z6KDIMaPjo@example.com"
+        "context":{
+          "id":"site-123",
+          "type":"site"
         },
-        "app":{
-          "id":"app-confluence",
-          "type":"first-party"
+        "container":{
+          "id":"org-456",
+          "type":"organization"
         }
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
       },
       "message":{
         "content":"",
@@ -40,67 +38,61 @@
     {
       "id":"550e8400-e29b-41d4-a716-446655440012",
       "type":"events",
-      "time":"2024-01-16T09:30:00.000Z",
       "attributes":{
         "action":"rovo_search_performed",
-        "actionCategory":"rovo",
-        "product":"rovo"
-      },
-      "actor":{
-        "id":"t~HhRofKzxVuj5HdJum2jZJbTHlyxvUHG1SVSvgpTY4xg",
-        "type":"user"
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
+        "time":"2024-01-16T09:30:00.000Z",
+        "actor":{
+          "id":"t~HhRofKzxVuj5HdJum2jZJbTHlyxvUHG1SVSvgpTY4xg",
+          "type":"user"
+        },
+        "context":{
+          "id":"site-123",
+          "type":"site"
+        },
+        "container":{
+          "id":"org-456",
+          "type":"organization"
+        }
       }
     },
     {
       "id":"550e8400-e29b-41d4-a716-446655440013",
       "type":"events",
-      "time":"2024-01-16T10:45:00.000Z",
       "attributes":{
         "action":"rovo_agent_updated",
-        "actionCategory":"rovo",
-        "product":"rovo"
-      },
-      "actor":{
-        "id":"t~qhwrU1-PafU343ZHSkivJ2a3eIFrjBePeQVCtY_t40s",
-        "type":"user"
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
+        "time":"2024-01-16T10:45:00.000Z",
+        "actor":{
+          "id":"t~qhwrU1-PafU343ZHSkivJ2a3eIFrjBePeQVCtY_t40s",
+          "type":"user"
+        },
+        "context":{
+          "id":"site-123",
+          "type":"site"
+        },
+        "container":{
+          "id":"org-456",
+          "type":"organization"
+        }
       }
     },
     {
       "id":"550e8400-e29b-41d4-a716-446655440014",
       "type":"events",
-      "time":"2024-01-16T07:00:00.000Z",
       "attributes":{
         "action":"user_login",
-        "actionCategory":"authentication",
-        "product":"admin"
-      },
-      "actor":{
-        "id":"t~tAzEwJiwKniTTxR9FwXN2Hbb4erRF_WKRHR5-Wie7D0",
-        "type":"user"
-      },
-      "context":{
-        "id":"site-123",
-        "type":"site"
-      },
-      "container":{
-        "id":"org-456",
-        "type":"organization"
+        "time":"2024-01-16T07:00:00.000Z",
+        "actor":{
+          "id":"t~tAzEwJiwKniTTxR9FwXN2Hbb4erRF_WKRHR5-Wie7D0",
+          "type":"user"
+        },
+        "context":{
+          "id":"site-123",
+          "type":"site"
+        },
+        "container":{
+          "id":"org-456",
+          "type":"organization"
+        }
       }
     }
   ],

--- a/docs/sources/atlassian/organization/organization.yaml
+++ b/docs/sources/atlassian/organization/organization.yaml
@@ -16,9 +16,9 @@ endpoints:
     transforms:
       - !<pseudonymize>
         jsonPaths:
-          - "$.data[*].actor.id"
-          - "$.data[*].actor.onBehalfOf.id"
-          - "$.data[*].actor.onBehalfOf.email"
+          - "$.data[*].attributes.actor.id"
+          - "$.data[*].attributes.actor.onBehalfOf.id"
+          - "$.data[*].attributes.actor.onBehalfOf.email"
         encoding: "URL_SAFE_TOKEN"
       - !<redactExceptPhrases>
         jsonPaths:
@@ -148,9 +148,9 @@ endpoints:
     transforms:
       - !<pseudonymize>
         jsonPaths:
-          - "$.data[*].actor.id"
-          - "$.data[*].actor.onBehalfOf.id"
-          - "$.data[*].actor.onBehalfOf.email"
+          - "$.data[*].attributes.actor.id"
+          - "$.data[*].attributes.actor.onBehalfOf.id"
+          - "$.data[*].attributes.actor.onBehalfOf.email"
         encoding: "URL_SAFE_TOKEN"
       - !<redactExceptPhrases>
         jsonPaths:
@@ -333,28 +333,27 @@ definitions:
     properties:
       action:
         type: "string"
-      actionCategory:
-        type: "string"
-      product:
-        type: "string"
-  AuditEvent:
-    type: "object"
-    properties:
       actor:
         $ref: "#/definitions/Actor"
-      attributes:
-        $ref: "#/definitions/Attributes"
       container:
         $ref: "#/definitions/Container"
       context:
         $ref: "#/definitions/Context"
+      processedAt:
+        type: "string"
+        format: "date-time"
+      time:
+        type: "string"
+        format: "date-time"
+  AuditEvent:
+    type: "object"
+    properties:
+      attributes:
+        $ref: "#/definitions/Attributes"
       id:
         type: "string"
       message:
         $ref: "#/definitions/Message"
-      time:
-        type: "string"
-        format: "date-time"
       type:
         type: "string"
   Container:

--- a/docs/sources/atlassian/organization/organization.yaml
+++ b/docs/sources/atlassian/organization/organization.yaml
@@ -333,6 +333,8 @@ definitions:
     properties:
       action:
         type: "string"
+      actionCategory:
+        type: "string"
       actor:
         $ref: "#/definitions/Actor"
       container:


### PR DESCRIPTION
Rules update after https://github.com/Worklytics/evalengin/pull/8660

### Fixes
[atlassian-organization no items stored](https://app.asana.com/1/27145998307022/project/1213797956438900/task/1215455191946050)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
