### PR TITLE
Minor claude rule update

### DIFF
--- a/docs/sources/anthropic/claude/claude.yaml
+++ b/docs/sources/anthropic/claude/claude.yaml
@@ -124,9 +124,7 @@ endpoints:
         user:
           $ref: "#/definitions/User"
   - pathTemplate: "/v1/compliance/organizations"
-    allowedQueryParams:
-      - "page"
-      - "limit"
+    allowedQueryParams: []
     responseSchema:
       type: "object"
       properties:

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/anthropic/ClaudeTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/anthropic/ClaudeTests.java
@@ -49,8 +49,6 @@ public class ClaudeTests extends JavaRulesTestBaseCase {
 
             // Organizations endpoint
             InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations", "organizations-response.json"),
-            InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations?page=1&limit=20", "organizations-response.json"),
-            InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations?page=2&limit=50", "organizations-response.json"),
 
             // Organization Users endpoint
             InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations/org_uuid_123/users", "organization-users-response.json"),


### PR DESCRIPTION
Not important, but to reflect that we are not paginating orgs after https://github.com/Worklytics/evalengin/pull/8657

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**
