### PR TITLE
Add headers to example API requests for connector test calls

### DIFF
--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -228,25 +228,8 @@ output "api_connector_instances" {
   value = { for k, v in module.psoxy.api_connector_instances : k => {
     endpoint_url     = v.endpoint_url
     sanitized_bucket = v.sanitized_bucket
-    test_examples = merge({
-      api_requests = concat(
-        [for path in try(v.example_api_calls, []) : "GET ${path}"],
-        [for req in try(v.example_api_requests, []) : merge(
-          {
-            request = "${try(req.method, "GET")} ${req.path}"
-          },
-          try(req.method, "GET") == "POST" || try(req.method, "GET") == "PUT" ? merge(
-            try(req.content_type, null) != null ? { content_type = req.content_type } : {},
-            try(req.body, null) != null ? { body = req.body } : {}
-          ) : {},
-          length(try(req.headers, {})) > 0 ? { headers = req.headers } : {}
-        )]
-      )
-      },
-      try(v.enable_async_processing, false) ? { supports_async = true } : {},
-      try(v.example_api_calls_user_to_impersonate, null) != null ? { user_to_impersonate = try(v.example_api_calls_user_to_impersonate, null) } : {}
-    ) }
-  }
+    test_examples    = v.test_examples
+  } }
 }
 
 output "bulk_connector_instances" {

--- a/infra/examples-dev/aws/main.tf
+++ b/infra/examples-dev/aws/main.tf
@@ -238,7 +238,8 @@ output "api_connector_instances" {
           try(req.method, "GET") == "POST" || try(req.method, "GET") == "PUT" ? merge(
             try(req.content_type, null) != null ? { content_type = req.content_type } : {},
             try(req.body, null) != null ? { body = req.body } : {}
-          ) : {}
+          ) : {},
+          length(try(req.headers, {})) > 0 ? { headers = req.headers } : {}
         )]
       )
       },

