### PR TITLE
Adding property config for redirect

### DIFF
--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -126,6 +126,12 @@ EOT
       reserved_concurrent_executions : null
       enable_async_processing : true
       enable_side_output : false
+      environment_variables : {
+        # ChatGPT Enterprise's API issues redirects that must be intercepted manually by the proxy
+        # in async mode; disable automatic redirect following so the 3xx Location URL is fetched
+        # by the async redirect-handling block rather than transparently by the HTTP client.
+        FOLLOW_REDIRECTS : "FALSE"
+      }
       example_api_calls_user_to_impersonate : null
       example_api_calls : [
         "/v1/compliance/workspaces/${local.chat_gpt_enterprise_example_workspace_id}/projects",

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProxyConfigProperty.java
@@ -138,6 +138,20 @@ public enum ProxyConfigProperty implements ConfigService.ConfigProperty {
      * in the bulk mode cases.
      */
     SOURCE,
+
+    /**
+     * Whether the proxy should follow HTTP redirects (3xx responses) when calling source APIs.
+     *
+     * OPTIONAL; defaults to {@code true} (redirects are followed), matching the default behavior
+     * of the underlying HTTP client.
+     *
+     * Set to {@code FALSE} for connectors whose APIs issue redirects that must not be
+     * automatically followed — e.g. ChatGPT Enterprise, which uses async processing and relies
+     * on the proxy intercepting 3xx responses to fetch data from the Location URL manually.
+     *
+     * Accepted values: {@code true} / {@code false} (case-insensitive).
+     */
+    FOLLOW_REDIRECTS,
     ;
 
 

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -93,6 +93,7 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.Value;
 import lombok.extern.java.Log;
+import co.worklytics.psoxy.gateway.ProxyConfigProperty;
 import co.worklytics.psoxy.gateway.ProxyConstants;
 
 @NoArgsConstructor(onConstructor_ = @Inject)
@@ -376,13 +377,15 @@ public class ApiDataRequestHandler {
             populateHeadersFromSource(requestToSourceApi, requestToProxy, requestUrls.getTarget());
 
             // setup request
+            boolean followRedirects = config.getConfigPropertyAsOptional(ProxyConfigProperty.FOLLOW_REDIRECTS)
+                    .map(Boolean::parseBoolean)
+                    .orElse(true);
+
             requestToSourceApi
                     .setThrowExceptionOnExecuteError(false)
                     .setConnectTimeout(apiModeConfig.getSourceApiConnectTimeoutMs())
                     .setReadTimeout(apiModeConfig.getSourceApiReadTimeoutMs())
-                    // disable automatic redirect following in async mode so that our redirect
-                    // handling block can intercept 3xx responses and fetch from Location manually
-                    .setFollowRedirects(!processingContext.getAsync());
+                    .setFollowRedirects(followRedirects);
 
         } catch (SocketTimeoutException e) {
             return buildConnectTimeoutErrorResponse(builder, e);


### PR DESCRIPTION
Instead of relying into the async case, just supporting have this as a env var, so we can setup without doing major changes.

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Setting for handling redirect](https://app.asana.com/1/27145998307022/project/1213797956438900/task/1215510682641177)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? *no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
