### PR TITLE
Handling transient cases when reading a secret

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/TransientConfigException.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/TransientConfigException.java
@@ -1,0 +1,19 @@
+package co.worklytics.psoxy.gateway;
+
+/**
+ * Signals that a config/secret backend had a transient failure (credential rotation, network
+ * blip, service hiccup) and the value may still be accessible on the next attempt.
+ *
+ * Distinct from a missing value ({@code Optional.empty()} / {@code NEGATIVE_VALUE}): callers
+ * should NOT treat this as "property not configured" — they should retry or serve a cached value.
+ */
+public class TransientConfigException extends RuntimeException {
+
+    public TransientConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TransientConfigException(String message) {
+        super(message);
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -405,6 +405,14 @@ public class ApiDataRequestHandler {
             log.log(Level.WARNING,
                     "Confirm oauth scopes set in config.yaml match those granted in data source");
             return builder.build();
+        } catch (co.worklytics.psoxy.gateway.TransientConfigException e) {
+            // Config store was temporarily unreachable (e.g. credential rotation, AWS hiccup).
+            // The proxy already retried internally; this is not a misconfiguration.
+            builder.statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
+            builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
+                    ErrorCauses.CONFIGURATION_FAILURE.name());
+            log.log(Level.WARNING, "Transient config store failure after retries: " + e.getMessage(), e);
+            return builder.build();
         } catch (java.util.NoSuchElementException e) {
             // missing config, such as ACCESS_TOKEN
             builder.statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
@@ -9,21 +9,39 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.SecretStore;
 import co.worklytics.psoxy.gateway.WritableConfigService;
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.java.Log;
+import org.jspecify.annotations.NonNull;
+
+import java.util.logging.Level;
 
 
-@RequiredArgsConstructor
+@Log
 public class CachingConfigServiceDecorator implements WritableConfigService, SecretStore {
 
     final ConfigService delegate;
     final Duration defaultTtl;
+    final Ticker ticker;
+
+    public CachingConfigServiceDecorator(ConfigService delegate, Duration defaultTtl) {
+        this(delegate, defaultTtl, Ticker.systemTicker());
+    }
+
+    @VisibleForTesting
+    CachingConfigServiceDecorator(ConfigService delegate, Duration defaultTtl, Ticker ticker) {
+        this.delegate = delegate;
+        this.defaultTtl = defaultTtl;
+        this.ticker = ticker;
+    }
 
     private volatile LoadingCache<ConfigProperty, String> cache;
 
@@ -39,12 +57,32 @@ public class CachingConfigServiceDecorator implements WritableConfigService, Sec
                 if (this.cache == null) {
                     this.cache = CacheBuilder.newBuilder()
                         .maximumSize(100)
-                        .expireAfterWrite(defaultTtl.getSeconds(), TimeUnit.SECONDS)
+                        .ticker(ticker)
+                        .refreshAfterWrite(defaultTtl.getSeconds(), TimeUnit.SECONDS)
                         .recordStats()
                         .build(new CacheLoader<ConfigProperty, String>() {  //req for java8-backwards compatibility
                             @Override
-                            public String load(ConfigProperty key) {
+                            public String load(@NonNull ConfigProperty key) {
                                 return delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
+                            }
+
+                            @Override
+                            public ListenableFuture<String> reload(@NonNull ConfigProperty key, @NonNull String oldValue) {
+                                String newValue = delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
+                                // If the store returns empty but we previously had a valid value,
+                                // treat it as a transient backend failure and retain the old value.
+                                // Crucially, we return immediateFuture(oldValue) rather than a failed
+                                // future: a failed future leaves the write-time unchanged so Guava
+                                // would re-attempt the reload on every subsequent cache.get() call,
+                                // hammering SSM for the entire outage window. Returning the old value
+                                // marks the entry as freshly written, so the next retry waits a full TTL.
+                                if (NEGATIVE_VALUE.equals(newValue) && !NEGATIVE_VALUE.equals(oldValue)) {
+                                    log.log(Level.WARNING,
+                                        "Transient failure reloading config property {0}; retaining cached value until next refresh cycle",
+                                        key.name());
+                                    return Futures.immediateFuture(oldValue);
+                                }
+                                return Futures.immediateFuture(newValue);
                             }
                         });
                 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
@@ -30,19 +30,29 @@ import java.util.logging.Level;
 @Log
 public class CachingConfigServiceDecorator implements WritableConfigService, SecretStore {
 
+    static final int MAX_TRANSIENT_RETRIES = 3;
+    static final long DEFAULT_TRANSIENT_RETRY_DELAY_MS = 500L;
+
     final ConfigService delegate;
     final Duration defaultTtl;
     final Ticker ticker;
+    final long transientRetryDelayMs;
 
     public CachingConfigServiceDecorator(ConfigService delegate, Duration defaultTtl) {
-        this(delegate, defaultTtl, Ticker.systemTicker());
+        this(delegate, defaultTtl, Ticker.systemTicker(), DEFAULT_TRANSIENT_RETRY_DELAY_MS);
     }
 
     @VisibleForTesting
     CachingConfigServiceDecorator(ConfigService delegate, Duration defaultTtl, Ticker ticker) {
+        this(delegate, defaultTtl, ticker, DEFAULT_TRANSIENT_RETRY_DELAY_MS);
+    }
+
+    @VisibleForTesting
+    CachingConfigServiceDecorator(ConfigService delegate, Duration defaultTtl, Ticker ticker, long transientRetryDelayMs) {
         this.delegate = delegate;
         this.defaultTtl = defaultTtl;
         this.ticker = ticker;
+        this.transientRetryDelayMs = transientRetryDelayMs;
     }
 
     private volatile LoadingCache<ConfigProperty, String> cache;
@@ -65,7 +75,27 @@ public class CachingConfigServiceDecorator implements WritableConfigService, Sec
                         .build(new CacheLoader<ConfigProperty, String>() {  //req for java8-backwards compatibility
                             @Override
                             public String load(@NonNull ConfigProperty key) {
-                                return delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
+                                TransientConfigException lastException = null;
+                                for (int attempt = 0; attempt < MAX_TRANSIENT_RETRIES; attempt++) {
+                                    if (attempt > 0) {
+                                        try {
+                                            if (transientRetryDelayMs > 0) Thread.sleep(transientRetryDelayMs);
+                                        } catch (InterruptedException ie) {
+                                            Thread.currentThread().interrupt();
+                                            throw new TransientConfigException("Config load for " + key.name() + " interrupted during retry", ie);
+                                        }
+                                        log.log(Level.WARNING, "Retrying config property {0}, attempt {1}/{2}",
+                                            new Object[]{key.name(), attempt + 1, MAX_TRANSIENT_RETRIES});
+                                    }
+                                    try {
+                                        return delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
+                                    } catch (TransientConfigException e) {
+                                        lastException = e;
+                                        log.log(Level.WARNING, "Transient failure on attempt {0}/{1} for config property {2}",
+                                            new Object[]{attempt + 1, MAX_TRANSIENT_RETRIES, key.name()});
+                                    }
+                                }
+                                throw Objects.requireNonNull(lastException);
                             }
 
                             @Override
@@ -136,14 +166,13 @@ public class CachingConfigServiceDecorator implements WritableConfigService, Sec
                 // TransientConfigException is a RuntimeException, so it lands here.
                 Throwable cause = e.getCause();
                 if (cause instanceof TransientConfigException) {
-                    // load() threw a TransientConfigException — the cache stored nothing, so the
-                    // next request will retry the backend immediately. Return empty so that
-                    // optional-property callers degrade gracefully; required-property callers will
-                    // reach getConfigPropertyOrError() which throws NoSuchElementException.
+                    // load() retried MAX_TRANSIENT_RETRIES times and still failed. Nothing was
+                    // cached, so the next request will retry immediately. Re-throw so callers can
+                    // distinguish a transient store outage from a genuinely missing property.
                     log.log(Level.WARNING,
-                        "Transient backend failure for config property {0}; value not cached, next request will retry",
+                        "Transient backend failure for config property {0}; all retries exhausted",
                         property.name());
-                    return Optional.empty();
+                    throw (TransientConfigException) cause;
                 }
                 throw (cause instanceof RuntimeException) ? (RuntimeException) cause : e;
             } catch (ExecutionException e) {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
@@ -15,8 +15,10 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.SecretStore;
+import co.worklytics.psoxy.gateway.TransientConfigException;
 import co.worklytics.psoxy.gateway.WritableConfigService;
 import lombok.SneakyThrows;
 import lombok.extern.java.Log;
@@ -68,21 +70,27 @@ public class CachingConfigServiceDecorator implements WritableConfigService, Sec
 
                             @Override
                             public ListenableFuture<String> reload(@NonNull ConfigProperty key, @NonNull String oldValue) {
-                                String newValue = delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
-                                // If the store returns empty but we previously had a valid value,
-                                // treat it as a transient backend failure and retain the old value.
-                                // Crucially, we return immediateFuture(oldValue) rather than a failed
-                                // future: a failed future leaves the write-time unchanged so Guava
-                                // would re-attempt the reload on every subsequent cache.get() call,
-                                // hammering SSM for the entire outage window. Returning the old value
-                                // marks the entry as freshly written, so the next retry waits a full TTL.
-                                if (NEGATIVE_VALUE.equals(newValue) && !NEGATIVE_VALUE.equals(oldValue)) {
+                                try {
+                                    String newValue = delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
+                                    // Fallback heuristic for backends that still swallow exceptions
+                                    // (e.g. GCP SecretManagerConfigService): if the value was valid
+                                    // before but now comes back empty, assume transient and retain.
+                                    if (NEGATIVE_VALUE.equals(newValue) && !NEGATIVE_VALUE.equals(oldValue)) {
+                                        log.log(Level.WARNING,
+                                            "Backend returned empty for config property {0} which was previously set; assuming transient failure and retaining cached value",
+                                            key.name());
+                                        return Futures.immediateFuture(oldValue);
+                                    }
+                                    return Futures.immediateFuture(newValue);
+                                } catch (TransientConfigException e) {
+                                    // Backend explicitly signalled a transient failure.
+                                    // Returning the old value resets the write-time so Guava waits a
+                                    // full TTL before retrying, rather than retrying on every request.
                                     log.log(Level.WARNING,
                                         "Transient failure reloading config property {0}; retaining cached value until next refresh cycle",
                                         key.name());
                                     return Futures.immediateFuture(oldValue);
                                 }
-                                return Futures.immediateFuture(newValue);
                             }
                         });
                 }
@@ -123,8 +131,23 @@ public class CachingConfigServiceDecorator implements WritableConfigService, Sec
                 } else {
                     return Optional.of(value);
                 }
+            } catch (UncheckedExecutionException e) {
+                // Guava wraps RuntimeExceptions from load() in UncheckedExecutionException.
+                // TransientConfigException is a RuntimeException, so it lands here.
+                Throwable cause = e.getCause();
+                if (cause instanceof TransientConfigException) {
+                    // load() threw a TransientConfigException — the cache stored nothing, so the
+                    // next request will retry the backend immediately. Return empty so that
+                    // optional-property callers degrade gracefully; required-property callers will
+                    // reach getConfigPropertyOrError() which throws NoSuchElementException.
+                    log.log(Level.WARNING,
+                        "Transient backend failure for config property {0}; value not cached, next request will retry",
+                        property.name());
+                    return Optional.empty();
+                }
+                throw (cause instanceof RuntimeException) ? (RuntimeException) cause : e;
             } catch (ExecutionException e) {
-                //unwrap if possible, re-throw
+                // Guava wraps checked exceptions from load() in ExecutionException.
                 if (e.getCause() == null) {
                     throw e;
                 } else {

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
@@ -77,25 +78,22 @@ public class CachingConfigServiceDecorator implements WritableConfigService, Sec
                             public String load(@NonNull ConfigProperty key) {
                                 TransientConfigException lastException = null;
                                 for (int attempt = 0; attempt < MAX_TRANSIENT_RETRIES; attempt++) {
-                                    if (attempt > 0) {
-                                        try {
-                                            if (transientRetryDelayMs > 0) Thread.sleep(transientRetryDelayMs);
-                                        } catch (InterruptedException ie) {
-                                            Thread.currentThread().interrupt();
-                                            throw new TransientConfigException("Config load for " + key.name() + " interrupted during retry", ie);
-                                        }
-                                        log.log(Level.WARNING, "Retrying config property {0}, attempt {1}/{2}",
-                                            new Object[]{key.name(), attempt + 1, MAX_TRANSIENT_RETRIES});
-                                    }
                                     try {
                                         return delegate.getConfigPropertyAsOptional(key).orElse(NEGATIVE_VALUE);
                                     } catch (TransientConfigException e) {
                                         lastException = e;
-                                        log.log(Level.WARNING, "Transient failure on attempt {0}/{1} for config property {2}",
-                                            new Object[]{attempt + 1, MAX_TRANSIENT_RETRIES, key.name()});
+                                        log.log(Level.WARNING, String.format("Transient failure on attempt {0}/{1} for config property {2}",
+                                            attempt + 1, MAX_TRANSIENT_RETRIES, key.name()));
+                                    }
+                                    try {
+                                        if (transientRetryDelayMs > 0)
+                                            Thread.sleep(transientRetryDelayMs);
+                                    } catch (InterruptedException ie) {
+                                        Thread.currentThread().interrupt();
+                                        throw new TransientConfigException("Config load for " + key.name() + " interrupted during retry", ie);
                                     }
                                 }
-                                throw Objects.requireNonNull(lastException);
+                                throw lastException;
                             }
 
                             @Override

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecorator.java
@@ -20,9 +20,9 @@ import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.SecretStore;
 import co.worklytics.psoxy.gateway.TransientConfigException;
 import co.worklytics.psoxy.gateway.WritableConfigService;
+import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.java.Log;
-import org.jspecify.annotations.NonNull;
 
 import java.util.logging.Level;
 

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecoratorTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecoratorTest.java
@@ -146,24 +146,26 @@ class CachingConfigServiceDecoratorTest {
         ThrowingConfigService delegate = new ThrowingConfigService("valid_token");
         delegate.setThrowTransient(true);
 
+        // 0ms delay so the retry loop is fast in tests
         CachingConfigServiceDecorator cache =
-            new CachingConfigServiceDecorator(delegate, Duration.ofMinutes(1), ticker);
+            new CachingConfigServiceDecorator(delegate, Duration.ofMinutes(1), ticker, 0L);
 
-        // cold start with transient error: returns empty but does NOT cache NEGATIVE_VALUE
-        assertEquals(Optional.empty(),
-            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
-        assertEquals(1, delegate.getReads());
+        // cold start with transient error: retries MAX_TRANSIENT_RETRIES times then throws —
+        // nothing is cached as NEGATIVE_VALUE, so the next request will retry immediately
+        assertThrows(TransientConfigException.class,
+            () -> cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(CachingConfigServiceDecorator.MAX_TRANSIENT_RETRIES, delegate.getReads());
 
-        // next request retries immediately (nothing cached) — still failing
-        assertEquals(Optional.empty(),
-            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
-        assertEquals(2, delegate.getReads()); // retried, not served from cache
+        // second request: still failing, retries again from scratch (nothing was cached)
+        assertThrows(TransientConfigException.class,
+            () -> cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(CachingConfigServiceDecorator.MAX_TRANSIENT_RETRIES * 2, delegate.getReads());
 
-        // backend recovers (no TTL advance needed — nothing was cached)
+        // backend recovers — no TTL advance needed since nothing was ever cached
         delegate.setThrowTransient(false);
         assertEquals(Optional.of("valid_token"),
             cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
-        assertEquals(3, delegate.getReads());
+        assertEquals(CachingConfigServiceDecorator.MAX_TRANSIENT_RETRIES * 2 + 1, delegate.getReads());
     }
 
     @Test

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecoratorTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecoratorTest.java
@@ -13,6 +13,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Ticker;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -73,6 +76,39 @@ class CachingConfigServiceDecoratorTest {
     }
 
     @Test
+    void retainsStaleValueOnTransientReloadFailure() {
+        FakeTicker ticker = new FakeTicker();
+        ToggleableConfigService delegate = new ToggleableConfigService();
+        delegate.putConfigProperty(TestConfigProperties.EXAMPLE_PROPERTY, "valid_token");
+
+        CachingConfigServiceDecorator cache =
+            new CachingConfigServiceDecorator(delegate, Duration.ofMinutes(1), ticker);
+
+        // initial load succeeds
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(1, delegate.getReads());
+
+        // simulate transient SSM failure and advance past TTL
+        delegate.setSimulateFailure(true);
+        ticker.advance(2, TimeUnit.MINUTES);
+
+        // reload fails silently; old value is retained — caller sees no error
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(2, delegate.getReads()); // reload was attempted
+
+        // SSM recovers; advance past TTL again
+        delegate.setSimulateFailure(false);
+        ticker.advance(2, TimeUnit.MINUTES);
+
+        // next reload succeeds; value still valid
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(3, delegate.getReads());
+    }
+
+    @Test
     void getConfigProperty_noCache() {
         assertTrue(config.getConfigPropertyAsOptional(TestConfigProperties.NO_CACHE).isEmpty());
         assertEquals(1, localHashMapConfigService.getReads());
@@ -90,6 +126,52 @@ class CachingConfigServiceDecoratorTest {
         assertEquals(3, localHashMapConfigService.getReads());
     }
 
+
+    static class FakeTicker extends Ticker {
+        private long nanos = 0;
+
+        @Override
+        public long read() {
+            return nanos;
+        }
+
+        void advance(long amount, TimeUnit unit) {
+            nanos += unit.toNanos(amount);
+        }
+    }
+
+    static class ToggleableConfigService implements WritableConfigService {
+        private final Map<ConfigProperty, String> map = new HashMap<>();
+
+        @Getter
+        private int reads = 0;
+
+        private boolean simulateFailure = false;
+
+        void setSimulateFailure(boolean simulateFailure) {
+            this.simulateFailure = simulateFailure;
+        }
+
+        @Override
+        public void putConfigProperty(ConfigProperty property, String value) {
+            map.put(property, value);
+        }
+
+        @Override
+        public String getConfigPropertyOrError(ConfigProperty property) {
+            return getConfigPropertyAsOptional(property)
+                .orElseThrow(() -> new NoSuchElementException("no value for " + property));
+        }
+
+        @Override
+        public Optional<String> getConfigPropertyAsOptional(ConfigProperty property) {
+            reads++;
+            if (simulateFailure) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(map.get(property));
+        }
+    }
 
     static class LocalHashMapConfigService implements WritableConfigService {
 

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecoratorTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/CachingConfigServiceDecoratorTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Ticker;
+import co.worklytics.psoxy.gateway.TransientConfigException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -109,6 +110,63 @@ class CachingConfigServiceDecoratorTest {
     }
 
     @Test
+    void retainsStaleValueOnExplicitTransientException() {
+        FakeTicker ticker = new FakeTicker();
+        ThrowingConfigService delegate = new ThrowingConfigService("valid_token");
+
+        CachingConfigServiceDecorator cache =
+            new CachingConfigServiceDecorator(delegate, Duration.ofMinutes(1), ticker);
+
+        // initial load succeeds
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(1, delegate.getReads());
+
+        // backend starts throwing TransientConfigException
+        delegate.setThrowTransient(true);
+        ticker.advance(2, TimeUnit.MINUTES);
+
+        // reload catches TransientConfigException; old value retained, no error to caller
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(2, delegate.getReads());
+
+        // backend recovers
+        delegate.setThrowTransient(false);
+        ticker.advance(2, TimeUnit.MINUTES);
+
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(3, delegate.getReads());
+    }
+
+    @Test
+    void transientExceptionOnColdStartDoesNotCacheNegativeValue() {
+        FakeTicker ticker = new FakeTicker();
+        ThrowingConfigService delegate = new ThrowingConfigService("valid_token");
+        delegate.setThrowTransient(true);
+
+        CachingConfigServiceDecorator cache =
+            new CachingConfigServiceDecorator(delegate, Duration.ofMinutes(1), ticker);
+
+        // cold start with transient error: returns empty but does NOT cache NEGATIVE_VALUE
+        assertEquals(Optional.empty(),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(1, delegate.getReads());
+
+        // next request retries immediately (nothing cached) — still failing
+        assertEquals(Optional.empty(),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(2, delegate.getReads()); // retried, not served from cache
+
+        // backend recovers (no TTL advance needed — nothing was cached)
+        delegate.setThrowTransient(false);
+        assertEquals(Optional.of("valid_token"),
+            cache.getConfigPropertyAsOptional(TestConfigProperties.EXAMPLE_PROPERTY));
+        assertEquals(3, delegate.getReads());
+    }
+
+    @Test
     void getConfigProperty_noCache() {
         assertTrue(config.getConfigPropertyAsOptional(TestConfigProperties.NO_CACHE).isEmpty());
         assertEquals(1, localHashMapConfigService.getReads());
@@ -137,6 +195,42 @@ class CachingConfigServiceDecoratorTest {
 
         void advance(long amount, TimeUnit unit) {
             nanos += unit.toNanos(amount);
+        }
+    }
+
+    static class ThrowingConfigService implements WritableConfigService {
+        private String value;
+        private boolean throwTransient = false;
+
+        @Getter
+        private int reads = 0;
+
+        ThrowingConfigService(String value) {
+            this.value = value;
+        }
+
+        void setThrowTransient(boolean throwTransient) {
+            this.throwTransient = throwTransient;
+        }
+
+        @Override
+        public void putConfigProperty(ConfigProperty property, String newValue) {
+            this.value = newValue;
+        }
+
+        @Override
+        public String getConfigPropertyOrError(ConfigProperty property) {
+            return getConfigPropertyAsOptional(property)
+                .orElseThrow(() -> new NoSuchElementException("no value for " + property));
+        }
+
+        @Override
+        public Optional<String> getConfigPropertyAsOptional(ConfigProperty property) {
+            reads++;
+            if (throwTransient) {
+                throw new TransientConfigException("simulated transient failure");
+            }
+            return Optional.ofNullable(value);
         }
     }
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsExceptionUtils.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/AwsExceptionUtils.java
@@ -1,0 +1,14 @@
+package co.worklytics.psoxy.aws;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+
+class AwsExceptionUtils {
+
+    static boolean isAccessDenied(AwsServiceException e) {
+        if (e.awsErrorDetails() == null) {
+            return false;
+        }
+        String code = e.awsErrorDetails().errorCode();
+        return code != null && (code.contains("AccessDenied") || code.contains("Forbidden"));
+    }
+}

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/ParameterStoreConfigService.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.aws;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.LockService;
 import co.worklytics.psoxy.gateway.SecretStore;
+import co.worklytics.psoxy.gateway.TransientConfigException;
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import co.worklytics.psoxy.utils.DevLogUtils;
 import co.worklytics.psoxy.utils.RandomNumberGenerator;
@@ -137,11 +138,17 @@ public class ParameterStoreConfigService implements SecretStore, LockService {
             // does not exist, that could be OK depending on case.
             DevLogUtils.info(envVarsConfig, log, "No SSM parameter for " + paramName + " (may be expected)");
             return Optional.empty();
-        } catch (SsmException ignore) {
-            // very likely the policy doesn't allow reading this parameter
-            // may be OK in those cases
-            DevLogUtils.warn(envVarsConfig, log, "Failed to read SSM parameter for " + paramName, ignore);
-            return Optional.empty();
+        } catch (SsmException e) {
+            if (AwsExceptionUtils.isAccessDenied(e)) {
+                // IAM grants are created explicitly per parameter; access-denied is expected for
+                // optional parameters with no grant in this deployment.
+                DevLogUtils.warn(envVarsConfig, log, "Access denied reading SSM parameter " + paramName + "; expected if optional with no IAM grant", e);
+                return Optional.empty();
+            }
+            // Any other SsmException is a transient failure (credential rotation window, service
+            // hiccup, etc.) — signal to the cache layer to retain the previous value.
+            log.log(Level.WARNING, "Transient failure reading SSM parameter " + paramName + "; will retry on next cache refresh", e);
+            throw new TransientConfigException("Transient failure reading SSM parameter: " + paramName, e);
         } catch (AwsServiceException e) {
             if (e.isThrottlingException()) {
                 log.log(Level.SEVERE, String.format("Throttling issues for key %s, rate limit reached most likely despite retries", paramName), e);

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerSecretStore.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/SecretsManagerSecretStore.java
@@ -14,6 +14,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import co.worklytics.psoxy.gateway.ConfigService;
 import co.worklytics.psoxy.gateway.SecretStore;
+import co.worklytics.psoxy.gateway.TransientConfigException;
 import co.worklytics.psoxy.gateway.impl.EnvVarsConfigService;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedInject;
@@ -113,7 +114,7 @@ public class SecretsManagerSecretStore implements SecretStore {
 
             GetSecretValueResponse response = client.getSecretValue(request);
             return Optional.ofNullable(mapping.apply(response));
-        } catch (DecryptionFailureException e ) {
+        } catch (DecryptionFailureException e) {
             log.log(Level.SEVERE, "failed to read secret due to decryption error; check lambda's exec role perms for secret " + id);
             return Optional.empty();
         } catch (ResourceNotFoundException e) {
@@ -123,15 +124,19 @@ public class SecretsManagerSecretStore implements SecretStore {
             }
             return Optional.empty();
         } catch (SecretsManagerException e) {
-            //permissions error hits this case ... could still be expected for optional secrets, as
-            // explicit IAM grant made for each one that exists
-            //eg
-            // software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException:
-            // User: arn:aws:sts::{{SOME_ACCOUNT_ID}}}:assumed-role/{{LAMBDAS_EXEC_ROLE}}/{{SESSION_NAME}} is not authorized to perform: secretsmanager:GetSecretValue on resource: {{SECRET_ID}} because no identity-based policy allows the secretsmanager:GetSecretValue action (Service: SecretsManager, Status Code: 400, Request ID: ---, Extended Request ID: null)
-            if (envVarsConfig.isDevelopment()) {
-                log.log(Level.WARNING, "failed to read secret " + id, e);
+            if (AwsExceptionUtils.isAccessDenied(e)) {
+                // IAM grants are created explicitly for each secret that exists; access-denied is
+                // therefore expected for optional secrets that have no grant in this deployment.
+                if (envVarsConfig.isDevelopment()) {
+                    log.log(Level.WARNING, "access denied reading secret " + id + "; expected if this is an optional secret with no IAM grant");
+                }
+                return Optional.empty();
             }
-            return Optional.empty();
+            // Any other SecretsManagerException (credential rotation window, transient service
+            // error, etc.) — signal to the cache layer that this is a transient failure so it can
+            // retain the previous cached value rather than treating it as "not configured".
+            log.log(Level.WARNING, "transient failure reading secret " + id + "; will retry on next cache refresh", e);
+            throw new TransientConfigException("Transient failure reading secret: " + id, e);
         } catch (AwsServiceException e) {
             if (e.isThrottlingException()) {
                 log.log(Level.SEVERE, String.format("Throttling issues for Secrets Manager Secret %s, rate limit reached most likely despite retries", id), e);


### PR DESCRIPTION
Trying to fix issue that happening in AWS when there are requests after a few and then the instance starts returning CONNECTION_SETUP. 

I think the issue could come about how the `ParameterStore` /  `SecretsManagerSecretStore` in AWS. Its client is marked as `Singleton` so the instance is the same across all the lifetime of the function. As a difference with GCP, where even `SecretManagerConfigService` is marked as singleton, the GCP client is created on each request:

https://github.com/Worklytics/psoxy/blob/82542de64aaeb7cd4fc23e42e42d29155ecf17e4/java/impl/gcp/src/main/java/co/worklytics/psoxy/SecretManagerConfigService.java#L93

What I think it is happening in AWS is that after a while (it should match less han an hour of running time) is that the internal token authentication between PS / SMS it is expired, waiting some requests until this is obtained a new fresh one. That matches what I see in the caller side where after some requests returning CONNECTION_SETUP during 1-3 seconds, then the function is working well after that.

So what this PR is doing is mostly:
- trying to enforce reload on cache
- detect access denied vs other error, considering it as transient, after couple of retries it will return 503 if still not working

Ideas are welcomed here

### Fixes
[Suddenly CONNECTION_SETUP error is killing the reader](https://app.asana.com/1/27145998307022/project/1203776123599466/task/1215641372342099)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