--- a/infra/examples-dev/aws/variables.tf
+++ b/infra/examples-dev/aws/variables.tf
@@ -265,6 +265,7 @@ variable "custom_api_connectors" {
       path         = string
       content_type = optional(string, "application/json")
       body         = optional(string, null)
+      headers      = optional(map(string), {})
     })), [])
     example_api_calls_user_to_impersonate = optional(string)
     secured_variables = optional(list(object({

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -205,25 +205,8 @@ output "api_connector_instances" {
     }, v.sanitized_bucket != null ? {
     sanitized_bucket = v.sanitized_bucket
     } : {}, {
-    test_examples = merge({
-      api_requests = concat(
-        [for path in try(v.example_api_calls, []) : "GET ${path}"],
-        [for req in try(v.example_api_requests, []) : merge(
-          {
-            request = "${try(req.method, "GET")} ${req.path}"
-          },
-          try(req.method, "GET") == "POST" || try(req.method, "GET") == "PUT" ? merge(
-            try(req.content_type, null) != null ? { content_type = req.content_type } : {},
-            try(req.body, null) != null ? { body = req.body } : {}
-          ) : {},
-          length(try(req.headers, {})) > 0 ? { headers = req.headers } : {}
-        )]
-      )
-      },
-      try(v.enable_async_processing, false) ? { supports_async = true } : {},
-      try(v.example_api_calls_user_to_impersonate, null) != null ? { user_to_impersonate = try(v.example_api_calls_user_to_impersonate, null) } : {}
-    ) }
-  ) }
+    test_examples = v.test_examples
+  }) }
 }
 
 output "bulk_connector_instances" {

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -215,7 +215,8 @@ output "api_connector_instances" {
           try(req.method, "GET") == "POST" || try(req.method, "GET") == "PUT" ? merge(
             try(req.content_type, null) != null ? { content_type = req.content_type } : {},
             try(req.body, null) != null ? { body = req.body } : {}
-          ) : {}
+          ) : {},
+          length(try(req.headers, {})) > 0 ? { headers = req.headers } : {}
         )]
       )
       },

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -260,6 +260,7 @@ variable "custom_api_connectors" {
       path         = string
       content_type = optional(string, "application/json")
       body         = optional(string, null)
+      headers      = optional(map(string), {})
     })), [])
     example_api_calls_user_to_impersonate = optional(string)
     secured_variables = optional(list(object({

--- a/infra/modules/aws-host/main.tf
+++ b/infra/modules/aws-host/main.tf
@@ -632,10 +632,34 @@ resource "aws_iam_role_policy_attachment" "lookup_bucket_read" {
 }
 
 locals {
+  api_connector_test_examples = { for k, connector in var.api_connectors : k => merge(
+    {
+      api_requests = concat(
+        [for path in try(connector.example_api_calls, []) : {
+          method       = "GET"
+          path         = path
+          content_type = null
+          body         = null
+          headers      = {}
+        }],
+        [for req in try(connector.example_api_requests, []) : {
+          method       = try(req.method, "GET")
+          path         = req.path
+          content_type = try(req.content_type, null)
+          body         = try(req.body, null)
+          headers      = try(req.headers, {})
+        }]
+      )
+    },
+    try(connector.enable_async_processing, false) ? { supports_async = true } : {},
+    try(connector.example_api_calls_user_to_impersonate, null) != null ? { user_to_impersonate = connector.example_api_calls_user_to_impersonate } : {}
+  ) }
+
   api_instances = { for k, instance in module.api_connector :
     k => merge(
       {
-        sanitized_bucket : try(instance.async_output_bucket_id, null),
+        sanitized_bucket = try(instance.async_output_bucket_id, null),
+        test_examples    = local.api_connector_test_examples[k],
       },
       instance,
       var.api_connectors[k]

--- a/infra/modules/aws-host/variables.tf
+++ b/infra/modules/aws-host/variables.tf
@@ -203,6 +203,7 @@ variable "api_connectors" {
       path         = string
       content_type = optional(string, "application/json")
       body         = optional(string, null)
+      headers      = optional(map(string), {})
     })), [])
     example_api_calls_user_to_impersonate = optional(string)
     secured_variables = optional(list(object({

--- a/infra/modules/aws-proxy-api/main.tf
+++ b/infra/modules/aws-proxy-api/main.tf
@@ -341,7 +341,15 @@ locals {
     "${request.method} ${request.path}" => join("", [for name, value in try(request.headers, {}) : " -H \"${name}: ${value}\""])
   }
 
-  default_get_request_header_flags = length(local.example_api_get_requests) > 0 ? local.example_request_header_flags["${local.example_api_get_requests[0].method} ${local.example_api_get_requests[0].path}"] : ""
+  example_api_get_requests_for_script = [for r in local.example_api_get_requests : merge(r, {
+    header_flags = trimspace(lookup(local.example_request_header_flags, "${r.method} ${r.path}", ""))
+  })]
+
+  example_api_post_requests_for_script = [for r in local.all_example_api_requests : merge(r, {
+    header_flags = trimspace(lookup(local.example_request_header_flags, "${r.method} ${r.path}", ""))
+  }) if r.method == "POST" && r.body != null]
+
+  default_header_flags = length(local.example_api_get_requests_for_script) > 0 ? local.example_api_get_requests_for_script[0].header_flags : ""
 
   # Generate test calls from all example requests
   sync_test_calls = [for request in local.all_example_api_requests :
@@ -433,14 +441,14 @@ resource "local_file" "todo" {
 
 locals {
   test_script = templatefile("${path.module}/test_script.tftpl", {
-    proxy_endpoint_url               = local.proxy_endpoint_url,
-    function_name                    = module.psoxy_lambda.function_name,
-    impersonation_param              = local.impersonation_param,
-    command_cli_call                 = local.command_cli_call,
-    default_get_request_header_flags = local.default_get_request_header_flags,
-    example_api_get_requests         = local.example_api_get_requests,
-    example_api_post_requests        = [for r in local.all_example_api_requests : r if r.method == "POST" && r.body != null], # body being null will blow up the templating
-    enable_async_processing          = var.enable_async_processing,
+    proxy_endpoint_url        = local.proxy_endpoint_url,
+    function_name             = module.psoxy_lambda.function_name,
+    impersonation_param       = local.impersonation_param,
+    command_cli_call          = local.command_cli_call,
+    default_header_flags      = local.default_header_flags,
+    example_api_get_requests  = local.example_api_get_requests_for_script,
+    example_api_post_requests = local.example_api_post_requests_for_script,
+    enable_async_processing   = var.enable_async_processing,
   })
 }
 

--- a/infra/modules/aws-proxy-api/main.tf
+++ b/infra/modules/aws-proxy-api/main.tf
@@ -335,9 +335,17 @@ locals {
     var.example_api_requests
   )
 
+  example_api_get_requests = [for r in local.all_example_api_requests : r if r.method == "GET"]
+
+  example_request_header_flags = { for request in local.all_example_api_requests :
+    "${request.method} ${request.path}" => join("", [for name, value in try(request.headers, {}) : " -H \"${name}: ${value}\""])
+  }
+
+  default_get_request_header_flags = length(local.example_api_get_requests) > 0 ? local.example_request_header_flags["${local.example_api_get_requests[0].method} ${local.example_api_get_requests[0].path}"] : ""
+
   # Generate test calls from all example requests
   sync_test_calls = [for request in local.all_example_api_requests :
-    "${local.command_cli_call} -u \"${local.proxy_endpoint_url}${request.path}\" -m ${request.method}${request.body != null ? " -b \"${request.body}\"" : ""}${local.impersonation_param}"
+    "${local.command_cli_call} -u \"${local.proxy_endpoint_url}${request.path}\" -m ${request.method}${request.body != null ? " -b \"${request.body}\"" : ""}${local.example_request_header_flags["${request.method} ${request.path}"]}${local.impersonation_param}"
   ]
 
   command_test_calls = concat(local.sync_test_calls,
@@ -425,13 +433,14 @@ resource "local_file" "todo" {
 
 locals {
   test_script = templatefile("${path.module}/test_script.tftpl", {
-    proxy_endpoint_url        = local.proxy_endpoint_url,
-    function_name             = module.psoxy_lambda.function_name,
-    impersonation_param       = local.impersonation_param,
-    command_cli_call          = local.command_cli_call,
-    example_api_get_requests  = [for r in local.all_example_api_requests : r if r.method == "GET"],
-    example_api_post_requests = [for r in local.all_example_api_requests : r if r.method == "POST" && r.body != null], # body being null will blow up the templating
-    enable_async_processing   = var.enable_async_processing,
+    proxy_endpoint_url               = local.proxy_endpoint_url,
+    function_name                    = module.psoxy_lambda.function_name,
+    impersonation_param              = local.impersonation_param,
+    command_cli_call                 = local.command_cli_call,
+    default_get_request_header_flags = local.default_get_request_header_flags,
+    example_api_get_requests         = local.example_api_get_requests,
+    example_api_post_requests        = [for r in local.all_example_api_requests : r if r.method == "POST" && r.body != null], # body being null will blow up the templating
+    enable_async_processing          = var.enable_async_processing,
   })
 }
 

--- a/infra/modules/aws-proxy-api/test_script.tftpl
+++ b/infra/modules/aws-proxy-api/test_script.tftpl
@@ -4,6 +4,7 @@ METHOD=$${1:-"GET"}
 API_PATH=$${2:-${try(example_api_get_requests[0].path, "")}}
 CONTENT_TYPE=$${3:-""}
 BODY=$${4:-""}
+HEADER_FLAGS=$${5:-'${replace(default_header_flags, "'", "'\\''")}'}
 
 echo "Quick test of ${function_name} ..."
 
@@ -13,11 +14,11 @@ export NODE_OPTIONS="$${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
 ${command_cli_call} -u "${proxy_endpoint_url}/" --health-check
 HEALTHCHECK_RC=$?
 
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags}
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY" $HEADER_FLAGS
 SYNC_CALL_RC=$?
 
 %{ if enable_async_processing ~}
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags} --async
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY" $HEADER_FLAGS --async
 ASYNC_CALL_RC=$?
 %{ else ~}
 ASYNC_CALL_RC=0
@@ -26,10 +27,10 @@ ASYNC_CALL_RC=0
 echo "Invoke this script with any of the following as arguments to test other endpoints:"
 
 %{ for example_api_get_request in example_api_get_requests ~}
-    printf "\t%s\n" "${example_api_get_request.method} '${example_api_get_request.path}'"
+    printf "\t%s\n" "${example_api_get_request.method} '${example_api_get_request.path}' '' '' '${replace(example_api_get_request.header_flags, "'", "'\\''")}'"
 %{ endfor ~}
 %{ for example_api_post_request in example_api_post_requests ~}
-    printf "\t%s\n" "${example_api_post_request.method} '${example_api_post_request.path}' ${example_api_post_request.content_type} '${replace(example_api_post_request.body, "\"", "\\\"")}'"
+    printf "\t%s\n" "${example_api_post_request.method} '${example_api_post_request.path}' ${example_api_post_request.content_type} '${replace(example_api_post_request.body, "\"", "\\\"")}' '${replace(example_api_post_request.header_flags, "'", "'\\''")}'"
 %{ endfor ~}
 
 exit $(( HEALTHCHECK_RC + SYNC_CALL_RC + ASYNC_CALL_RC ))

--- a/infra/modules/aws-proxy-api/test_script.tftpl
+++ b/infra/modules/aws-proxy-api/test_script.tftpl
@@ -13,11 +13,11 @@ export NODE_OPTIONS="$${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
 ${command_cli_call} -u "${proxy_endpoint_url}/" --health-check
 HEALTHCHECK_RC=$?
 
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags}
 SYNC_CALL_RC=$?
 
 %{ if enable_async_processing ~}
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY" --async
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags} --async
 ASYNC_CALL_RC=$?
 %{ else ~}
 ASYNC_CALL_RC=0

--- a/infra/modules/aws-proxy-api/variables.tf
+++ b/infra/modules/aws-proxy-api/variables.tf
@@ -150,8 +150,9 @@ variable "example_api_requests" {
     path         = string
     content_type = optional(string, "application/json")
     body         = optional(string, null)
+    headers      = optional(map(string), {})
   }))
