### PR TITLE
Using metadata from ProcessedContent

### DIFF
--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSOutput.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSOutput.java
@@ -16,7 +16,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import java.util.Map;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 @Log
 public class GCSOutput implements Output {
@@ -46,11 +48,15 @@ public class GCSOutput implements Output {
 
         try {
             Storage storageClient = storageProvider.get();
+            Map<String, String> metadata = content.getMetadata().entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
             try (WriteChannel writeChannel = storageClient.writer(
                 BlobInfo.newBuilder(bucket, pathPrefix + key)
                     .setContentType(content.getContentType())
                     .setContentEncoding(content.getContentEncoding())
-                    //.setMetadata(outputUtils.buildMetadata(request))
+                    .setMetadata(metadata)
                     .build())) {
                 writeChannel.write(java.nio.ByteBuffer.wrap(content.getContent(), 0, content.getContent().length));
             }


### PR DESCRIPTION
Passing metadata from processed content into GCS output

### Fixes
[Metadata in GCSOutput](https://app.asana.com/1/27145998307022/project/1215464266090587/task/1215769507906335)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **yes (explain) / no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
