### PR TITLE
avoid apparent GCP drfit

### DIFF
--- a/infra/modules/gcp-host/api_rules.tftest.hcl
+++ b/infra/modules/gcp-host/api_rules.tftest.hcl
@@ -25,6 +25,13 @@ variables {
 }
 
 mock_provider "google" {
+  mock_data "google_project" {
+    defaults = {
+      project_id = "test-project-123456"
+      number     = 123456789
+    }
+  }
+
   mock_data "google_compute_default_service_account" {
     defaults = {
       email = "123456789-compute@developer.gserviceaccount.com"

--- a/infra/modules/gcp-host/bulk_rules.tftest.hcl
+++ b/infra/modules/gcp-host/bulk_rules.tftest.hcl
@@ -47,6 +47,13 @@ variables {
 
 # Mock provider since we're only testing the logic, not actual GCP resources
 mock_provider "google" {
+  mock_data "google_project" {
+    defaults = {
+      project_id = "test-project-123456"
+      number     = 123456789
+    }
+  }
+
   mock_data "google_compute_default_service_account" {
     defaults = {
       email = "123456789-compute@developer.gserviceaccount.com"

--- a/infra/modules/gcp-host/concurrency.tftest.hcl
+++ b/infra/modules/gcp-host/concurrency.tftest.hcl
@@ -24,6 +24,13 @@ variables {
 
 # Mock provider since we're only testing the logic, not actual GCP resources
 mock_provider "google" {
+  mock_data "google_project" {
+    defaults = {
+      project_id = "test-project-123456"
+      number     = 123456789
+    }
+  }
+
   mock_data "google_compute_default_service_account" {
     defaults = {
       email = "123456789-compute@developer.gserviceaccount.com"

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -231,7 +231,7 @@ module "api_connector" {
 
   source = "../../modules/gcp-proxy-api"
 
-  project_id                            = var.gcp_project_id
+  gcp_project                           = module.psoxy.gcp_project
   region                                = var.gcp_region
   source_kind                           = each.value.source_kind
   environment_id_prefix                 = local.environment_id_prefix
@@ -332,7 +332,7 @@ module "webhook_collector" {
 
   source = "../../modules/gcp-webhook-collector"
 
-  project_id            = var.gcp_project_id
+  gcp_project           = module.psoxy.gcp_project
   region                = var.gcp_region
   environment_id_prefix = local.environment_id_prefix
   instance_id           = each.key
@@ -397,8 +397,7 @@ module "bulk_connector" {
 
   source = "../../modules/gcp-proxy-bulk"
 
-  project_id                        = var.gcp_project_id
-  gcp_project_number                = module.psoxy.gcp_project_number
+  gcp_project                       = module.psoxy.gcp_project
   region                            = var.gcp_region
   environment_id_prefix             = local.environment_id_prefix
   instance_id                       = each.key

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -398,6 +398,7 @@ module "bulk_connector" {
   source = "../../modules/gcp-proxy-bulk"
 
   project_id                        = var.gcp_project_id
+  gcp_project_number                = module.psoxy.gcp_project_number
   region                            = var.gcp_region
   environment_id_prefix             = local.environment_id_prefix
   instance_id                       = each.key

--- a/infra/modules/gcp-proxy-api/ip_lock_conditions.tftest.hcl
+++ b/infra/modules/gcp-proxy-api/ip_lock_conditions.tftest.hcl
@@ -1,5 +1,8 @@
 variables {
-  project_id                    = "test-project"
+  gcp_project = {
+    project_id = "test-project"
+    number     = 123456789
+  }
   environment_id_prefix         = "dev-"
   instance_id                   = "test-instance"
   service_account_email         = "test@example.com"
@@ -7,18 +10,12 @@ variables {
   deployment_bundle_object_name = "bundle.zip"
   builder_sa_id                 = "projects/test-project/serviceAccounts/builder@example.com"
   source_kind                   = "test"
+  tf_runner_iam_principal       = "user:terraform@example.com"
 
   allowed_data_access_ip_blocks = ["192.168.0.0/24"]
 }
 
 mock_provider "google" {
-  mock_data "google_project" {
-    defaults = {
-      project_id = "test-project"
-      number     = "123456789"
-    }
-  }
-
   mock_data "google_service_account" {
     defaults = {
       account_id = "test@example.com"

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -292,7 +292,8 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = var.gcp_project.number
+        # project_id string (not number) avoids apply-time drift: number comes from data.google_project
+        project_id = var.gcp_project.project_id
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -1,14 +1,10 @@
 # deployment for a single Psoxy instance in GCP project that has be initialized for Psoxy.
 # project itself may hold MULTIPLE psoxy instances
 
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret" {
   for_each = var.secret_bindings
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account_email}"
   role      = "roles/secretmanager.secretAccessor"
@@ -65,7 +61,7 @@ module "async_output" {
 
   count = var.enable_async_processing ? 1 : 0
 
-  project_id                     = var.project_id
+  project_id                     = var.gcp_project.project_id
   bucket_write_role_id           = var.bucket_write_role_id
   function_service_account_email = var.service_account_email
   bucket_name_prefix             = local.bucket_name_prefix
@@ -83,7 +79,7 @@ module "async_output" {
 resource "google_pubsub_topic" "async_output_topic" {
   count = var.enable_async_processing ? 1 : 0
 
-  project = var.project_id
+  project = var.gcp_project.project_id
   name    = "${var.environment_id_prefix}${var.instance_id}-async-output"
 }
 
@@ -91,7 +87,7 @@ resource "google_pubsub_topic" "async_output_topic" {
 resource "google_pubsub_subscription" "async_output_subscription" {
   count = var.enable_async_processing ? 1 : 0
 
-  project = var.project_id
+  project = var.gcp_project.project_id
   name    = "${var.environment_id_prefix}${var.instance_id}-async-output-subscription"
   topic   = google_pubsub_topic.async_output_topic[0].name
 
@@ -119,14 +115,14 @@ resource "google_pubsub_subscription" "async_output_subscription" {
 
 locals {
   # TODO: there's a `google_project_service_identity` resource in `google-beta` provider, which we might be able to leverage from 0.6+
-  pubsub_service_identity = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  pubsub_service_identity = "service-${var.gcp_project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
 # 1. Allow the Cloud Function's service account to publish to the topic
 resource "google_pubsub_topic_iam_member" "function_publisher" {
   count = var.enable_async_processing ? 1 : 0
 
-  project = var.project_id
+  project = var.gcp_project.project_id
   topic   = google_pubsub_topic.async_output_topic[0].id
   member  = "serviceAccount:${var.service_account_email}"
   role    = "roles/pubsub.publisher"
@@ -140,7 +136,7 @@ resource "google_pubsub_topic_iam_member" "function_publisher" {
 resource "google_service_account_iam_member" "pubsub_oidc_minter" {
   count = var.enable_async_processing ? 1 : 0
 
-  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
+  service_account_id = "projects/${var.gcp_project.project_id}/serviceAccounts/${var.service_account_email}"
   member             = "serviceAccount:${local.pubsub_service_identity}"
   role               = "roles/iam.serviceAccountOpenIdTokenCreator"
 }
@@ -150,7 +146,7 @@ module "side_output_bucket" {
 
   for_each = local.side_outputs_to_provision
 
-  project_id                     = var.project_id
+  project_id                     = var.gcp_project.project_id
   bucket_write_role_id           = var.bucket_write_role_id
   function_service_account_email = var.service_account_email
   bucket_name_prefix             = local.bucket_name_prefix
@@ -217,7 +213,7 @@ locals {
 resource "google_service_account_iam_member" "tf_runner_act_as" {
   member             = var.tf_runner_iam_principal
   role               = "roles/iam.serviceAccountUser"
-  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
+  service_account_id = "projects/${var.gcp_project.project_id}/serviceAccounts/${var.service_account_email}"
 }
 
 # migration: remove old resource address from state (destroyed in GCP)
@@ -233,7 +229,7 @@ resource "google_cloudfunctions2_function" "function" {
   name        = "${var.environment_id_prefix}${var.instance_id}"
   description = "Psoxy Connector - ${var.source_kind}"
 
-  project  = var.project_id
+  project  = var.gcp_project.project_id
   location = var.region
 
   build_config {
@@ -296,7 +292,7 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = data.google_project.project.number
+        project_id = var.gcp_project.number
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }
@@ -317,7 +313,7 @@ module "service_url_parameter" {
 
   count = var.enable_async_processing ? 1 : 0
 
-  secret_project    = var.project_id
+  secret_project    = var.gcp_project.project_id
   path_prefix       = local.path_to_instance_config_parameters
   replica_locations = var.secret_replica_locations
   secrets = {
@@ -343,7 +339,7 @@ locals {
 resource "google_secret_manager_secret_iam_member" "grant_sa_viewer_on_parameter" {
   for_each = local.secrets_to_grant_access_to
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account_email}"
   role      = "roles/secretmanager.viewer"
@@ -352,7 +348,7 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_viewer_on_parameter
 resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_parameter" {
   for_each = local.secrets_to_grant_access_to
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account_email}"
   role      = "roles/secretmanager.secretAccessor" # this is ONLY accessing payload of a secret version

--- a/infra/modules/gcp-proxy-api/variables.tf
+++ b/infra/modules/gcp-proxy-api/variables.tf
@@ -1,6 +1,9 @@
-variable "project_id" {
-  type        = string
-  description = "name of the gcp project"
+variable "gcp_project" {
+  type = object({
+    project_id = string
+    number     = number
+  })
+  description = "GCP project hosting this Psoxy instance. project_id and number must refer to the same project (same fields as data.google_project); pass from parent (eg module.psoxy.gcp_project) to avoid data.google_project lookups in each connector instance."
 }
 
 variable "tf_runner_iam_principal" {

--- a/infra/modules/gcp-proxy-bulk/main.tf
+++ b/infra/modules/gcp-proxy-bulk/main.tf
@@ -252,7 +252,8 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = var.gcp_project.number
+        # project_id string (not number) avoids apply-time drift: number comes from data.google_project
+        project_id = var.gcp_project.project_id
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }

--- a/infra/modules/gcp-proxy-bulk/main.tf
+++ b/infra/modules/gcp-proxy-bulk/main.tf
@@ -51,7 +51,7 @@ locals {
 # trivy:ignore:AVD-GCP-0078
 # trivy:ignore:AVD-GCP-0077
 resource "google_storage_bucket" "input_bucket" {
-  project                     = var.project_id
+  project                     = var.gcp_project.project_id
   name                        = coalesce(var.input_bucket_name, "${local.bucket_prefix}-input")
   location                    = var.region
   force_destroy               = var.bucket_force_destroy
@@ -85,7 +85,7 @@ resource "google_storage_bucket" "input_bucket" {
 module "output_bucket" {
   source = "../gcp-output-bucket"
 
-  project_id                     = var.project_id
+  project_id                     = var.gcp_project.project_id
   bucket_write_role_id           = var.bucket_write_role_id
   function_service_account_email = google_service_account.service_account.email
   bucket_name_prefix             = coalesce(var.sanitized_bucket_name, local.bucket_prefix)
@@ -98,7 +98,7 @@ module "output_bucket" {
 }
 
 resource "google_service_account" "service_account" {
-  project      = var.project_id
+  project      = var.gcp_project.project_id
   account_id   = local.sa_name
   display_name = "Psoxy Connector - ${var.source_kind}"
   description  = "${local.function_name} runs as this service account"
@@ -157,7 +157,7 @@ resource "google_storage_bucket_iam_member" "grant_testers_admin_on_processed_bu
 resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret" {
   for_each = var.secret_bindings
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${google_service_account.service_account.email}"
   role      = "roles/secretmanager.secretAccessor"
@@ -170,13 +170,13 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret"
 # historically, we used the GCP Compute Engine default service account as the event trigger SA, and relied on it having 'Editor' by default on most GCP projects
 # but that does not seem to be universally true - so we'll stop relying on that assumption from 0.5.9 onwards
 resource "google_project_iam_member" "grant_sa_event_receiver" {
-  project = var.project_id
+  project = var.gcp_project.project_id
   member  = "serviceAccount:${google_service_account.service_account.email}"
   role    = "roles/eventarc.eventReceiver"
 }
 
 resource "google_cloud_run_service_iam_member" "grant_sa_invoker" {
-  project  = var.project_id
+  project  = var.gcp_project.project_id
   location = google_cloudfunctions2_function.function.location
   service  = google_cloudfunctions2_function.function.name
   member   = "serviceAccount:${google_service_account.service_account.email}"
@@ -204,7 +204,7 @@ removed {
 resource "google_cloudfunctions2_function" "function" {
   name        = local.function_name
   description = "Psoxy instance to process ${var.source_kind} files"
-  project     = var.project_id
+  project     = var.gcp_project.project_id
   location    = var.region
 
   build_config {
@@ -252,7 +252,7 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = var.gcp_project_number
+        project_id = var.gcp_project.number
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }
@@ -321,7 +321,7 @@ EOT
 
 Review the deployed Cloud function in GCP console:
 
-[Function in GCP Console](https://console.cloud.google.com/functions/details/${var.region}/${google_cloudfunctions2_function.function.name}?project=${var.project_id})
+[Function in GCP Console](https://console.cloud.google.com/functions/details/${var.region}/${google_cloudfunctions2_function.function.name}?project=${var.gcp_project.project_id})
 
 We provide some Node.js scripts to easily validate the deployment. To be able
 to run the test commands below, you need Node.js (>=20) and npm (v >=8)

--- a/infra/modules/gcp-proxy-bulk/main.tf
+++ b/infra/modules/gcp-proxy-bulk/main.tf
@@ -18,10 +18,6 @@ locals {
   path_to_instance_config_parameters = "${coalesce(var.config_parameter_prefix, "")}${replace(upper(local.instance_id), "-", "_")}_"
 }
 
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 resource "random_string" "bucket_id_part" {
   length  = 8
   special = false
@@ -256,7 +252,7 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = data.google_project.project.number
+        project_id = var.gcp_project_number
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }

--- a/infra/modules/gcp-proxy-bulk/variables.tf
+++ b/infra/modules/gcp-proxy-bulk/variables.tf
@@ -3,6 +3,11 @@ variable "project_id" {
   description = "id of GCP project that will host psoxy instance"
 }
 
+variable "gcp_project_number" {
+  type        = string
+  description = "numeric GCP project number (used for secret environment variables; pass from parent to avoid a data.google_project lookup per bulk connector instance)"
+}
+
 variable "tf_runner_iam_principal" {
   description = "The IAM principal (e.g., 'user:alice@example.com' or 'serviceAccount:terraform@project.iam.gserviceaccount.com') that Terraform is running as, used for granting necessary permissions to provision Cloud Functions."
   type        = string

--- a/infra/modules/gcp-proxy-bulk/variables.tf
+++ b/infra/modules/gcp-proxy-bulk/variables.tf
@@ -1,11 +1,9 @@
-variable "project_id" {
-  type        = string
-  description = "id of GCP project that will host psoxy instance"
-}
-
-variable "gcp_project_number" {
-  type        = string
-  description = "numeric GCP project number (used for secret environment variables; pass from parent to avoid a data.google_project lookup per bulk connector instance)"
+variable "gcp_project" {
+  type = object({
+    project_id = string
+    number     = number
+  })
+  description = "GCP project hosting this Psoxy instance. project_id and number must refer to the same project (same fields as data.google_project); pass from parent (eg module.psoxy.gcp_project) to avoid data.google_project lookups in each connector instance."
 }
 
 variable "tf_runner_iam_principal" {

--- a/infra/modules/gcp-webhook-collector/ip_lock_conditions.tftest.hcl
+++ b/infra/modules/gcp-webhook-collector/ip_lock_conditions.tftest.hcl
@@ -1,5 +1,8 @@
 variables {
-  project_id              = "test-project"
+  gcp_project = {
+    project_id = "test-project"
+    number     = 123456789
+  }
   environment_id_prefix   = "dev-"
   instance_id             = "test-instance"
   config_parameter_prefix = "TEST_"
@@ -24,13 +27,6 @@ variables {
 }
 
 mock_provider "google" {
-  mock_data "google_project" {
-    defaults = {
-      project_id = "test-project"
-      number     = "123456789"
-    }
-  }
-
 }
 
 run "validate_cloud_run_webhook_invokers_no_ip_condition" {

--- a/infra/modules/gcp-webhook-collector/main.tf
+++ b/infra/modules/gcp-webhook-collector/main.tf
@@ -21,16 +21,12 @@ locals {
 # deployment for a single Psoxy instance in GCP project that has be initialized for Psoxy.
 # project itself may hold MULTIPLE psoxy instances
 
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 # perms for secrets
 # TODO: imho, would be cleaner to combine into a custom project role??
 resource "google_secret_manager_secret_iam_member" "grant_sa_viewer_on_secret" {
   for_each = var.secret_bindings
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account.email}"
   role      = "roles/secretmanager.viewer"
@@ -39,7 +35,7 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_viewer_on_secret" {
 resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_secret" {
   for_each = var.secret_bindings
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account.email}"
   role      = "roles/secretmanager.secretAccessor" # this is ONLY accessing payload of a secret version
@@ -152,7 +148,7 @@ module "sanitized_webhook_output" {
 
   enable_versioning              = var.enable_versioning
   bucket_access_logs_destination = var.bucket_access_logs_destination
-  project_id                     = var.project_id
+  project_id                     = var.gcp_project.project_id
   bucket_write_role_id           = var.bucket_write_role_id
   function_service_account_email = var.service_account.email
   bucket_name_prefix             = local.bucket_name_prefix
@@ -172,7 +168,7 @@ module "side_output_bucket" {
 
   enable_versioning              = var.enable_versioning
   bucket_access_logs_destination = var.bucket_access_logs_destination
-  project_id                     = var.project_id
+  project_id                     = var.gcp_project.project_id
   bucket_write_role_id           = var.bucket_write_role_id
   function_service_account_email = var.service_account.email
   bucket_name_prefix             = local.bucket_name_prefix
@@ -241,7 +237,7 @@ locals {
 module "auth_issuer_secret" {
   source = "../../modules/gcp-secrets"
 
-  secret_project    = var.project_id
+  secret_project    = var.gcp_project.project_id
   path_prefix       = local.path_to_instance_config_parameters
   replica_locations = var.secret_replica_locations
   secrets = {
@@ -273,7 +269,7 @@ locals {
 resource "google_secret_manager_secret_iam_member" "grant_sa_viewer_on_parameter" {
   for_each = local.secrets_to_grant_access_to
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account.email}"
   role      = "roles/secretmanager.viewer"
@@ -282,7 +278,7 @@ resource "google_secret_manager_secret_iam_member" "grant_sa_viewer_on_parameter
 resource "google_secret_manager_secret_iam_member" "grant_sa_accessor_on_parameter" {
   for_each = local.secrets_to_grant_access_to
 
-  project   = var.project_id
+  project   = var.gcp_project.project_id
   secret_id = each.value.secret_id
   member    = "serviceAccount:${var.service_account.email}"
   role      = "roles/secretmanager.secretAccessor" # this is ONLY accessing payload of a secret version
@@ -311,7 +307,7 @@ resource "google_cloudfunctions2_function" "function" {
   name        = "${var.environment_id_prefix}${var.instance_id}"
   description = "Webhook Collector - ${var.source_kind}"
 
-  project  = var.project_id
+  project  = var.gcp_project.project_id
   location = var.region
 
   build_config {
@@ -372,7 +368,7 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = data.google_project.project.number
+        project_id = var.gcp_project.number
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }
@@ -404,14 +400,14 @@ resource "google_cloud_run_service_iam_binding" "invokers" {
 # Pub/Sub topic for individual webhook messages
 resource "google_pubsub_topic" "webhook_topic" {
   name    = "${var.environment_id_prefix}${var.instance_id}-webhooks"
-  project = var.project_id
+  project = var.gcp_project.project_id
 }
 
 # Pub/Sub subscription for batch processing
 resource "google_pubsub_subscription" "webhook_subscription" {
   name    = "${var.environment_id_prefix}${var.instance_id}-webhook-subscription"
   topic   = google_pubsub_topic.webhook_topic.name
-  project = var.project_id
+  project = var.gcp_project.project_id
 
   # Configure for batch processing
   ack_deadline_seconds       = 600       # 10 minutes to process messages
@@ -428,7 +424,7 @@ resource "google_pubsub_subscription" "webhook_subscription" {
 
 # IAM binding to allow the Cloud Function to publish to the topic
 resource "google_pubsub_topic_iam_member" "publisher" {
-  project = var.project_id
+  project = var.gcp_project.project_id
   topic   = google_pubsub_topic.webhook_topic.name
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:${var.service_account.email}"
@@ -436,7 +432,7 @@ resource "google_pubsub_topic_iam_member" "publisher" {
 
 # IAM binding to allow the Cloud Function to pull from the subscription
 resource "google_pubsub_subscription_iam_member" "subscriber" {
-  project      = var.project_id
+  project      = var.gcp_project.project_id
   subscription = google_pubsub_subscription.webhook_subscription.name
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${var.service_account.email}"
@@ -444,7 +440,7 @@ resource "google_pubsub_subscription_iam_member" "subscriber" {
 
 
 resource "google_cloud_scheduler_job" "trigger_batch_processing" {
-  project     = var.project_id
+  project     = var.gcp_project.project_id
   region      = var.region
   name        = "${var.environment_id_prefix}${var.instance_id}-batch-processing"
   schedule    = "*/${var.batch_processing_frequency_minutes} * * * *"

--- a/infra/modules/gcp-webhook-collector/main.tf
+++ b/infra/modules/gcp-webhook-collector/main.tf
@@ -368,7 +368,8 @@ resource "google_cloudfunctions2_function" "function" {
 
       content {
         key        = secret_environment_variable.key
-        project_id = var.gcp_project.number
+        # project_id string (not number) avoids apply-time drift: number comes from data.google_project
+        project_id = var.gcp_project.project_id
         secret     = secret_environment_variable.value.secret_id
         version    = secret_environment_variable.value.version_number
       }

--- a/infra/modules/gcp-webhook-collector/variables.tf
+++ b/infra/modules/gcp-webhook-collector/variables.tf
@@ -1,6 +1,9 @@
-variable "project_id" {
-  type        = string
-  description = "name of the gcp project"
+variable "gcp_project" {
+  type = object({
+    project_id = string
+    number     = number
+  })
+  description = "GCP project hosting this Psoxy instance. project_id and number must refer to the same project (same fields as data.google_project); pass from parent (eg module.psoxy.gcp_project) to avoid data.google_project lookups in each connector instance."
 }
 
 variable "tf_runner_iam_principal" {

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -526,6 +526,11 @@ resource "google_project_iam_member" "data_sanitization_tester_grant" {
 
 
 
+output "gcp_project_number" {
+  value       = data.google_project.project.number
+  description = "Numeric GCP project number. Exposed so child modules (eg bulk connectors) can reference it without their own data.google_project lookup."
+}
+
 output "artifacts_bucket_name" {
   value = local.artifact_bucket_name
 }

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -526,9 +526,12 @@ resource "google_project_iam_member" "data_sanitization_tester_grant" {
 
 
 
-output "gcp_project_number" {
-  value       = data.google_project.project.number
-  description = "Numeric GCP project number. Exposed so child modules (eg bulk connectors) can reference it without their own data.google_project lookup."
+output "gcp_project" {
+  value = {
+    project_id = data.google_project.project.project_id
+    number     = data.google_project.project.number
+  }
+  description = "GCP project hosting this Psoxy environment. Mirrors data.google_project attributes (project_id, number) so connector modules can reference them without their own data.google_project lookup."
 }
 
 output "artifacts_bucket_name" {

--- a/infra/modules/gcp/main.tf
+++ b/infra/modules/gcp/main.tf
@@ -528,10 +528,10 @@ resource "google_project_iam_member" "data_sanitization_tester_grant" {
 
 output "gcp_project" {
   value = {
-    project_id = data.google_project.project.project_id
+    project_id = var.project_id
     number     = data.google_project.project.number
   }
-  description = "GCP project hosting this Psoxy environment. Mirrors data.google_project attributes (project_id, number) so connector modules can reference them without their own data.google_project lookup."
+  description = "GCP project hosting this Psoxy environment. project_id is the configured project id (known at plan time); number is from data.google_project (for IAM principal patterns that require it)."
 }
 
 output "artifacts_bucket_name" {


### PR DESCRIPTION
### Features
 - `google_project` data resources appear to show changes on every apply; avoid that by passing project details down.
 - service_config.secret_environment_variables ALSO seems to show changes, although none have happened

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - breaking changes? **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215719543581327