-  description = "example API requests with method, content_type and body parameters that can be called via proxy"
+  description = "example API requests with method, content_type, body, and headers parameters that can be called via proxy"
   default     = []
 }
 

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -545,11 +545,35 @@ resource "google_secret_manager_secret_iam_member" "additional_transforms" {
 # END LOOKUP TABLES
 
 locals {
+  api_connector_test_examples = { for k, connector in var.api_connectors : k => merge(
+    {
+      api_requests = concat(
+        [for path in try(connector.example_api_calls, []) : {
+          method       = "GET"
+          path         = path
+          content_type = null
+          body         = null
+          headers      = {}
+        }],
+        [for req in try(connector.example_api_requests, []) : {
+          method       = try(req.method, "GET")
+          path         = req.path
+          content_type = try(req.content_type, null)
+          body         = try(req.body, null)
+          headers      = try(req.headers, {})
+        }]
+      )
+    },
+    try(connector.enable_async_processing, false) ? { supports_async = true } : {},
+    try(connector.example_api_calls_user_to_impersonate, null) != null ? { user_to_impersonate = connector.example_api_calls_user_to_impersonate } : {}
+  ) }
+
   api_instances = { for instance in module.api_connector :
     instance.instance_id => merge(
       {
-        endpoint_url : instance.cloud_function_url,
-        sanitized_bucket : try(instance.async_output_bucket_name, null),
+        endpoint_url     = instance.cloud_function_url,
+        sanitized_bucket   = try(instance.async_output_bucket_name, null),
+        test_examples      = local.api_connector_test_examples[instance.instance_id],
       },
       instance,
       var.api_connectors[instance.instance_id]

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -199,6 +199,7 @@ variable "api_connectors" {
       path         = string
       content_type = optional(string, "application/json")
       body         = optional(string, null)
+      headers      = optional(map(string), {})
     })), [])
     example_api_calls_user_to_impersonate = optional(string)
     secured_variables = optional(list(object({

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -397,9 +397,17 @@ locals {
     var.example_api_requests
   )
 
+  example_api_get_requests = [for r in local.all_example_api_requests : r if r.method == "GET"]
+
+  example_request_header_flags = { for request in local.all_example_api_requests :
+    "${request.method} ${request.path}" => join("", [for name, value in try(request.headers, {}) : " -H \"${name}: ${value}\""])
+  }
+
+  default_get_request_header_flags = length(local.example_api_get_requests) > 0 ? local.example_request_header_flags["${local.example_api_get_requests[0].method} ${local.example_api_get_requests[0].path}"] : ""
+
   # Generate test calls from all example requests
   command_test_calls = [for request in local.all_example_api_requests :
-    "${local.command_cli_call} -u \"${local.proxy_endpoint_url}${request.path}\" -m ${request.method}${request.body != null ? " -b \"${request.body}\"" : ""}${local.impersonation_param}"
+    "${local.command_cli_call} -u \"${local.proxy_endpoint_url}${request.path}\" -m ${request.method}${request.body != null ? " -b \"${request.body}\"" : ""}${local.example_request_header_flags["${request.method} ${request.path}"]}${local.impersonation_param}"
   ]
   command_test_logs = "node ${var.path_to_repo_root}tools/psoxy-test/cli-logs.js -p \"${google_cloudfunctions2_function.function.project}\" -f \"${google_cloudfunctions2_function.function.name}\""
 }
@@ -461,13 +469,14 @@ resource "local_file" "test_script" {
   filename        = "test-${trimprefix(var.instance_id, var.environment_id_prefix)}.sh"
   file_permission = "755"
   content = templatefile("${path.module}/test_script.tftpl", {
-    proxy_endpoint_url        = local.proxy_endpoint_url,
-    function_name             = var.instance_id,
-    impersonation_param       = local.impersonation_param,
-    command_cli_call          = local.command_cli_call,
-    example_api_get_requests  = [for r in local.all_example_api_requests : r if r.method == "GET"],
-    example_api_post_requests = [for r in local.all_example_api_requests : r if r.method == "POST" && r.body != null], # body being null will blow up the templating
-    enable_async_processing   = var.enable_async_processing
+    proxy_endpoint_url               = local.proxy_endpoint_url,
+    function_name                    = var.instance_id,
+    impersonation_param              = local.impersonation_param,
+    command_cli_call                 = local.command_cli_call,
+    default_get_request_header_flags = local.default_get_request_header_flags,
+    example_api_get_requests         = local.example_api_get_requests,
+    example_api_post_requests        = [for r in local.all_example_api_requests : r if r.method == "POST" && r.body != null], # body being null will blow up the templating
+    enable_async_processing          = var.enable_async_processing
   })
 }
 

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -403,7 +403,15 @@ locals {
     "${request.method} ${request.path}" => join("", [for name, value in try(request.headers, {}) : " -H \"${name}: ${value}\""])
   }
 
-  default_get_request_header_flags = length(local.example_api_get_requests) > 0 ? local.example_request_header_flags["${local.example_api_get_requests[0].method} ${local.example_api_get_requests[0].path}"] : ""
+  example_api_get_requests_for_script = [for r in local.example_api_get_requests : merge(r, {
+    header_flags = trimspace(lookup(local.example_request_header_flags, "${r.method} ${r.path}", ""))
+  })]
+
+  example_api_post_requests_for_script = [for r in local.all_example_api_requests : merge(r, {
+    header_flags = trimspace(lookup(local.example_request_header_flags, "${r.method} ${r.path}", ""))
+  }) if r.method == "POST" && r.body != null]
+
+  default_header_flags = length(local.example_api_get_requests_for_script) > 0 ? local.example_api_get_requests_for_script[0].header_flags : ""
 
   # Generate test calls from all example requests
   command_test_calls = [for request in local.all_example_api_requests :
@@ -469,14 +477,14 @@ resource "local_file" "test_script" {
   filename        = "test-${trimprefix(var.instance_id, var.environment_id_prefix)}.sh"
   file_permission = "755"
   content = templatefile("${path.module}/test_script.tftpl", {
-    proxy_endpoint_url               = local.proxy_endpoint_url,
-    function_name                    = var.instance_id,
-    impersonation_param              = local.impersonation_param,
-    command_cli_call                 = local.command_cli_call,
-    default_get_request_header_flags = local.default_get_request_header_flags,
-    example_api_get_requests         = local.example_api_get_requests,
-    example_api_post_requests        = [for r in local.all_example_api_requests : r if r.method == "POST" && r.body != null], # body being null will blow up the templating
-    enable_async_processing          = var.enable_async_processing
+    proxy_endpoint_url        = local.proxy_endpoint_url,
+    function_name             = var.instance_id,
+    impersonation_param       = local.impersonation_param,
+    command_cli_call          = local.command_cli_call,
+    default_header_flags      = local.default_header_flags,
+    example_api_get_requests  = local.example_api_get_requests_for_script,
+    example_api_post_requests = local.example_api_post_requests_for_script,
+    enable_async_processing   = var.enable_async_processing
   })
 }
 

--- a/infra/modules/gcp-proxy-api/test_script.tftpl
+++ b/infra/modules/gcp-proxy-api/test_script.tftpl
@@ -4,6 +4,7 @@ METHOD=$${1:-"GET"}
 API_PATH=$${2:-${try(example_api_get_requests[0].path, "")}}
 CONTENT_TYPE=$${3:-""}
 BODY=$${4:-""}
+HEADER_FLAGS=$${5:-'${replace(default_header_flags, "'", "'\\''")}'}
 
 echo "Quick test of ${function_name} ..."
 
@@ -13,11 +14,11 @@ export NODE_OPTIONS="$${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
 ${command_cli_call} -u "${proxy_endpoint_url}/" --health-check
 HEALTHCHECK_RC=$?
 
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags}
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY" $HEADER_FLAGS
 SYNC_CALL_RC=$?
 
 %{ if enable_async_processing ~}
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags} --async
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY" $HEADER_FLAGS --async
 ASYNC_CALL_RC=$?
 %{ else ~}
 ASYNC_CALL_RC=0
@@ -26,10 +27,10 @@ ASYNC_CALL_RC=0
 echo "Invoke this script with any of the following as arguments to test other endpoints:"
 
 %{ for example_api_get_request in example_api_get_requests ~}
-    printf "\t%s\n" "${example_api_get_request.method} '${example_api_get_request.path}'"
+    printf "\t%s\n" "${example_api_get_request.method} '${example_api_get_request.path}' '' '' '${replace(example_api_get_request.header_flags, "'", "'\\''")}'"
 %{ endfor ~}
 %{ for example_api_post_request in example_api_post_requests ~}
-    printf "\t%s\n" "${example_api_post_request.method} '${example_api_post_request.path}' ${example_api_post_request.content_type} '${replace(example_api_post_request.body, "\"", "\\\"")}'"
+    printf "\t%s\n" "${example_api_post_request.method} '${example_api_post_request.path}' ${example_api_post_request.content_type} '${replace(example_api_post_request.body, "\"", "\\\"")}' '${replace(example_api_post_request.header_flags, "'", "'\\''")}'"
 %{ endfor ~}
 
 exit $(( HEALTHCHECK_RC + SYNC_CALL_RC + ASYNC_CALL_RC ))

