### PR TITLE
Improve release publish tooling and consolidate bundle CI workflows

### DIFF
--- a/.github/workflows/publish-aws-bundle.yaml
+++ b/.github/workflows/publish-aws-bundle.yaml
@@ -14,12 +14,8 @@ name: Publish AWS Bundle
 #   - Consider adding branch protection rules to restrict who can push tags and create rc-* branches
 
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - 'rc-*'
 
 env:
   IMPLEMENTATION: aws
@@ -113,37 +109,14 @@ jobs:
         run: |
           TAG_NAME="${{ github.ref_name }}"
           
-          # Construct AWS markdown block
-          AWS_BLOCK=""
-          while IFS='=' read -r key url; do
-            region=$(echo "$key" | sed 's/^ARTIFACT_URI_//')
-            filename="${url##*/}"
-            bucket="${BUCKET_PREFIX}-${region}"
-            s3_uri="s3://${bucket}/${filename}"
-            
-            AWS_BLOCK="${AWS_BLOCK}* **${region}:**"$'\n'
-            AWS_BLOCK="${AWS_BLOCK}  * **S3 URI:** \`${s3_uri}\`"$'\n'
-            AWS_BLOCK="${AWS_BLOCK}  * **HTTP URL:** [$url]($url)"$'\n'
-          done < artifact-uris.txt
-          
-          # Read SHA256 hash
-          AWS_SHA256=$(cut -d'=' -f2 < artifact-sha.txt || echo "")
+          bash ./tools/release/lib/deployment-bundle-release-notes-block.sh aws "$TAG_NAME" "$(cut -d'=' -f2 < artifact-sha.txt || echo "")" artifact-uris.txt > aws-release-block.md
           
           IDENTIFIER="<!-- aws-artifacts-info -->"
-          
           BLOCK_FILE=$(mktemp)
