### PR TITLE
fix possible null body side outputs

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/ProcessedContent.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/ProcessedContent.java
@@ -50,19 +50,27 @@ public class ProcessedContent implements Serializable {
     Map<String, String> metadata = new HashMap<>();
 
     /**
-     * the actual content
+     * the actual content; may be null when the upstream response has no body (e.g. 204, HEAD)
      */
+    @Getter(lombok.AccessLevel.NONE)
     byte[] content;
 
     /**
+     * Returns content bytes for consumers that need to read or write the body.
+     * Missing bodies are treated as an empty array to avoid NPEs in output writers.
+     */
+    public byte[] getContent() {
+        return content != null ? content : new byte[0];
+    }
+
+    /**
      * for convenience, a method to get the content as a string - rather than byte array
-     * @return the content as a string, using the specified contentCharset
+     * @return the content as a string, using the specified contentCharset; null if no body
      */
     public String getContentAsString() {
-        if (getContent() == null) {
+        if (content == null) {
             return null;
-        } else {
-            return new String(getContent(), contentCharset);
         }
+        return new String(content, contentCharset);
     }
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapper.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapper.java
@@ -33,7 +33,7 @@ public class CompressedOutputWrapper implements Output {
     @Override
     public void write(String key, ProcessedContent content) throws WriteFailure {
         try {
-            byte[] rawContent = content.getContent() != null ? content.getContent() : new byte[0];
+            byte[] rawContent = content.getContent();
             if (!Objects.equals(COMPRESSION_TYPE, content.getContentEncoding())) {
                 log.info("Compressing response with gzip encoding through wrapper");
                 byte[] compressedContent = gzipContent(rawContent);
@@ -51,7 +51,7 @@ public class CompressedOutputWrapper implements Output {
      * @param content to compress
      * @return a byte[] reflecting gzip-encoding of the content
      */
-    byte[] gzipContent(byte[] content) throws WriteFailure {
+    byte[] gzipContent(@NonNull byte[] content) throws WriteFailure {
         try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
              GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
             gzipOutputStream.write(content);

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapper.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapper.java
@@ -33,9 +33,10 @@ public class CompressedOutputWrapper implements Output {
     @Override
     public void write(String key, ProcessedContent content) throws WriteFailure {
         try {
-            if (!Objects.equals(COMPRESSION_TYPE, content.getContentEncoding())) {             
+            byte[] rawContent = content.getContent() != null ? content.getContent() : new byte[0];
+            if (!Objects.equals(COMPRESSION_TYPE, content.getContentEncoding())) {
                 log.info("Compressing response with gzip encoding through wrapper");
-                byte[] compressedContent = gzipContent(content.getContent());
+                byte[] compressedContent = gzipContent(rawContent);
                 content = content.withContentEncoding(COMPRESSION_TYPE).withContent(compressedContent);
             }
             delegate.write(key, content);
@@ -50,7 +51,7 @@ public class CompressedOutputWrapper implements Output {
      * @param content to compress
      * @return a byte[] reflecting gzip-encoding of the content
      */
-    byte[] gzipContent(@NonNull byte[] content) throws WriteFailure {
+    byte[] gzipContent(byte[] content) throws WriteFailure {
         try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
              GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
             gzipOutputStream.write(content);

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapperTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapperTest.java
@@ -1,5 +1,8 @@
 package co.worklytics.psoxy.gateway.impl.output;
 
+import co.worklytics.psoxy.gateway.ProcessedContent;
+import co.worklytics.psoxy.gateway.output.Output;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -12,6 +15,14 @@ import java.util.zip.GZIPInputStream;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CompressedOutputWrapperTest {
+
+    @Test
+    void writeNullContent() throws Exception {
+        Output delegate = new NoOutput();
+        CompressedOutputWrapper wrapper = CompressedOutputWrapper.wrap(delegate);
+        ProcessedContent content = ProcessedContent.builder().content(null).build();
+        assertDoesNotThrow(() -> wrapper.write(content));
+    }
 
     @Test
     void gzipContent() throws Exception {

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapperTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/output/CompressedOutputWrapperTest.java
@@ -25,6 +25,17 @@ class CompressedOutputWrapperTest {
     }
 
     @Test
+    void writeNullContentAlreadyGzipEncoded() throws Exception {
+        Output delegate = new NoOutput();
+        CompressedOutputWrapper wrapper = CompressedOutputWrapper.wrap(delegate);
+        ProcessedContent content = ProcessedContent.builder()
+            .content(null)
+            .contentEncoding(CompressedOutputWrapper.COMPRESSION_TYPE)
+            .build();
+        assertDoesNotThrow(() -> wrapper.write(content));
+    }
+
+    @Test
     void gzipContent() throws Exception {
         String content = "Hello, world!";
         // Verify that the content is gzipped

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/S3Output.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/S3Output.java
@@ -49,7 +49,7 @@ public class S3Output implements Output {
 
     @Override
     public void write(String key, ProcessedContent content) throws WriteFailure {
-        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
+        byte[] body = content.getContent();
 
         if (key == null) {
             key = DigestUtils.md5Hex(body);
@@ -84,8 +84,7 @@ public class S3Output implements Output {
     public void write(ProcessedContent content) throws WriteFailure {
         // Generate a canonical key based on the content's hash
         // random UUID better??
-        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
-        String key = DigestUtils.sha256Hex(body);
+        String key = DigestUtils.sha256Hex(content.getContent());
         write(key, content);
     }
 }

--- a/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/S3Output.java
+++ b/java/impl/aws/src/main/java/co/worklytics/psoxy/aws/S3Output.java
@@ -49,9 +49,10 @@ public class S3Output implements Output {
 
     @Override
     public void write(String key, ProcessedContent content) throws WriteFailure {
+        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
 
         if (key == null) {
-            key = DigestUtils.md5Hex(content.getContent());
+            key = DigestUtils.md5Hex(body);
         }
 
         try {
@@ -66,14 +67,14 @@ public class S3Output implements Output {
             PutObjectRequest.Builder putBuilder = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(pathPrefix + key)
-                .contentLength((long) content.getContent().length)
+                .contentLength((long) body.length)
                 .metadata(userMetadata);
 
             // s3 client blows up if these are filled with 'null' values, so only set if present
             Optional.ofNullable(content.getContentEncoding()).ifPresent(putBuilder::contentEncoding);
             Optional.ofNullable(content.getContentType()).ifPresent(putBuilder::contentType);
 
-            s3Client.putObject(putBuilder.build(), RequestBody.fromBytes(content.getContent()));
+            s3Client.putObject(putBuilder.build(), RequestBody.fromBytes(body));
         } catch (Exception e) {
             throw new WriteFailure("Failed to write to S3 output", e);
         }
@@ -83,7 +84,8 @@ public class S3Output implements Output {
     public void write(ProcessedContent content) throws WriteFailure {
         // Generate a canonical key based on the content's hash
         // random UUID better??
-        String key = DigestUtils.sha256Hex(content.getContent());
+        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
+        String key = DigestUtils.sha256Hex(body);
         write(key, content);
     }
 }

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSOutput.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSOutput.java
@@ -42,8 +42,10 @@ public class GCSOutput implements Output {
 
     @Override
     public void write(String key, ProcessedContent content) throws WriteFailure {
+        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
+
         if (key == null) {
-            key = DigestUtils.md5Hex(content.getContent());
+            key = DigestUtils.md5Hex(body);
         }
 
         try {
@@ -58,7 +60,9 @@ public class GCSOutput implements Output {
                     .setContentEncoding(content.getContentEncoding())
                     .setMetadata(metadata)
                     .build())) {
-                writeChannel.write(java.nio.ByteBuffer.wrap(content.getContent(), 0, content.getContent().length));
+                if (body.length > 0) {
+                    writeChannel.write(java.nio.ByteBuffer.wrap(body));
+                }
             }
         } catch (Exception e) {
             log.log(Level.WARNING, "Failed to write to GCS sideOutput", e);
@@ -69,7 +73,8 @@ public class GCSOutput implements Output {
     @Override
     public void write(ProcessedContent content) throws WriteFailure {
         // Generate a canonical key for the response
-        String key = DigestUtils.md5Hex(content.getContent());
+        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
+        String key = DigestUtils.md5Hex(body);
         write(key, content);
     }
 

--- a/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSOutput.java
+++ b/java/impl/gcp/src/main/java/co/worklytics/psoxy/GCSOutput.java
@@ -42,7 +42,7 @@ public class GCSOutput implements Output {
 
     @Override
     public void write(String key, ProcessedContent content) throws WriteFailure {
-        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
+        byte[] body = content.getContent();
 
         if (key == null) {
             key = DigestUtils.md5Hex(body);
@@ -73,8 +73,7 @@ public class GCSOutput implements Output {
     @Override
     public void write(ProcessedContent content) throws WriteFailure {
         // Generate a canonical key for the response
-        byte[] body = content.getContent() != null ? content.getContent() : new byte[0];
-        String key = DigestUtils.md5Hex(body);
+        String key = DigestUtils.md5Hex(content.getContent());
         write(key, content);
     }
 


### PR DESCRIPTION
### Fixes
- incorrect handling of side-output writes when the response body is null, for GCS, S3, and gzip-wrapped outputs.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? **No** — runtime behavior fix only
   - breaking changes? **No** — bug fix; no API or module contract changes expected