--- a/infra/modules/gcp-proxy-api/test_script.tftpl
+++ b/infra/modules/gcp-proxy-api/test_script.tftpl
@@ -13,11 +13,11 @@ export NODE_OPTIONS="$${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
 ${command_cli_call} -u "${proxy_endpoint_url}/" --health-check
 HEALTHCHECK_RC=$?
 
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags}
 SYNC_CALL_RC=$?
 
 %{ if enable_async_processing ~}
-${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY" --async
+${command_cli_call} -u "${proxy_endpoint_url}$API_PATH" ${impersonation_param} -m $METHOD -b "$BODY"${default_get_request_header_flags} --async
 ASYNC_CALL_RC=$?
 %{ else ~}
 ASYNC_CALL_RC=0

--- a/infra/modules/gcp-proxy-api/variables.tf
+++ b/infra/modules/gcp-proxy-api/variables.tf
@@ -113,8 +113,9 @@ variable "example_api_requests" {
     path         = string
     content_type = optional(string, "application/json")
     body         = optional(string, null)
+    headers      = optional(map(string), {})
   }))
-  description = "example API requests with method, content_type and body parameters that can be called via proxy"
+  description = "example API requests with method, content_type, body, and headers parameters that can be called via proxy"
   default     = []
 }
 

