### PR TITLE
fix aws bulk testing

### DIFF
--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -36,7 +36,8 @@ locals {
   has_enabled_webhook_collectors = length(keys(var.webhook_collectors)) > 0
   enable_webhook_testing         = var.provision_testing_infra && local.has_enabled_webhook_collectors
 
-  terraform_principal_arn = can(regex(":assumed-role/", data.aws_caller_identity.current.arn)) ? data.aws_iam_session_context.current.issuer_arn : data.aws_caller_identity.current.arn
+  terraform_principal_arn   = can(regex(":assumed-role/", data.aws_caller_identity.current.arn)) ? data.aws_iam_session_context.current.issuer_arn : data.aws_caller_identity.current.arn
+  terraform_upload_role_arn = can(regex("^arn:aws:iam::\\d{12}:role/", local.terraform_principal_arn)) ? local.terraform_principal_arn : null
 
   test_aws_principal_arns = var.provision_testing_infra ? (
     var.test_aws_principal_arns != null ? var.test_aws_principal_arns : [local.terraform_principal_arn]
@@ -364,21 +365,22 @@ module "bulk_connector" {
 
   source = "../../modules/aws-proxy-bulk"
 
-  aws_account_id                   = var.aws_account_id
-  test_aws_principal_arns            = local.test_aws_principal_arns
-  provision_iam_policy_for_testing = var.provision_testing_infra
-  aws_role_to_assume_when_testing  = var.provision_testing_infra ? module.psoxy.api_caller_role_arn : null
-  environment_name                 = var.environment_name
-  new_relic_account_id             = var.new_relic_account_id
-  instance_id                      = each.key
-  source_kind                      = each.value.source_kind
-  aws_region                       = data.aws_region.current.region
-  path_to_function_zip             = module.psoxy.path_to_deployment_jar
-  function_zip_hash                = module.psoxy.deployment_package_hash
-  function_env_kms_key_arn         = var.function_env_kms_key_arn
-  logs_kms_key_arn                 = var.logs_kms_key_arn
-  log_retention_days               = var.log_retention_days
-  psoxy_base_dir                   = var.psoxy_base_dir
+  aws_account_id                         = var.aws_account_id
+  test_aws_principal_arns                = local.test_aws_principal_arns
+  provision_iam_policy_for_testing       = var.provision_testing_infra
+  aws_role_to_assume_when_testing        = var.provision_testing_infra ? module.psoxy.api_caller_role_arn : null
+  aws_upload_role_to_assume_when_testing = var.provision_testing_infra ? local.terraform_upload_role_arn : null
+  environment_name                       = var.environment_name
+  new_relic_account_id                   = var.new_relic_account_id
+  instance_id                            = each.key
+  source_kind                            = each.value.source_kind
+  aws_region                             = data.aws_region.current.region
+  path_to_function_zip                   = module.psoxy.path_to_deployment_jar
+  function_zip_hash                      = module.psoxy.deployment_package_hash
+  function_env_kms_key_arn               = var.function_env_kms_key_arn
+  logs_kms_key_arn                       = var.logs_kms_key_arn
+  log_retention_days                     = var.log_retention_days
+  psoxy_base_dir                         = var.psoxy_base_dir
   rules = (
     try(var.custom_bulk_connector_rules[each.key], null) != null ? var.custom_bulk_connector_rules[each.key] :
     each.value.rules

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -353,8 +353,6 @@ resource "aws_iam_role_policy_attachment" "testing_sanitized_cleanup_to_caller_r
 }
 
 locals {
-  role_option_for_tests = var.aws_role_to_assume_when_testing == null ? "" : "-r ${var.aws_role_to_assume_when_testing}"
-
   # id that is unique for connector, within the environment (eg, files with this token in name, but otherwise equivalent, will not conflict)
   local_file_id = trimprefix(var.instance_id, var.environment_name)
 
@@ -368,13 +366,25 @@ locals {
 
   example_files_csv = join(",", [for f in local.all_example_files : "${var.psoxy_base_dir}${f}"])
 
+  cli_file_upload_role_args = compact([
+    var.aws_upload_role_to_assume_when_testing != null ? "--upload-role-to-assume ${var.aws_upload_role_to_assume_when_testing}" : null,
+    var.aws_role_to_assume_when_testing != null ? "-r ${var.aws_role_to_assume_when_testing}" : null,
+  ])
+  cli_file_upload_role_args_todo  = join("\n", [for arg in local.cli_file_upload_role_args : "  ${arg} \\"])
+  cli_file_upload_role_args_shell = join("\n", [for arg in local.cli_file_upload_role_args : "    ${arg} \\"])
+
   todo_brief = <<EOT
 ## Test ${var.instance_id}
 Check that the Psoxy works as expected, and it transforms the files of your input bucket following
 the rules you have defined:
 
 ```shell
-node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f ${local.example_files_csv} ${local.role_option_for_tests} -d AWS -i ${aws_s3_bucket.input.bucket} -o ${aws_s3_bucket.sanitized.bucket} --region ${data.aws_region.current.region}
+node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js \\
+  -f ${local.example_files_csv} \\
+  -d AWS \\
+  -i ${aws_s3_bucket.input.bucket} \\
+  -o ${aws_s3_bucket.sanitized.bucket} \\
+${local.cli_file_upload_role_args_todo != "" ? "${local.cli_file_upload_role_args_todo}\n" : ""}  --region ${data.aws_region.current.region}
 ```
 EOT
 
@@ -446,7 +456,12 @@ for FILE in "$${FILES[@]}"; do
   fi
   
   printf "Testing file: $FILE\n"
-  node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js -f "$FILE" -d "AWS" -i "${aws_s3_bucket.input.bucket}" -o "${aws_s3_bucket.sanitized.bucket}" ${local.role_option_for_tests} --region "${var.aws_region}"
+  node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js \
+    -f "$FILE" \
+    -d "AWS" \
+    -i "${aws_s3_bucket.input.bucket}" \
+    -o "${aws_s3_bucket.sanitized.bucket}" \
+${local.cli_file_upload_role_args_shell != "" ? "${local.cli_file_upload_role_args_shell}\n" : ""}    --region "${var.aws_region}"
   if [ $? -ne 0 ]; then
     FAILED=1
   fi

--- a/infra/modules/aws-proxy-bulk/variables.tf
+++ b/infra/modules/aws-proxy-bulk/variables.tf
@@ -123,12 +123,23 @@ variable "test_aws_principal_arns" {
 
 variable "aws_role_to_assume_when_testing" {
   type        = string
-  description = "ARN of role to assume when testing instance. Leave blank to use default credentials of location from which you'll run tests (which must be for a principal with sufficient privileges, or use `provision_iam_policy_for_testing`)."
+  description = "ARN of role to assume when downloading from the sanitized bucket during tests. Leave blank to use default credentials of location from which you'll run tests (which must be for a principal with sufficient privileges, or use `provision_iam_policy_for_testing`)."
   default     = null
 
   validation {
     condition     = var.aws_role_to_assume_when_testing == null || can(regex("^arn:aws:iam::\\d{12}:role/.*$", var.aws_role_to_assume_when_testing))
     error_message = "if provided, aws_role_to_assume_when_testing must be a valid ARN of an IAM Role"
+  }
+}
+
+variable "aws_upload_role_to_assume_when_testing" {
+  type        = string
+  description = "ARN of role to assume when uploading test files to the input bucket. Typically the IAM role used when running Terraform, if Terraform runs via role assumption."
+  default     = null
+
+  validation {
+    condition     = var.aws_upload_role_to_assume_when_testing == null || can(regex("^arn:aws:iam::\\d{12}:role/.*$", var.aws_upload_role_to_assume_when_testing))
+    error_message = "if provided, aws_upload_role_to_assume_when_testing must be a valid ARN of an IAM Role"
   }
 }
 

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -332,10 +332,10 @@ module "webhook_collector" {
 
   source = "../../modules/gcp-webhook-collector"
 
-  project_id                         = var.gcp_project_id
-  region                             = var.gcp_region
-  environment_id_prefix              = local.environment_id_prefix
-  instance_id                        = each.key
+  project_id            = var.gcp_project_id
+  region                = var.gcp_region
+  environment_id_prefix = local.environment_id_prefix
+  instance_id           = each.key
   service_account = {
     # .id is the provider's fully-qualified name (projects/.../serviceAccounts/...); same value google_service_account_iam_member.service_account_id expects
     service_account_id = google_service_account.webhook_collector[each.key].id

--- a/infra/modules/gcp-webhook-collector/ip_lock_conditions.tftest.hcl
+++ b/infra/modules/gcp-webhook-collector/ip_lock_conditions.tftest.hcl
@@ -1,8 +1,8 @@
 variables {
-  project_id                     = "test-project"
-  environment_id_prefix          = "dev-"
-  instance_id                    = "test-instance"
-  config_parameter_prefix        = "TEST_"
+  project_id              = "test-project"
+  environment_id_prefix   = "dev-"
+  instance_id             = "test-instance"
+  config_parameter_prefix = "TEST_"
   service_account = {
     service_account_id = "projects/test-project/serviceAccounts/testsa@test-project.iam.gserviceaccount.com"
     email              = "testsa@test-project.iam.gserviceaccount.com"

--- a/infra/modules/psoxy-package/main.tf
+++ b/infra/modules/psoxy-package/main.tf
@@ -26,10 +26,10 @@ data "external" "deployment_package" {
 }
 
 locals {
-  path_to_deployment_jar = coalesce(var.deployment_bundle, try(data.external.deployment_package[0].result.path_to_deployment_jar, "unknown"))
-  filename               = var.deployment_bundle != null ? basename(var.deployment_bundle) : try(data.external.deployment_package[0].result.filename, "unknown")
-  version                = var.deployment_bundle != null ? try(regex("^psoxy-(?:aws|gcp)-(.+)\\.jar$", basename(var.deployment_bundle))[0], "unknown") : try(data.external.deployment_package[0].result.version, "unknown")
-  built_package_hash     = try(data.external.deployment_package[0].result.deployment_package_hash, null)
+  path_to_deployment_jar   = coalesce(var.deployment_bundle, try(data.external.deployment_package[0].result.path_to_deployment_jar, "unknown"))
+  filename                 = var.deployment_bundle != null ? basename(var.deployment_bundle) : try(data.external.deployment_package[0].result.filename, "unknown")
+  version                  = var.deployment_bundle != null ? try(regex("^psoxy-(?:aws|gcp)-(.+)\\.jar$", basename(var.deployment_bundle))[0], "unknown") : try(data.external.deployment_package[0].result.version, "unknown")
+  built_package_hash       = try(data.external.deployment_package[0].result.deployment_package_hash, null)
   deployment_jar_is_remote = can(regex("^(s3|gs)://", local.path_to_deployment_jar))
 }
 

--- a/tools/psoxy-test/cli-file-upload.js
+++ b/tools/psoxy-test/cli-file-upload.js
@@ -28,7 +28,8 @@ const { version } = require('./package.json');
     .requiredOption('-i, --input <bucketName>', 'Input bucket\'s name')
     .requiredOption('-f, --file <path/to/file>', 'Path of the file to be processed')
     .requiredOption('-o, --output <bucketName>', 'Output bucket\'s name')
-    .option('-r, --role <arn>', 'ARN of AWS role to assume; if omitted, AWS CLI must be authenticated as a principal with perms to write to input bucket and read from output bucket')
+    .option('-r, --role <arn>', 'ARN of AWS role to assume when downloading from the output bucket (and deleting test artifacts); if omitted, default AWS credentials are used')
+    .option('--upload-role-to-assume <arn>', 'ARN of AWS role to assume when uploading to the input bucket; if omitted, default AWS credentials are used')
     .option('--region <region>', 'AWS region of the buckets (input/output)',
       'us-east-1')
     .option('-v, --verbose', 'Verbose output', false)
@@ -41,8 +42,21 @@ const { version } = require('./package.json');
   program.addHelpText(
     'after',
     `
-      AWS example call: node cli-file-upload.js -d AWS -i my-input-bucket -o my-output-bucket -f /path/to/file -r arn:aws:iam::id:myRole --region us-east-1
-      GCP example call: node cli-file-upload.js -d GCP -i my-input-bucket -o my-output-bucket -f /path/to/file
+      AWS example call:
+        node cli-file-upload.js \\
+          -d AWS \\
+          -i my-input-bucket \\
+          -o my-output-bucket \\
+          -f /path/to/file \\
+          --upload-role-to-assume arn:aws:iam::id:uploadRole \\
+          -r arn:aws:iam::id:downloadRole \\
+          --region us-east-1
+      GCP example call:
+        node cli-file-upload.js \\
+          -d GCP \\
+          -i my-input-bucket \\
+          -o my-output-bucket \\
+          -f /path/to/file
     `
   );
 

--- a/tools/psoxy-test/psoxy-test-file-upload.js
+++ b/tools/psoxy-test/psoxy-test-file-upload.js
@@ -29,10 +29,15 @@ async function testAWS(options, logger) {
   const parsedPath = path.parse(options.file);
   const filenameWithTimestamp = addFilenameSuffix(parsedPath.base, TIMESTAMP);
 
-  const uploadClient = await aws.createS3Client(null, options.region);
+  let uploadClient = await aws.createS3Client(null, options.region);
+  if (options.uploadRoleToAssume) {
+    logger.verbose(`Assuming role ${options.uploadRoleToAssume} for upload`);
+    uploadClient = await aws.createS3Client(options.uploadRoleToAssume, options.region);
+  }
+
   let downloadClient = uploadClient;
   if (options.role) {
-    logger.verbose(`Assuming role ${options.role}`);
+    logger.verbose(`Assuming role ${options.role} for download`);
     downloadClient = await aws.createS3Client(options.role, options.region);
   }
 
@@ -173,7 +178,8 @@ async function testGCP(options, logger) {
  * @param {string} options.input
  * @param {string} options.output
  * @param {string} options.region - AWS: buckets region
- * @param {string} options.role - AWS: role to assume (ARN format; optional)
+ * @param {string} options.role - AWS: role to assume for download/delete (ARN format; optional)
+ * @param {string} options.uploadRoleToAssume - AWS: role to assume for upload (ARN format; optional)
  * @param {boolean} options.saveSanitizedFile - Whether to save sanitized file or not
  * @param {boolean} options.keepSanitizedFile - Whether to delete sanitized file or not (from
  *  output bucket, after test completion)


### PR DESCRIPTION
### Fixes
 - aws bulk test fails if tf was run with AWS assumed role (test perms granted OK to that role, but it's not passed to test tool to be assumed when uploading files)

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - breaking changes? No
