### PR TITLE
fix duplicate query params from API Gateway 1.0 payloads

### DIFF
--- a/infra/modules/worklytics-connector-specs/msft-365.tf
+++ b/infra/modules/worklytics-connector-specs/msft-365.tf
@@ -66,7 +66,7 @@ locals {
       external_todo : null
       enable_side_output : false
       example_api_calls : [
-        "/v1.0/users",
+        "/v1.0/users?\\$select=id,mail,otherMails",
         "/v1.0/users/${local.example_msft_user_guid}/events",
         "/v1.0/users/${local.example_msft_user_guid}/calendarView?startDateTime=${timeadd(var.example_api_calls_sample_date, "-4320h")}&endDateTime=${var.example_api_calls_sample_date}",
         "/v1.0/users/${local.example_msft_user_guid}/mailboxSettings",
@@ -93,7 +93,7 @@ locals {
       external_todo : null
       enable_side_output : false
       example_api_calls : [
-        "/v1.0/users",
+        "/v1.0/users?\\$select=id,mail,otherMails",
         "/v1.0/users/${local.example_msft_user_guid}/mailboxSettings",
         "/v1.0/users/${local.example_msft_user_guid}/mailFolders/SentItems/messages",
         "/v1.0/groups",

--- a/infra/modules/worklytics-connector-specs/msft-365.tf
+++ b/infra/modules/worklytics-connector-specs/msft-365.tf
@@ -66,6 +66,7 @@ locals {
       external_todo : null
       enable_side_output : false
       example_api_calls : [
+        "/v1.0/users",
         "/v1.0/users?\\$select=id,mail,otherMails",
         "/v1.0/users/${local.example_msft_user_guid}/events",
         "/v1.0/users/${local.example_msft_user_guid}/calendarView?startDateTime=${timeadd(var.example_api_calls_sample_date, "-4320h")}&endDateTime=${var.example_api_calls_sample_date}",
@@ -93,6 +94,7 @@ locals {
       external_todo : null
       enable_side_output : false
       example_api_calls : [
+        "/v1.0/users",
         "/v1.0/users?\\$select=id,mail,otherMails",
         "/v1.0/users/${local.example_msft_user_guid}/mailboxSettings",
         "/v1.0/users/${local.example_msft_user_guid}/mailFolders/SentItems/messages",

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapter.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.tuple.Pair;
@@ -37,20 +36,19 @@ public class APIGatewayV1ProxyEventRequestAdapter implements co.worklytics.psoxy
 
     @Override
     public Optional<String> getQuery() {
+        // API Gateway V1 REST populates both queryStringParameters and multiValueQueryStringParameters
+        // with the same parameters; prefer multiValue to preserve repeated keys without duplication.
+        if (event.getMultiValueQueryStringParameters() != null) {
+            return Optional.ofNullable(StringUtils.trimToNull(
+                event.getMultiValueQueryStringParameters().entrySet().stream()
+                    .flatMap(entry -> entry.getValue().stream().map(v -> Pair.of(entry.getKey(), v)))
+                    .map(pair -> pair.getLeft() + "=" + pair.getRight())
+                    .collect(Collectors.joining("&"))));
+        }
 
-        Stream<Pair<String, String>> paramStream = Stream.concat(
-            Optional.ofNullable(event.getQueryStringParameters())
-                .map(params -> params.entrySet().stream()
-                    .map(k -> Pair.of(k.getKey(), k.getValue())))
-                .orElse(Stream.empty()),
-            Optional.ofNullable(event.getMultiValueQueryStringParameters())
-                .map(params -> params.entrySet().stream()
-                    .flatMap(k -> k.getValue().stream().map(v -> Pair.of(k.getKey(), v))))
-                .orElse(Stream.empty())
-        );
-
-        return Optional.ofNullable(StringUtils.trimToNull(paramStream
-                .map(pair -> pair.getLeft() + "=" + pair.getRight())
+        return Optional.ofNullable(event.getQueryStringParameters())
+            .map(params -> StringUtils.trimToNull(params.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
                 .collect(Collectors.joining("&"))));
     }
 

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapter.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapter.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.tuple.Pair;
@@ -36,20 +37,24 @@ public class APIGatewayV1ProxyEventRequestAdapter implements co.worklytics.psoxy
 
     @Override
     public Optional<String> getQuery() {
-        // API Gateway V1 REST populates both queryStringParameters and multiValueQueryStringParameters
+        // API Gateway payload 1.0 populates both queryStringParameters and multiValueQueryStringParameters
         // with the same parameters; prefer multiValue to preserve repeated keys without duplication.
-        if (event.getMultiValueQueryStringParameters() != null) {
-            return Optional.ofNullable(StringUtils.trimToNull(
-                event.getMultiValueQueryStringParameters().entrySet().stream()
-                    .flatMap(entry -> entry.getValue().stream().map(v -> Pair.of(entry.getKey(), v)))
-                    .map(pair -> pair.getLeft() + "=" + pair.getRight())
-                    .collect(Collectors.joining("&"))));
+        Stream<Pair<String, String>> paramStream;
+        if (event.getMultiValueQueryStringParameters() == null
+            || event.getMultiValueQueryStringParameters().isEmpty()) {
+            paramStream = Optional.ofNullable(event.getQueryStringParameters())
+                .map(params -> params.entrySet().stream()
+                    .map(k -> Pair.of(k.getKey(), k.getValue())))
+                .orElse(Stream.empty());
+        } else {
+            paramStream = event.getMultiValueQueryStringParameters().entrySet().stream()
+                .flatMap(entry -> Optional.ofNullable(entry.getValue()).orElse(List.of()).stream()
+                    .map(v -> Pair.of(entry.getKey(), v)));
         }
 
-        return Optional.ofNullable(event.getQueryStringParameters())
-            .map(params -> StringUtils.trimToNull(params.entrySet().stream()
-                .map(entry -> entry.getKey() + "=" + entry.getValue())
-                .collect(Collectors.joining("&"))));
+        return Optional.ofNullable(StringUtils.trimToNull(paramStream
+            .map(pair -> pair.getLeft() + "=" + pair.getRight())
+            .collect(Collectors.joining("&"))));
     }
 
     @Override

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.aws.request;
 import co.worklytics.test.TestUtils;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
@@ -47,36 +48,53 @@ public class APIGatewayV1ProxyEventRequestAdapterTest {
         assertEquals("/something", requestAdapter.getPath());
 
         assertTrue(requestAdapter.getQuery().isPresent());
-
-        assertEquals("name=John", requestAdapter.getQuery().get());
+        assertEquals("name=John", requestAdapter.getQuery().orElseThrow());
 
 
         assertFalse(requestAdapter.isHttps().isPresent());
     }
 
-    @SneakyThrows
     @Test
     public void getQuery_doesNotDuplicateWhenBothQueryMapsPopulated() {
-        APIGatewayProxyRequestEvent apiGatewayEvent = objectMapper.readerFor(APIGatewayProxyRequestEvent.class)
-            .readValue(TestUtils.getData("lambda-proxy-events/api-gateway-v2-payload-v1.json"));
+        Map<String, String> queryStringParameters = new LinkedHashMap<>();
+        queryStringParameters.put("$select", "id,mail,otherMails");
+        queryStringParameters.put("$top", "50");
+
+        Map<String, List<String>> multiValueQueryStringParameters = new LinkedHashMap<>();
+        multiValueQueryStringParameters.put("$select", List.of("id,mail,otherMails"));
+        multiValueQueryStringParameters.put("$top", List.of("50"));
+
+        APIGatewayProxyRequestEvent apiGatewayEvent = new APIGatewayProxyRequestEvent()
+            .withQueryStringParameters(queryStringParameters)
+            .withMultiValueQueryStringParameters(multiValueQueryStringParameters);
 
         APIGatewayV1ProxyEventRequestAdapter requestAdapter =
             APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
 
-        assertEquals("page_size=30", requestAdapter.getQuery().get());
+        assertTrue(requestAdapter.getQuery().isPresent());
+        assertEquals("$select=id,mail,otherMails&$top=50", requestAdapter.getQuery().orElseThrow());
     }
 
-    @SneakyThrows
     @Test
     public void getQuery_preservesRepeatedKeysFromMultiValueMap() {
+        Map<String, String> queryStringParameters = new LinkedHashMap<>();
+        queryStringParameters.put("$select", "id,mail,otherMails");
+        queryStringParameters.put("$top", "50");
+
+        Map<String, List<String>> multiValueQueryStringParameters = new LinkedHashMap<>();
+        multiValueQueryStringParameters.put("$select", List.of("id", "mail", "otherMails"));
+        multiValueQueryStringParameters.put("$top", List.of("50"));
+
         APIGatewayProxyRequestEvent apiGatewayEvent = new APIGatewayProxyRequestEvent()
-            .withQueryStringParameters(Map.of("$select", "mail"))
-            .withMultiValueQueryStringParameters(Map.of("$select", List.of("id", "mail")));
+            .withQueryStringParameters(queryStringParameters)
+            .withMultiValueQueryStringParameters(multiValueQueryStringParameters);
 
         APIGatewayV1ProxyEventRequestAdapter requestAdapter =
             APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
 
-        assertEquals("$select=id&$select=mail", requestAdapter.getQuery().get());
+        assertTrue(requestAdapter.getQuery().isPresent());
+        assertEquals("$select=id&$select=mail&$select=otherMails&$top=50",
+            requestAdapter.getQuery().orElseThrow());
     }
 
     @SneakyThrows
@@ -88,7 +106,8 @@ public class APIGatewayV1ProxyEventRequestAdapterTest {
         APIGatewayV1ProxyEventRequestAdapter requestAdapter =
             APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
 
-        assertEquals("name=John", requestAdapter.getQuery().get());
+        assertTrue(requestAdapter.getQuery().isPresent());
+        assertEquals("name=John", requestAdapter.getQuery().orElseThrow());
     }
 
     @SneakyThrows

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.aws.request;
 import co.worklytics.test.TestUtils;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,43 @@ public class APIGatewayV1ProxyEventRequestAdapterTest {
 
 
         assertFalse(requestAdapter.isHttps().isPresent());
+    }
+
+    @SneakyThrows
+    @Test
+    public void getQuery_doesNotDuplicateWhenBothQueryMapsPopulated() {
+        APIGatewayProxyRequestEvent apiGatewayEvent = objectMapper.readerFor(APIGatewayProxyRequestEvent.class)
+            .readValue(TestUtils.getData("lambda-proxy-events/api-gateway-v2-payload-v1.json"));
+
+        APIGatewayV1ProxyEventRequestAdapter requestAdapter =
+            APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
+
+        assertEquals("page_size=30", requestAdapter.getQuery().get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void getQuery_preservesRepeatedKeysFromMultiValueMap() {
+        APIGatewayProxyRequestEvent apiGatewayEvent = new APIGatewayProxyRequestEvent()
+            .withQueryStringParameters(Map.of("$select", "id,mail"))
+            .withMultiValueQueryStringParameters(Map.of("$select", List.of("id,mail")));
+
+        APIGatewayV1ProxyEventRequestAdapter requestAdapter =
+            APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
+
+        assertEquals("$select=id,mail", requestAdapter.getQuery().get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void getQuery_fallsBackToSingleValueMapWhenMultiValueAbsent() {
+        APIGatewayProxyRequestEvent apiGatewayEvent = objectMapper.readerFor(APIGatewayProxyRequestEvent.class)
+            .readValue(TestUtils.getData("lambda-proxy-events/api-gateway-v1-example_interesting.json"));
+
+        APIGatewayV1ProxyEventRequestAdapter requestAdapter =
+            APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
+
+        assertEquals("name=John", requestAdapter.getQuery().get());
     }
 
     @SneakyThrows

--- a/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
+++ b/java/impl/aws/src/test/java/co/worklytics/psoxy/aws/request/APIGatewayV1ProxyEventRequestAdapterTest.java
@@ -70,13 +70,13 @@ public class APIGatewayV1ProxyEventRequestAdapterTest {
     @Test
     public void getQuery_preservesRepeatedKeysFromMultiValueMap() {
         APIGatewayProxyRequestEvent apiGatewayEvent = new APIGatewayProxyRequestEvent()
-            .withQueryStringParameters(Map.of("$select", "id,mail"))
-            .withMultiValueQueryStringParameters(Map.of("$select", List.of("id,mail")));
+            .withQueryStringParameters(Map.of("$select", "mail"))
+            .withMultiValueQueryStringParameters(Map.of("$select", List.of("id", "mail")));
 
         APIGatewayV1ProxyEventRequestAdapter requestAdapter =
             APIGatewayV1ProxyEventRequestAdapter.of(apiGatewayEvent);
 
-        assertEquals("$select=id,mail", requestAdapter.getQuery().get());
+        assertEquals("$select=id&$select=mail", requestAdapter.getQuery().get());
     }
 
     @SneakyThrows

--- a/tools/psoxy-test/data-sources/spec.js
+++ b/tools/psoxy-test/data-sources/spec.js
@@ -358,6 +358,7 @@ export default {
       {
         name: 'Users',
         path: '/v1.0/users',
+        params: { $select: 'id,mail,otherMails' },
         refs: [
           {
             name: 'Events',
@@ -393,6 +394,7 @@ export default {
       {
         name: 'Users',
         path: '/beta/users',
+        params: { $select: 'id,mail,otherMails' },
         refs: [
           {
             name: 'Mailbox Settings',


### PR DESCRIPTION
### Fixes
 - duplicate query params from API Gateway 1.0 payload events

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? **No** — runtime behavior fix only; no expected Terraform plan/apply changes.
   - breaking changes? **No** — corrects incorrect duplicate query params; callers should see the intended single set of parameters.