--- a/infra/modules/worklytics-connector-specs/main.tf
+++ b/infra/modules/worklytics-connector-specs/main.tf
@@ -39,6 +39,10 @@ locals {
   # 3 days before the sample date, for interesting API calls (without repeating computation a dozen times)
   example_api_calls_sample_interval_start = timeadd(var.example_api_calls_sample_date, "-72h")
 
+  anthropic_api_headers = {
+    "anthropic-version" = "2023-06-01"
+  }
+
   chat_gpt_enterprise_example_workspace_id = coalesce(var.chat_gpt_enterprise_example_workspace_id, try(var.connector_settings["chat_gpt_enterprise_example_workspace_id"], null), "YOUR_WORKSPACEID")
   confluence_example_cloud_id              = coalesce(var.confluence_example_cloud_id, try(var.connector_settings["confluence_example_cloud_id"], null), "YOUR_confluence_example_cloud_id")
   confluence_example_group_id              = coalesce(var.confluence_example_group_id, try(var.connector_settings["confluence_example_group_id"], null), "YOUR_confluence_example_group_id")
@@ -164,10 +168,12 @@ EOT
         {
           method : "GET"
           path : "/v1/compliance/organizations"
+          headers : local.anthropic_api_headers
         },
         {
           method : "GET"
           path : "/v1/compliance/activities"
+          headers : local.anthropic_api_headers
         }
       ],
       external_token_todo : templatefile("${path.module}/docs/claude/claude_instructions.tftpl", {
@@ -196,10 +202,12 @@ EOT
         {
           method : "GET"
           path : "/v1/organizations/users"
+          headers : local.anthropic_api_headers
         },
         {
           method : "GET"
           path : "/v1/organizations/usage_report/claude_code"
+          headers : local.anthropic_api_headers
         }
       ],
       external_token_todo : templatefile("${path.module}/docs/claude/claude_code_instructions.tftpl", {


### PR DESCRIPTION
### Fixes
 - Fixes example test calls failing for Claude / Claude Code with `anthropic-version: header is required`

### Features
 - Add optional `headers` map to `example_api_requests` in connector specs and host/proxy modules
 - Pass headers through to generated TODO test commands and `test-*.sh` scripts via `psoxy-test` `-H` flags
 - Set `anthropic-version: 2023-06-01` on Claude and Claude Code example requests

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - No plan/apply impact beyond regenerated local test TODO files when `todos_as_local_files` is enabled
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
   - No breaking changes; `headers` is optional on `example_api_requests`

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215633146293253