-          cat > "$BLOCK_FILE" <<EOF
-          
-          $IDENTIFIER
-          ## AWS Deployment Bundles
-          * **SHA256 Hash:** \`$AWS_SHA256\`
-          $AWS_BLOCK
-          $IDENTIFIER
-          EOF
+          cp aws-release-block.md "$BLOCK_FILE"
 
-          chmod +x ./tools/release/lib/amend-github-release-notes.sh
-          ./tools/release/lib/amend-github-release-notes.sh "$TAG_NAME" "$IDENTIFIER" "$BLOCK_FILE"
-          rm -f "$BLOCK_FILE"
+          bash ./tools/release/lib/amend-github-release-notes.sh "$TAG_NAME" "$IDENTIFIER" "$BLOCK_FILE"
+          rm -f "$BLOCK_FILE" aws-release-block.md
 
       - name: Summary
         if: success()

--- a/.github/workflows/publish-bundles.yaml
+++ b/.github/workflows/publish-bundles.yaml
@@ -1,0 +1,70 @@
+name: Publish Release Bundles
+
+# Orchestrates AWS + GCP bundle publication and verification.
+# Individual platform workflows remain available via workflow_dispatch.
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'rc-*'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  aws:
+    name: AWS Bundle
+    uses: ./.github/workflows/publish-aws-bundle.yaml
+    secrets: inherit
+
+  gcp:
+    name: GCP Bundle
+    uses: ./.github/workflows/publish-gcp-bundle.yaml
+    secrets: inherit
+
+  verify:
+    name: Verify Bundles
+    needs: [aws, gcp]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # verify-bundles.sh reads S3 object metadata across regions; this job needs its own
+      # OIDC session (separate from the publish-aws-bundle reusable workflow).
+      # aws-region is only the CLI default; each s3api call passes an explicit --region.
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Verify published bundles
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REF_NAME="${{ github.ref_name }}"
+          RC_FLAG=""
+          if [[ "$REF_NAME" =~ ^rc- ]]; then
+            RC_FLAG="--rc"
+          fi
+
+          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            ./tools/release/verify-bundles.sh "$REF_NAME" $RC_FLAG
+          else
+            VERSION="${REF_NAME#rc-}"
+            ./tools/release/verify-bundles.sh "$VERSION" $RC_FLAG
+          fi

--- a/.github/workflows/publish-gcp-bundle.yaml
+++ b/.github/workflows/publish-gcp-bundle.yaml
@@ -15,12 +15,8 @@ name: Publish GCP Bundle
 #   - Consider adding branch protection rules to restrict who can push tags and create rc-* branches
 
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - 'rc-*'
 
 env:
   IMPLEMENTATION: gcp
@@ -128,24 +124,12 @@ jobs:
             exit 1
           fi
           
-          # Convert gs:// URI to HTTP URL
-          HTTP_URL=$(echo "$ARTIFACT_URI" | sed 's|^gs://|https://storage.googleapis.com/|')
-          
           IDENTIFIER="<!-- gcp-artifacts-info -->"
           
           BLOCK_FILE=$(mktemp)
-          cat > "$BLOCK_FILE" <<EOF
-          
-          $IDENTIFIER
-          ## GCP Deployment Bundle
-          * **GCS URI:** \`$ARTIFACT_URI\`
-          * **HTTP URL:** [$HTTP_URL]($HTTP_URL)
-          * **SHA256 Hash:** \`$ARTIFACT_SHA256\`
-          $IDENTIFIER
-          EOF
+          bash ./tools/release/lib/deployment-bundle-release-notes-block.sh gcp "$TAG_NAME" "$ARTIFACT_SHA256" "$ARTIFACT_URI" > "$BLOCK_FILE"
 
-          chmod +x ./tools/release/lib/amend-github-release-notes.sh
-          ./tools/release/lib/amend-github-release-notes.sh "$TAG_NAME" "$IDENTIFIER" "$BLOCK_FILE"
+          bash ./tools/release/lib/amend-github-release-notes.sh "$TAG_NAME" "$IDENTIFIER" "$BLOCK_FILE"
           rm -f "$BLOCK_FILE"
 
       - name: Summary

--- a/tools/release/lib/deployment-bundle-release-notes-block.sh
+++ b/tools/release/lib/deployment-bundle-release-notes-block.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Build markdown blocks for deployment bundle references in GitHub release notes.
+#
+# Usage:
+#   ./deployment-bundle-release-notes-block.sh aws <tag> <sha256> <artifact-uris.txt>
+#   ./deployment-bundle-release-notes-block.sh gcp <tag> <sha256> <artifact_uri>
+#
+# Writes block content to stdout (includes start/end HTML comment markers).
+
+set -euo pipefail
+
+PLATFORM="${1:?platform required (aws|gcp)}"
+TAG_NAME="${2:?tag required}"
+SHA256="${3:?sha256 required}"
+ARTIFACTS_INPUT="${4:?artifact input required}"
+
+VERSION="${TAG_NAME#v}"
+UPGRADE_GUIDE_URL="https://github.com/Worklytics/psoxy/blob/main/docs/guides/upgrading-versions.md"
+BUCKET_PREFIX="${BUCKET_PREFIX:-psoxy-public-artifacts}"
+GCS_BUCKET="${GCS_BUCKET:-psoxy-public-artifacts}"
+
+usage_guidance() {
+  local platform="$1"
+  local example=""
+  case "$platform" in
+    aws)
+      example="deployment_bundle = \"s3://${BUCKET_PREFIX}-us-east-1/psoxy-aws-${VERSION}.jar\""
+      ;;
+    gcp)
+      example="deployment_bundle = \"gs://${GCS_BUCKET}/psoxy-gcp-${VERSION}.zip\""
+      ;;
+  esac
+  cat <<EOF
+
+To use a deployment bundle in Terraform, set \`deployment_bundle\` to the S3 or GCS URI for your platform, for example:
+
+\`\`\`hcl
+${example}
+\`\`\`
+
+To upgrade to this release using one of our examples, run \`./upgrade-terraform-modules ${TAG_NAME}\`. See [Upgrading Proxy Versions](${UPGRADE_GUIDE_URL}) for more information.
+EOF
+}
+
+case "$PLATFORM" in
+  aws)
+    IDENTIFIER="<!-- aws-artifacts-info -->"
+    printf '%s\n' "$IDENTIFIER"
+    printf '## AWS Deployment Bundles\n\n'
+    printf 'SHA256: `%s`\n\n' "$SHA256"
+    while IFS='=' read -r key url; do
+      [ -z "$key" ] && continue
+      region="${key#ARTIFACT_URI_}"
+      filename="${url##*/}"
+      bucket="${BUCKET_PREFIX}-${region}"
+      s3_uri="s3://${bucket}/${filename}"
+      printf '* %s:\n' "$region"
+      printf '  * S3 URI: `%s`\n' "$s3_uri"
+      printf '  * HTTP URL: [%s](%s)\n' "$url" "$url"
+    done < "$ARTIFACTS_INPUT"
+    usage_guidance aws
+    printf '%s\n' "$IDENTIFIER"
+    ;;
+  gcp)
+    IDENTIFIER="<!-- gcp-artifacts-info -->"
+    ARTIFACT_URI="$ARTIFACTS_INPUT"
+    HTTP_URL="$(printf '%s' "$ARTIFACT_URI" | sed 's|^gs://|https://storage.googleapis.com/|')"
+    printf '%s\n' "$IDENTIFIER"
+    printf '## GCP Deployment Bundle\n\n'
+    printf 'GCS URI: `%s`\n' "$ARTIFACT_URI"
+    printf 'HTTP URL: [%s](%s)\n' "$HTTP_URL" "$HTTP_URL"
+    printf 'SHA256: `%s`\n' "$SHA256"
+    usage_guidance gcp
+    printf '%s\n' "$IDENTIFIER"
+    ;;
+  *)
+    printf 'Unknown platform: %s\n' "$PLATFORM" >&2
+    exit 1
+    ;;
+esac

--- a/tools/release/lib/gh-workflow-runs.sh
+++ b/tools/release/lib/gh-workflow-runs.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Shared helpers for triggering and monitoring GitHub Actions workflows during release.
+# Sourced by publish.sh, publish-rc-bundles-via-gh.sh, and watch-gh-runs.sh.
+
+gh_workflow_runs_require_gh() {
+  if ! command -v gh >/dev/null 2>&1; then
+    printf "${ERR}Error: GitHub CLI (gh) is required.${NC}\n"
+    return 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    printf "${ERR}Error: Not authenticated with GitHub CLI. Run 'gh auth login'.${NC}\n"
+    return 1
+  fi
+  return 0
+}
+
+# Find the most recent workflow run for a workflow file on a given git ref.
+# Prints: run_id|status|conclusion|url|created_at (ISO8601)
+gh_workflow_runs_find_latest() {
+  local workflow_file="$1"
+  local ref="$2"
+
+  gh run list \
+    --workflow="$workflow_file" \
+    --limit 15 \
+    --json databaseId,status,conclusion,url,createdAt,headBranch \
+    --jq '[.[] | select(.headBranch == "'"$ref"'")][0] | if . == null then "" else "\(.databaseId)|\(.status)|\(.conclusion // "")|\(.url)|\(.createdAt // "")" end' \
+    2>/dev/null || true
+}
+
+# Wait briefly for a workflow run to appear after a trigger (tag push or workflow_dispatch).
+gh_workflow_runs_wait_for_run() {
+  local workflow_file="$1"
+  local ref="$2"
+  local max_attempts="${3:-15}"
+  local attempt=0
+  local line=""
+
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    line="$(gh_workflow_runs_find_latest "$workflow_file" "$ref")"
+    if [ -n "$line" ] && [ "${line%%|*}" != "" ] && [ "${line%%|*}" != "null" ]; then
+      printf '%s' "$line"
+      return 0
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+# Trigger workflow_dispatch if no recent in-progress/queued run exists for this ref.
+# Prints: workflow_file|run_id|url|triggered (true|false)
+gh_workflow_runs_trigger_or_use_existing() {
+  local workflow_file="$1"
+  local ref="$2"
+  local label="$3"
+
+  gh_workflow_runs_require_gh || return 1
+
+  local line
+  line="$(gh_workflow_runs_find_latest "$workflow_file" "$ref")"
+  local run_id="${line%%|*}"
+  local status=""
+  local url=""
+  if [ -n "$line" ]; then
+    IFS='|' read -r run_id status _ url _ <<< "$line"
+  fi
+
+  if [ -n "$run_id" ] && { [ "$status" = "in_progress" ] || [ "$status" = "queued" ] || [ "$status" = "waiting" ] || [ "$status" = "pending" ]; }; then
+    printf "${INFO}${label}${NC} already running via GitHub Actions (run ${SUCCESS}${run_id}${NC}).\n" >&2
+    printf "  ${INFO}${url}${NC}\n" >&2
+    printf '%s|%s|%s|false\n' "$workflow_file" "$run_id" "$url"
+    return 0
+  fi
+
+  printf "${INFO}Triggering ${label} via GitHub Actions (${CODE}${workflow_file}${NC}) on ref ${SUCCESS}${ref}${NC} ...\n" >&2
+  if ! gh workflow run "$workflow_file" --ref "$ref"; then
+    printf "${ERR}Failed to trigger ${workflow_file} on ${ref}.${NC}\n" >&2
+    return 1
+  fi
+
+  line="$(gh_workflow_runs_wait_for_run "$workflow_file" "$ref")"
+  if [ -z "$line" ]; then
+    printf "${WARN}Triggered ${workflow_file}, but could not find the new run yet.${NC}\n" >&2
+    printf "${WARN}Check manually: ${INFO}gh run list --workflow=${workflow_file} --branch=${ref}${NC}\n" >&2
+    return 1
+  fi
+
+  IFS='|' read -r run_id status _ url _ <<< "$line"
+  printf "${SUCCESS}✓${NC} ${label} workflow started (run ${SUCCESS}${run_id}${NC}, status: ${status}).\n" >&2
+  printf "  ${INFO}${url}${NC}\n" >&2
+  printf '%s|%s|%s|true\n' "$workflow_file" "$run_id" "$url"
+  return 0
+}
+
+# Register a workflow run for later monitoring. Appends to RELEASE_GH_RUNS array.
+gh_workflow_runs_track() {
+  local workflow_file="$1"
+  local run_id="$2"
+  local url="$3"
+  local label="$4"
+  local existing=""
+
+  if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+    return 1
+  fi
+
+  for existing in "${RELEASE_GH_RUNS[@]}"; do
+    if [[ "$existing" == "${workflow_file}|${run_id}|"* ]]; then
+      return 0
+    fi
+  done
+
+  RELEASE_GH_RUNS+=("${workflow_file}|${run_id}|${url}|${label}")
+  return 0
+}
+
+# Parse gh_workflow_runs_trigger_or_use_existing output and track the run.
+gh_workflow_runs_trigger_and_track() {
+  local workflow_file="$1"
+  local ref="$2"
+  local label="$3"
+  local line=""
+
+  line="$(gh_workflow_runs_trigger_or_use_existing "$workflow_file" "$ref" "$label")" || return 1
+  local wf run_id url triggered
+  IFS='|' read -r wf run_id url triggered <<< "$line"
+  gh_workflow_runs_track "$wf" "$run_id" "$url" "$label"
+}
+
+# Seconds since an ISO8601 timestamp (best effort; macOS + Linux).
+gh_workflow_runs_age_seconds() {
+  local created_at="$1"
+  if [ -z "$created_at" ]; then
+    printf '0'
+    return 0
+  fi
+  local created_epoch now_epoch
+  if created_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$created_at" "+%s" 2>/dev/null); then
+    :
+  elif created_epoch=$(date -d "$created_at" "+%s" 2>/dev/null); then
+    :
+  else
+    printf '0'
+    return 0
+  fi
+  now_epoch=$(date "+%s")
+  printf '%s' "$((now_epoch - created_epoch))"
+}

--- a/tools/release/lib/gh-workflow-runs.sh
+++ b/tools/release/lib/gh-workflow-runs.sh
@@ -29,6 +29,42 @@ gh_workflow_runs_find_latest() {
     2>/dev/null || true
 }
 
+# Print human-readable status for the latest workflow run on a ref (stderr).
+# Tracks the run in RELEASE_GH_RUNS when found. Returns 0 always (informational).
+gh_workflow_runs_report_status() {
+  local workflow_file="$1"
+  local ref="$2"
+  local label="$3"
+  local line run_id status conclusion url
+
+  if ! gh_workflow_runs_require_gh 2>/dev/null; then
+    printf "${WARN}${label}:${NC} skipped GitHub Actions status check (gh not available)\n" >&2
+    return 0
+  fi
+
+  line="$(gh_workflow_runs_find_latest "$workflow_file" "$ref")"
+  if [ -z "$line" ] || [ -z "${line%%|*}" ] || [ "${line%%|*}" = "null" ]; then
+    printf "${INFO}${label}:${NC} no GitHub Actions run found yet for ${ref} (${CODE}${workflow_file}${NC})\n" >&2
+    printf "  ${INFO}Tag push may still be registering; check with: gh run list --workflow=${workflow_file}${NC}\n" >&2
+    return 0
+  fi
+
+  IFS='|' read -r run_id status conclusion url _ <<< "$line"
+
+  if [ "$status" = "completed" ] && [ -n "$conclusion" ]; then
+    if [ "$conclusion" = "success" ]; then
+      printf "${SUCCESS}✓${NC} ${label}: GitHub Actions run ${SUCCESS}${run_id}${NC} completed successfully\n" >&2
+    else
+      printf "${ERR}✗${NC} ${label}: GitHub Actions run ${run_id} completed with ${conclusion}\n" >&2
+    fi
+  else
+    printf "${INFO}…${NC} ${label}: GitHub Actions run ${SUCCESS}${run_id}${NC} is ${status}\n" >&2
+  fi
+  printf "  ${INFO}${url}${NC}\n" >&2
+  gh_workflow_runs_track "$workflow_file" "$run_id" "$url" "$label"
+  return 0
+}
+
 # Wait briefly for a workflow run to appear after a trigger (tag push or workflow_dispatch).
 gh_workflow_runs_wait_for_run() {
   local workflow_file="$1"

--- a/tools/release/lib/verify-bundles-lib.sh
+++ b/tools/release/lib/verify-bundles-lib.sh
@@ -106,6 +106,24 @@ verify_bundles_platform_label() {
   esac
 }
 
+verify_bundles_print_compile_remediation() {
+  local label="${1:-bundle}"
+  echo ""
+  echo -e "${WARN}The published ${label} appears to contain Eclipse stub classes from a failed compile.${NC}"
+  echo -e "${INFO}To fix locally, rebuild and republish:${NC}"
+  echo -e "  ${CODE}./tools/build.sh -qd aws java/${NC}"
+  echo -e "  ${CODE}./tools/build.sh -qd gcp java/${NC}"
+  echo -e "  ${CODE}cd java && mvn clean test${NC}"
+  echo ""
+  echo -e "${INFO}To rebuild via GitHub Actions and republish:${NC}"
+  echo -e "  ${CODE}gh workflow run publish-bundles.yaml --ref <release-tag-or-rc-branch>${NC}"
+  echo -e "  ${CODE}gh workflow run publish-aws-bundle.yaml --ref <release-tag-or-rc-branch>${NC}"
+  echo -e "  ${CODE}gh workflow run publish-gcp-bundle.yaml --ref <release-tag-or-rc-branch>${NC}"
+  echo ""
+  echo -e "${INFO}To catch compile issues before publishing, run bundle CI:${NC}"
+  echo -e "  ${CODE}gh workflow run ci-bundles.yaml --ref <branch>${NC}"
+}
+
 verify_bundles_scan_jar_for_compilation_errors() {
   local jar_path="$1"
   local label="$2"
@@ -131,6 +149,7 @@ verify_bundles_scan_jar_for_compilation_errors() {
     if [ "${#bad_classes[@]}" -gt 10 ]; then
       echo -e "  ${WARN}... and $((${#bad_classes[@]} - 10)) more${NC}"
     fi
+    verify_bundles_print_compile_remediation "$label"
     return 1
   fi
 

--- a/tools/release/lib/watch-gh-runs.sh
+++ b/tools/release/lib/watch-gh-runs.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Watch GitHub Actions release workflows briefly, then print follow-up commands.
+#
+# Usage:
+#   ./tools/release/lib/watch-gh-runs.sh <release-tag> [workflow|run_id|url|label ...]
+#
+# Each tracked run is encoded as: workflow_file|run_id|url|label
+#
+# Behavior:
+#   - Poll for up to 60 seconds while runs are in progress
+#   - If any run has been active for more than 5 minutes, stop waiting and print gh run watch commands
+#   - Suggest verify-bundles.sh when bundle workflows were tracked
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLORSCHEME_SH="${SCRIPT_DIR}/../../set-term-colorscheme.sh"
+if [ -f "$COLORSCHEME_SH" ]; then
+  # shellcheck source=/dev/null
+  source "$COLORSCHEME_SH"
+else
+  ERR='\033[0;31m'; SUCCESS='\033[0;32m'; WARN='\033[1;33m'; INFO='\033[0;34m'; CODE='\033[0;36m'; NC='\033[0m'
+fi
+
+# shellcheck source=gh-workflow-runs.sh
+source "${SCRIPT_DIR}/gh-workflow-runs.sh"
+
+RELEASE_TAG="${1:-}"
+shift || true
+
+if [ -z "$RELEASE_TAG" ]; then
+  printf "${ERR}Usage: $0 <release-tag> [workflow|run_id|url|label ...]${NC}\n"
+  exit 1
+fi
+
+if [ "$#" -eq 0 ]; then
+  printf "${INFO}No GitHub Actions release workflows to watch.${NC}\n"
+  exit 0
+fi
+
+TRACKED=("$@")
+BUNDLE_TRACKED="false"
+
+printf "\n${INFO}=== GitHub Actions release workflows ===${NC}\n"
+printf "${INFO}These jobs run in GitHub Actions (not locally). Checking status ...${NC}\n\n"
+
+STILL_RUNNING=()
+WATCH_COMMANDS=()
+local_max_wait=60
+elapsed=0
+any_over_five_minutes="false"
+
+refresh_status() {
+  STILL_RUNNING=()
+  local entry wf run_id url label status conclusion created_at age
+  for entry in "${TRACKED[@]}"; do
+    IFS='|' read -r wf run_id url label <<< "$entry"
+    if [[ "$wf" == *bundle* ]]; then
+      BUNDLE_TRACKED="true"
+    fi
+
+    local line
+    line="$(gh run view "$run_id" --json status,conclusion,url,createdAt --jq '"\(.status)|\(.conclusion // "")|\(.url)|\(.createdAt // "")"' 2>/dev/null || true)"
+    if [ -z "$line" ]; then
+      printf "${WARN}? ${label}: could not fetch run ${run_id}${NC}\n"
+      WATCH_COMMANDS+=("gh run watch ${run_id}  # ${label}")
+      continue
+    fi
+
+    IFS='|' read -r status conclusion url created_at <<< "$line"
+    age="$(gh_workflow_runs_age_seconds "$created_at")"
+
+    case "$status" in
+      completed)
+        if [ "$conclusion" = "success" ]; then
+          printf "${SUCCESS}✓${NC} ${label}: completed successfully\n"
+        else
+          printf "${ERR}✗${NC} ${label}: completed with status ${conclusion}\n"
+        fi
+        printf "    ${INFO}${url}${NC}\n"
+        ;;
+      *)
+        printf "${INFO}…${NC} ${label}: ${status} (run ${run_id})\n"
+        printf "    ${INFO}${url}${NC}\n"
+        STILL_RUNNING+=("$entry")
+        WATCH_COMMANDS+=("gh run watch ${run_id}  # ${label}")
+        if [ "$age" -gt 300 ]; then
+          any_over_five_minutes="true"
+        fi
+        ;;
+    esac
+  done
+}
+
+refresh_status
+
+if [ "${#STILL_RUNNING[@]}" -eq 0 ]; then
+  printf "\n${SUCCESS}All tracked GitHub Actions workflows have finished.${NC}\n"
+else
+  if [ "$any_over_five_minutes" = "true" ]; then
+    printf "\n${WARN}Some workflows have been running for more than 5 minutes; not waiting further.${NC}\n"
+  else
+    printf "\n${INFO}Watching in-progress workflows for up to ${local_max_wait}s ...${NC}\n"
+    while [ "$elapsed" -lt "$local_max_wait" ] && [ "${#STILL_RUNNING[@]}" -gt 0 ]; do
+      sleep 5
+      elapsed=$((elapsed + 5))
+      refresh_status
+    done
+
+    if [ "${#STILL_RUNNING[@]}" -gt 0 ]; then
+      printf "\n${WARN}Some workflows are still running after ${local_max_wait}s.${NC}\n"
+    else
+      printf "\n${SUCCESS}All tracked workflows completed during watch window.${NC}\n"
+    fi
+  fi
+
+  if [ "${#WATCH_COMMANDS[@]}" -gt 0 ]; then
+    printf "\n${INFO}To watch remaining runs interactively:${NC}\n"
+    for cmd in "${WATCH_COMMANDS[@]}"; do
+      printf "  ${CODE}${cmd}${NC}\n"
+    done
+  fi
+fi
+
+if [ "$BUNDLE_TRACKED" = "true" ]; then
+  printf "\n${INFO}Once bundle workflows finish, verify published artifacts:${NC}\n"
+  printf "  ${CODE}./tools/release/verify-bundles.sh ${RELEASE_TAG}${NC}\n"
+fi
+
+printf "\n"

--- a/tools/release/prep.sh
+++ b/tools/release/prep.sh
@@ -14,14 +14,29 @@ NEXT_RELEASE=$2
 
 if [ -z "$CURRENT_RELEASE" ]; then
   printf "${ERR}Current release version not specified. Exiting.${NC}\n"
-  printf "Usage: ${INFO}./tools/check-release.sh <current-release> <next-release>${NC}\n"
+  printf "Usage: ${INFO}./tools/release/prep.sh <current-release> <next-release>${NC}\n"
   exit 1
 fi
 
 if [ -z "$NEXT_RELEASE" ]; then
   printf "${ERR}Next release version not specified. Exiting.${NC}\n"
-  printf "Usage: ${INFO}./tools/check-release.sh <current-release> <next-release>${NC}\n"
+  printf "Usage: ${INFO}./tools/release/prep.sh <current-release> <next-release>${NC}\n"
   exit 1
+fi
+
+if [ "$NEXT_RELEASE" = "rc-NEXT" ] || [ "$NEXT_RELEASE" = "NEXT" ]; then
+  printf "${ERR}Invalid next release '${NEXT_RELEASE}'. Provide an explicit rc branch, e.g. rc-v0.6.5.${NC}\n"
+  exit 1
+fi
+
+if [[ "$NEXT_RELEASE" =~ ^rc- ]]; then
+  if [[ ! "$NEXT_RELEASE" =~ ^rc-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    printf "${ERR}Invalid rc branch name '${NEXT_RELEASE}'. Expected format: rc-vX.Y.Z (e.g. rc-v0.6.5).${NC}\n"
+    exit 1
+  fi
+  IS_RC=1
+else
+  IS_RC=0
 fi
 
 if [ ! -f "java/pom.xml" ]; then
@@ -29,7 +44,6 @@ if [ ! -f "java/pom.xml" ]; then
   exit 1
 fi
 
-IS_RC=$(echo $NEXT_RELEASE | grep -c "rc")
 if [ "$IS_RC" -eq 1 ]; then
   printf "Preparing release candidate ${SUCCESS}${NEXT_RELEASE}${NC} ...\n"
   CURRENT_BRANCH=$(git branch --show-current)
@@ -41,7 +55,6 @@ if [ "$IS_RC" -eq 1 ]; then
   fi
 
   if [ "$CURRENT_BRANCH" != "main" ]; then
-
     printf "${ERR}Current branch is not main. Please checkout main branch and try again to prepare release candidate.${NC}\n"
     exit 1
   fi
@@ -101,14 +114,11 @@ case "$REPLY" in
 esac
 echo "" # newline
 
-git add java/**.java
 git add java/pom.xml
-git add infra/examples/**/main.tf
-git add infra/examples-dev/**/main.tf
-git add infra/examples-dev/**/msft-365.tf
-git add infra/examples-dev/**/google-workspace.tf
-git add infra/modular-examples/**/main.tf
+git add infra/examples-dev/
 git add tools/init-tfvars.sh
+git add -u java/
+git add -u tools/
 
 git status
 

--- a/tools/release/publish-rc-bundles-via-gh.sh
+++ b/tools/release/publish-rc-bundles-via-gh.sh
@@ -1,211 +1,40 @@
 #!/bin/bash
 
-# Publish RC bundles (AWS and GCP) via GitHub Actions workflow_dispatch
+# Publish release bundles (AWS and GCP) via the publish-bundles GitHub Actions workflow.
 # Usage: ./publish-rc-bundles-via-gh.sh [ref]
-#   ref:  Git ref to trigger workflows on (branch, tag, or any git ref; default: current branch)
 #
-# This script triggers both AWS and GCP publish workflows and monitors their execution.
-# The workflows will read the version from pom.xml automatically.
+# Triggers (or reuses) the combined publish-bundles.yaml workflow, which builds AWS + GCP
+# bundles and runs verify-bundles in CI.
 
 set -e
 
-# Colors for output
-COLORSCHEME_SH="$(dirname "$0")/../set-term-colorscheme.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLORSCHEME_SH="${SCRIPT_DIR}/../set-term-colorscheme.sh"
 if [ -f "$COLORSCHEME_SH" ]; then
+    # shellcheck source=/dev/null
     source "$COLORSCHEME_SH"
 else
     ERR='\033[0;31m'; SUCCESS='\033[0;32m'; WARN='\033[1;33m'; INFO='\033[0;34m'; CODE='\033[0;36m'; NC='\033[0m'
 fi
 
-# Workflow file names (gh registers these by path when the workflow YAML is valid)
-AWS_WORKFLOW="publish-aws-bundle.yaml"
-GCP_WORKFLOW="publish-gcp-bundle.yaml"
+# shellcheck source=lib/gh-workflow-runs.sh
+source "${SCRIPT_DIR}/lib/gh-workflow-runs.sh"
 
-# Check if gh CLI is installed
-if ! command -v gh &> /dev/null; then
-    echo -e "${ERR}Error: GitHub CLI (gh) is not installed${NC}"
-    echo -e "${WARN}Install from: https://cli.github.com/${NC}"
-    exit 1
-fi
+BUNDLES_WORKFLOW="publish-bundles.yaml"
 
-# Check if authenticated
-if ! gh auth status &> /dev/null; then
-    echo -e "${ERR}Error: Not authenticated with GitHub CLI${NC}"
-    echo -e "${WARN}Run 'gh auth login' to authenticate${NC}"
-    exit 1
-fi
-
-# Get ref (branch, tag, or any git ref; default to current branch)
 REF="${1:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')}"
 if [ "$REF" = "HEAD" ]; then
-    echo -e "${ERR}Error: Detached HEAD state detected. Please provide a branch, tag, or other git ref.${NC}"
+    printf "${ERR}Error: Detached HEAD state detected. Please provide a branch, tag, or other git ref.${NC}\n"
     exit 1
 fi
 if [ -z "$REF" ]; then
-    echo -e "${WARN}Warning: Could not determine current branch, using 'main'${NC}"
+    printf "${WARN}Warning: Could not determine current branch, using 'main'${NC}\n"
     REF="main"
 fi
 
-echo -e "${INFO}Target ref: ${SUCCESS}${REF}${NC}"
-echo ""
+printf "${INFO}=== Publishing Release Bundles via GitHub Actions ===${NC}\n"
+printf "${INFO}Ref:${NC} ${SUCCESS}${REF}${NC}\n"
+printf "${INFO}Workflow:${NC} ${CODE}${BUNDLES_WORKFLOW}${NC} (AWS + GCP build, then verify)\n\n"
 
-# Function to trigger workflow and get run ID
-trigger_workflow() {
-    local workflow_name="$1"
-    local ref="$2"
-    
-    echo -e "${INFO}Triggering workflow: ${SUCCESS}${workflow_name}${NC}" >&2
-    
-    if ! gh workflow run "$workflow_name" --ref "$ref" >&2; then
-        echo -e "${ERR}Error: 'gh workflow run' failed for ${workflow_name}${NC}" >&2
-        return 1
-    fi
-    
-    # Wait for the workflow to start and get the run ID
-    local run_id=""
-    local max_attempts=10
-    local attempt=0
-    
-    while [ -z "$run_id" ] || [ "$run_id" = "null" ]; do
-        sleep 2
-        attempt=$((attempt + 1))
-        run_id=$(gh run list --workflow="$workflow_name" --limit 1 --json databaseId,status --jq '.[0].databaseId' 2>/dev/null || echo "")
-        
-        if [ $attempt -ge $max_attempts ]; then
-            echo -e "${ERR}Error: Could not get run ID for workflow after ${max_attempts} attempts${NC}" >&2
-            return 1
-        fi
-    done
-    
-    echo "$run_id"
-}
-
-# Function to watch workflow and return exit code
-watch_workflow() {
-    local workflow_name="$1"
-    local run_id="$2"
-    
-    echo -e "${INFO}Watching workflow run: ${SUCCESS}${workflow_name}${NC}"
-    echo -e "${INFO}Run ID: ${SUCCESS}${run_id}${NC}"
-    echo ""
-    
-    # Watch the workflow run
-    if gh run watch "$run_id"; then
-        return 0
-    else
-        return 1
-    fi
-}
-
-# Function to get workflow status
-get_workflow_status() {
-    local workflow_name="$1"
-    local run_id="$2"
-    
-    local status=$(gh run view "$run_id" --json conclusion --jq '.conclusion // "unknown"')
-    echo "$status"
-}
-
-# Function to get workflow URL
-get_workflow_url() {
-    local run_id="$1"
-    local url=$(gh run view "$run_id" --json url --jq '.url')
-    echo "$url"
-}
-
-# Main execution
-echo -e "${INFO}=== Publishing RC Bundles via GitHub Actions ===${NC}"
-echo -e "${INFO}Ref: ${SUCCESS}${REF}${NC}"
-echo ""
-
-# Trigger AWS workflow
-echo -e "${INFO}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${INFO}Step 1/2: AWS Bundle${NC}"
-echo -e "${INFO}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-if ! AWS_RUN_ID=$(trigger_workflow "$AWS_WORKFLOW" "$REF") || [ -z "$AWS_RUN_ID" ]; then
-    echo -e "${ERR}✗ Failed to trigger AWS workflow${NC}"
-    exit 1
-fi
-
-AWS_URL=$(get_workflow_url "$AWS_RUN_ID")
-echo -e "${INFO}Workflow URL: ${SUCCESS}${AWS_URL}${NC}"
-echo ""
-
-# Watch AWS workflow
-if watch_workflow "$AWS_WORKFLOW" "$AWS_RUN_ID"; then
-    AWS_SUCCESS=true
-    echo -e "${SUCCESS}✓ AWS workflow completed successfully${NC}"
-else
-    AWS_SUCCESS=false
-    echo -e "${ERR}✗ AWS workflow failed${NC}"
-fi
-
-echo ""
-echo ""
-
-# Trigger GCP workflow
-echo -e "${INFO}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${INFO}Step 2/2: GCP Bundle${NC}"
-echo -e "${INFO}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-if ! GCP_RUN_ID=$(trigger_workflow "$GCP_WORKFLOW" "$REF") || [ -z "$GCP_RUN_ID" ]; then
-    echo -e "${ERR}✗ Failed to trigger GCP workflow${NC}"
-    exit 1
-fi
-
-GCP_URL=$(get_workflow_url "$GCP_RUN_ID")
-echo -e "${INFO}Workflow URL: ${SUCCESS}${GCP_URL}${NC}"
-echo ""
-
-# Watch GCP workflow
-if watch_workflow "$GCP_WORKFLOW" "$GCP_RUN_ID"; then
-    GCP_SUCCESS=true
-    echo -e "${SUCCESS}✓ GCP workflow completed successfully${NC}"
-else
-    GCP_SUCCESS=false
-    echo -e "${ERR}✗ GCP workflow failed${NC}"
-fi
-
-echo ""
-echo ""
-
-# Summary
-echo -e "${INFO}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${INFO}=== Summary ===${NC}"
-echo -e "${INFO}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
-
-# Get final statuses
-AWS_STATUS=$(get_workflow_status "$AWS_WORKFLOW" "$AWS_RUN_ID")
-GCP_STATUS=$(get_workflow_status "$GCP_WORKFLOW" "$GCP_RUN_ID")
-
-# AWS status
-if [ "$AWS_SUCCESS" = true ]; then
-    echo -e "${SUCCESS}✓ AWS Bundle:${NC} SUCCESS"
-else
-    echo -e "${ERR}✗ AWS Bundle:${NC} FAILED (Status: ${AWS_STATUS})"
-fi
-echo -e "   URL: ${AWS_URL}"
-echo ""
-
-# GCP status
-if [ "$GCP_SUCCESS" = true ]; then
-    echo -e "${SUCCESS}✓ GCP Bundle:${NC} SUCCESS"
-else
-    echo -e "${ERR}✗ GCP Bundle:${NC} FAILED (Status: ${GCP_STATUS})"
-fi
-echo -e "   URL: ${GCP_URL}"
-echo ""
-
-# Overall result
-if [ "$AWS_SUCCESS" = true ] && [ "$GCP_SUCCESS" = true ]; then
-    echo -e "${SUCCESS}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${SUCCESS}✓ All workflows completed successfully!${NC}"
-    echo -e "${SUCCESS}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    exit 0
-else
-    echo -e "${ERR}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${ERR}✗ Some workflows failed${NC}"
-    echo -e "${ERR}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    exit 1
-fi
-
+line="$(gh_workflow_runs_trigger_or_use_existing "$BUNDLES_WORKFLOW" "$REF" "Release bundles (AWS + GCP)")" || exit 1
+printf '%s\n' "$line"

--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -101,27 +101,11 @@ RELEASE_GH_RUNS=()
 MVN_WORKFLOW="publish-release-artifacts.yaml"
 BUNDLES_WORKFLOW="publish-bundles.yaml"
 
-printf "\n${INFO}Pushing ${RELEASE} triggers GitHub Actions for Maven packages and release bundles.${NC}\n"
-printf "${INFO}These run in CI (not locally). Waiting a few seconds for workflow runs to register ...${NC}\n"
+printf "\n${INFO}Tag push also triggers GitHub Actions for Maven packages and release bundles.${NC}\n"
+printf "${INFO}Checking workflow status via gh ...${NC}\n"
 sleep 3
-
-auto_track_tag_workflow_run() {
-  local workflow_file="$1"
-  local label="$2"
-  local line run_id status url
-
-  line="$(gh_workflow_runs_find_latest "$workflow_file" "$RELEASE")"
-  [ -z "$line" ] && return 0
-  IFS='|' read -r run_id status _ url _ <<< "$line"
-  [ -z "$run_id" ] || [ "$run_id" = "null" ] && return 0
-
-  printf "${SUCCESS}✓${NC} Found ${label} GitHub Actions run ${SUCCESS}${run_id}${NC} (${status})\n"
-  printf "  ${INFO}${url}${NC}\n"
-  gh_workflow_runs_track "$workflow_file" "$run_id" "$url" "$label"
-}
-
-auto_track_tag_workflow_run "$MVN_WORKFLOW" "Maven packages (GitHub Packages)"
-auto_track_tag_workflow_run "$BUNDLES_WORKFLOW" "Release bundles (AWS + GCP)"
+gh_workflow_runs_report_status "$MVN_WORKFLOW" "$RELEASE" "Maven packages (GitHub Packages)"
+gh_workflow_runs_report_status "$BUNDLES_WORKFLOW" "$RELEASE" "Release bundles (AWS + GCP)"
 printf "\n"
 
 if gh release view $RELEASE >/dev/null 2>&1
@@ -159,46 +143,71 @@ fi
 printf "Opening release ${INFO}${RELEASE}${NC} in browser; review / update notes and then publish as latest ...\n"
 gh release view $RELEASE --web
 
-# prompt user to publish mvn artifacts via GitHub Actions
-printf "Publish Maven artifacts to GitHub Packages via GitHub Actions (${MVN_WORKFLOW})?\n"
+# Maven artifacts — report GH status again in case it changed, then offer local publish
+printf "Publish Maven artifacts to GitHub Packages locally?\n"
+gh_workflow_runs_report_status "$MVN_WORKFLOW" "$RELEASE" "Maven packages (GitHub Packages)"
 read -p "(Y/n) " -n 1 -r
 REPLY=${REPLY:-Y}
 echo    # Move to a new line
 case "$REPLY" in
   [yY][eE][sS]|[yY])
-    if gh_workflow_runs_trigger_and_track "$MVN_WORKFLOW" "$RELEASE" "Maven packages (GitHub Packages)"; then
-      :
+    LOG_FILE="/tmp/release_${RELEASE}_mvn-artifacts.log"
+    set +e
+    ./tools/release/publish-mvn-artifacts.sh "${PATH_TO_REPO}" &> "${LOG_FILE}"
+    EXIT_CODE=$?
+    set -e
+    if [ $EXIT_CODE -ne 0 ]; then
+      printf "${ERR}Failed to publish Maven artifacts locally.${NC}\n"
+      printf "Review logs: ${INFO}cat ${LOG_FILE}${NC}\n"
+      printf "Or use GitHub Actions: ${INFO}gh workflow run ${MVN_WORKFLOW} --ref ${RELEASE}${NC}\n"
+      exit $EXIT_CODE
     else
-      printf "${WARN}Could not confirm Maven workflow run. Trigger manually:${NC}\n"
-      printf "    ${INFO}gh workflow run ${MVN_WORKFLOW} --ref ${RELEASE}${NC}\n"
+      printf "${SUCCESS}✓${NC} Maven artifacts published locally\n"
+      printf "See logs: ${INFO}cat ${LOG_FILE}${NC}\n"
     fi
   ;;
   *)
-    printf "Skipped triggering Maven packages workflow\n"
-    printf "Tag push may already have started it. To trigger manually:\n"
-    printf "    ${INFO}gh workflow run ${MVN_WORKFLOW} --ref ${RELEASE}${NC}\n"
+    printf "Skipped local Maven publish\n"
+    printf "GitHub Actions equivalent: ${INFO}gh workflow run ${MVN_WORKFLOW} --ref ${RELEASE}${NC}\n"
     ;;
 esac
 
-# publish bundles via GitHub Actions
-printf "Publish release bundles (AWS + GCP) via GitHub Actions (${BUNDLES_WORKFLOW})?\n"
+# Bundles — report GH status, then offer local AWS + GCP publish
+printf "Publish release bundles locally (AWS + GCP)?\n"
+gh_workflow_runs_report_status "$BUNDLES_WORKFLOW" "$RELEASE" "Release bundles (AWS + GCP)"
 read -p "(Y/n) " -n 1 -r
 REPLY=${REPLY:-Y}
 echo    # Move to a new line
 case "$REPLY" in
   [yY][eE][sS]|[yY])
-    if line="$(./tools/release/publish-rc-bundles-via-gh.sh ${RELEASE})"; then
-      IFS='|' read -r wf run_id url _triggered <<< "$line"
-      gh_workflow_runs_track "$wf" "$run_id" "$url" "Release bundles (AWS + GCP)"
+    BUNDLE_LOG="/tmp/release_${RELEASE}_bundles.log"
+    : > "${BUNDLE_LOG}"
+    set +e
+    (
+      cd "${PATH_TO_REPO}"
+      ./tools/release/lib/publish-aws-bundle.sh
+      AWS_EXIT=$?
+      ./tools/release/lib/publish-gcp-bundle.sh
+      GCP_EXIT=$?
+      exit $((AWS_EXIT || GCP_EXIT))
+    ) >> "${BUNDLE_LOG}" 2>&1
+    EXIT_CODE=$?
+    set -e
+    if [ $EXIT_CODE -ne 0 ]; then
+      printf "${ERR}Failed to publish bundles locally.${NC}\n"
+      printf "Review logs: ${INFO}cat ${BUNDLE_LOG}${NC}\n"
+      printf "Or use GitHub Actions: ${INFO}gh workflow run ${BUNDLES_WORKFLOW} --ref ${RELEASE}${NC}\n"
+      exit $EXIT_CODE
     else
-      printf "${WARN}Could not confirm bundle workflow run. Trigger manually:${NC}\n"
-      printf "    ${INFO}gh workflow run ${BUNDLES_WORKFLOW} --ref ${RELEASE}${NC}\n"
+      printf "${SUCCESS}✓${NC} AWS and GCP bundles published locally\n"
+      printf "See logs: ${INFO}cat ${BUNDLE_LOG}${NC}\n"
     fi
   ;;
   *)
-    printf "Skipped triggering release bundles workflow\n"
-    printf "Tag push may already have started it. To trigger manually:\n"
-    printf "    ${INFO}gh workflow run ${BUNDLES_WORKFLOW} --ref ${RELEASE}${NC}\n"
+    printf "Skipped local bundle publish\n"
+    printf "GitHub Actions equivalent: ${INFO}gh workflow run ${BUNDLES_WORKFLOW} --ref ${RELEASE}${NC}\n"
+    printf "Or trigger individually: ${INFO}gh workflow run publish-aws-bundle.yaml --ref ${RELEASE}${NC}\n"
+    printf "                       ${INFO}gh workflow run publish-gcp-bundle.yaml --ref ${RELEASE}${NC}\n"
     ;;
 esac
 

--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -93,6 +93,37 @@ fi
 printf "Pushing tag ${SUCCESS}$RELEASE${NC} to origin ...\n"
 git push origin $RELEASE
 
+GH_RUNS_LIB="$(dirname "$0")/lib/gh-workflow-runs.sh"
+# shellcheck source=lib/gh-workflow-runs.sh
+source "$GH_RUNS_LIB"
+RELEASE_GH_RUNS=()
+
+MVN_WORKFLOW="publish-release-artifacts.yaml"
+BUNDLES_WORKFLOW="publish-bundles.yaml"
+
+printf "\n${INFO}Pushing ${RELEASE} triggers GitHub Actions for Maven packages and release bundles.${NC}\n"
+printf "${INFO}These run in CI (not locally). Waiting a few seconds for workflow runs to register ...${NC}\n"
+sleep 3
+
+auto_track_tag_workflow_run() {
+  local workflow_file="$1"
+  local label="$2"
+  local line run_id status url
+
+  line="$(gh_workflow_runs_find_latest "$workflow_file" "$RELEASE")"
+  [ -z "$line" ] && return 0
+  IFS='|' read -r run_id status _ url _ <<< "$line"
+  [ -z "$run_id" ] || [ "$run_id" = "null" ] && return 0
+
+  printf "${SUCCESS}✓${NC} Found ${label} GitHub Actions run ${SUCCESS}${run_id}${NC} (${status})\n"
+  printf "  ${INFO}${url}${NC}\n"
+  gh_workflow_runs_track "$workflow_file" "$run_id" "$url" "$label"
+}
+
+auto_track_tag_workflow_run "$MVN_WORKFLOW" "Maven packages (GitHub Packages)"
+auto_track_tag_workflow_run "$BUNDLES_WORKFLOW" "Release bundles (AWS + GCP)"
+printf "\n"
+
 if gh release view $RELEASE >/dev/null 2>&1
 then
   printf "Release ${SUCCESS}$RELEASE${NC} already exists.\n"
@@ -128,48 +159,46 @@ fi
 printf "Opening release ${INFO}${RELEASE}${NC} in browser; review / update notes and then publish as latest ...\n"
 gh release view $RELEASE --web
 
-# prompt user to publish mvn artifacts
-printf "Publish Maven artifacts to GitHub Packages?\n"
+# prompt user to publish mvn artifacts via GitHub Actions
+printf "Publish Maven artifacts to GitHub Packages via GitHub Actions (${MVN_WORKFLOW})?\n"
 read -p "(Y/n) " -n 1 -r
 REPLY=${REPLY:-Y}
 echo    # Move to a new line
 case "$REPLY" in
   [yY][eE][sS]|[yY])
-    LOG_FILE="/tmp/release_${RELEASE}_mvn-artifacts.log"
-    set +e  # Temporarily disable exit on error to check exit code
-    ./tools/release/publish-mvn-artifacts.sh ${PATH_TO_REPO} &> "${LOG_FILE}"
-    EXIT_CODE=$?
-    set -e  # Re-enable exit on error
-    if [ $EXIT_CODE -ne 0 ]; then
-      printf "${ERR}Failed to publish Maven artifacts to GitHub Packages.${NC}\n"
-      printf "Please review the error logs: ${INFO}cat ${LOG_FILE}${NC}\n"
-      exit $EXIT_CODE
+    if gh_workflow_runs_trigger_and_track "$MVN_WORKFLOW" "$RELEASE" "Maven packages (GitHub Packages)"; then
+      :
     else
-      printf "${SUCCESS}✓${NC} Maven artifacts published to GitHub Packages\n"
-      printf "See logs: ${INFO}cat ${LOG_FILE}${NC}\n"
+      printf "${WARN}Could not confirm Maven workflow run. Trigger manually:${NC}\n"
+      printf "    ${INFO}gh workflow run ${MVN_WORKFLOW} --ref ${RELEASE}${NC}\n"
     fi
   ;;
   *)
-    printf "Skipped publishing Maven artifacts to GitHub Packages\n"
-    printf "To do so manually, run:\n"
-    printf "    ${INFO}./tools/release/publish-mvn-artifacts.sh ${PATH_TO_REPO}${NC}\n"
-    printf "    or run the GitHub Actions workflow manually: ${INFO}gh workflow run publish-release-artifacts.yaml --ref ${RELEASE}${NC}\n"
+    printf "Skipped triggering Maven packages workflow\n"
+    printf "Tag push may already have started it. To trigger manually:\n"
+    printf "    ${INFO}gh workflow run ${MVN_WORKFLOW} --ref ${RELEASE}${NC}\n"
     ;;
 esac
 
-# publish bundles
-printf "Publish bundles (via GitHub Actions)?\n"
+# publish bundles via GitHub Actions
+printf "Publish release bundles (AWS + GCP) via GitHub Actions (${BUNDLES_WORKFLOW})?\n"
 read -p "(Y/n) " -n 1 -r
 REPLY=${REPLY:-Y}
 echo    # Move to a new line
 case "$REPLY" in
   [yY][eE][sS]|[yY])
-    ./tools/release/publish-rc-bundles-via-gh.sh ${RELEASE}
+    if line="$(./tools/release/publish-rc-bundles-via-gh.sh ${RELEASE})"; then
+      IFS='|' read -r wf run_id url _triggered <<< "$line"
+      gh_workflow_runs_track "$wf" "$run_id" "$url" "Release bundles (AWS + GCP)"
+    else
+      printf "${WARN}Could not confirm bundle workflow run. Trigger manually:${NC}\n"
+      printf "    ${INFO}gh workflow run ${BUNDLES_WORKFLOW} --ref ${RELEASE}${NC}\n"
+    fi
   ;;
   *)
-    printf "Skipped publishing bundles (via GitHub Actions)\n"
-    printf "To do so manually, run:\n"
-    printf "    ${INFO}./tools/release/publish-rc-bundles-via-gh.sh ${RELEASE}${NC}\n"
+    printf "Skipped triggering release bundles workflow\n"
+    printf "Tag push may already have started it. To trigger manually:\n"
+    printf "    ${INFO}gh workflow run ${BUNDLES_WORKFLOW} --ref ${RELEASE}${NC}\n"
     ;;
 esac
 
@@ -204,14 +233,29 @@ REPLY=${REPLY:-Y}
 echo    # Move to a new line
 case "$REPLY" in
   [yY][eE][sS]|[yY])
-    ./tools/release/prep.sh ${RELEASE} rc-NEXT
+    printf "Next release version number (e.g. ${INFO}0.6.5${NC}): "
+    read -r NEXT_VERSION_NUMBER
+    NEXT_VERSION_NUMBER="${NEXT_VERSION_NUMBER#v}"
+    if [[ ! "$NEXT_VERSION_NUMBER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      printf "${ERR}Invalid version '${NEXT_VERSION_NUMBER}'. Expected format X.Y.Z (e.g. 0.6.5). Skipping rc prep.${NC}\n"
+    else
+      NEXT_RC="rc-v${NEXT_VERSION_NUMBER}"
+      ./tools/release/prep.sh ${RELEASE} "${NEXT_RC}"
+    fi
   ;;
   *)
     printf "Skipped prepping next rc\n"
     printf "To do so manually, run:\n"
-    printf "    ${INFO}./tools/release/prep.sh ${RELEASE} rc-NEXT${NC}\n"
+    printf "    ${INFO}./tools/release/prep.sh ${RELEASE} rc-v<next-version>${NC}\n"
     ;;
 esac
+
+# Watch GitHub Actions release workflows (last step)
+if [ "${#RELEASE_GH_RUNS[@]}" -gt 0 ]; then
+  WATCH_RUNS_SH="$(dirname "$0")/lib/watch-gh-runs.sh"
+  chmod +x "$WATCH_RUNS_SH" 2>/dev/null || true
+  "$WATCH_RUNS_SH" "$RELEASE" "${RELEASE_GH_RUNS[@]}"
+fi
 
 printf "Next steps: \n"
 printf "  1. update example templates to point to it:\n"


### PR DESCRIPTION

### Fixes
 - `publish.sh` no longer passes `rc-NEXT` to `prep.sh`; prompts for an explicit next version number instead
 - `prep.sh` rejects invalid rc branch names and fixes `git add` paths for non-existent example directories
 - removed unnecessary `chmod +x` and `jq` install steps from bundle publish workflows

### Features
 - `publish.sh` triggers Maven packages and release bundles via GitHub Actions with `gh` status feedback and a final watch step
 -  New `publish-bundles.yaml` parent workflow orchestrates AWS + GCP bundle publish and runs `verify-bundles.sh`
 - Shared helpers: `gh-workflow-runs.sh`, `watch-gh-runs.sh`, `deployment-bundle-release-notes-block.sh`
 - verify-bundles.sh` prints remediation commands when compiled stub classes are detected in published bundles

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - Release publish flow now expects Maven artifacts and deployment bundles to be built in GitHub Actions rather than locally during `./tools/release/publish.sh`

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215614135400865