### PR TITLE
request metadata leak

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/ProcessedDataMetadataFields.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ProcessedDataMetadataFields.java
@@ -1,12 +1,17 @@
 package co.worklytics.psoxy;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 /**
- * metadata fields that Psoxy may add to processed data responses
- *  -- as HTTP headers on http responses
- *  -- as metadata if written to objects
+ * metadata fields that Psoxy may add to processed data responses.
+ *
+ * <p>On sync HTTP responses, only these fields are exposed as headers (via {@link #getHttpHeader()}).
+ * Request-capture metadata ({@link co.worklytics.psoxy.gateway.output.ApiDataOutputUtils.OutputObjectMetadata})
+ * is stored on {@link co.worklytics.psoxy.gateway.ProcessedContent} for async/side outputs only.
  */
 @RequiredArgsConstructor
 public enum ProcessedDataMetadataFields {
@@ -49,6 +54,12 @@ public enum ProcessedDataMetadataFields {
 
     public String getMetadataKey() {
         return formattedName;
+    }
+
+    public static Optional<ProcessedDataMetadataFields> fromMetadataKey(String metadataKey) {
+        return Arrays.stream(values())
+            .filter(f -> f.getMetadataKey().equals(metadataKey))
+            .findFirst();
     }
 
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -584,8 +584,8 @@ public class ApiDataRequestHandler {
                                 processingContext);
                     } else {
                         proxyResponseContent = sanitizationResult.getContentAsString();
-                        sanitizationResult.getMetadata().entrySet()
-                                .forEach(e -> builder.header(e.getKey(), e.getValue()));
+                        sanitizedApiResponseMetadata(sanitizationResult.getMetadata())
+                                .forEach((header, value) -> builder.header(header, value));
                     }
 
 
@@ -767,6 +767,19 @@ public class ApiDataRequestHandler {
     static Set<String> normalizeHeaders(Set<String> headers) {
         return headers.stream().map(ApiDataRequestHandler::normalizeHeader)
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Filters processed-content metadata to fields intended for sync HTTP responses.
+     * Request-capture metadata remains on {@link ProcessedContent} for async/side outputs.
+     */
+    @VisibleForTesting
+    static Map<String, String> sanitizedApiResponseMetadata(Map<String, String> metadata) {
+        return metadata.entrySet().stream()
+            .flatMap(e -> ProcessedDataMetadataFields.fromMetadataKey(e.getKey())
+                .stream()
+                .map(f -> Map.entry(f.getHttpHeader(), e.getValue())))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @SneakyThrows

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
@@ -2,6 +2,7 @@ package co.worklytics.psoxy.gateway.impl;
 
 import co.worklytics.psoxy.ConfigRulesModule;
 import co.worklytics.psoxy.ControlHeader;
+import co.worklytics.psoxy.ProcessedDataMetadataFields;
 import co.worklytics.psoxy.Pseudonymizer;
 import co.worklytics.psoxy.PseudonymizerImplFactory;
 import co.worklytics.psoxy.PsoxyModule;
@@ -11,6 +12,7 @@ import co.worklytics.psoxy.gateway.ApiModeConfig;
 import co.worklytics.psoxy.gateway.HttpEventRequest;
 import co.worklytics.psoxy.gateway.HttpEventResponse;
 import co.worklytics.psoxy.gateway.ProxyConfigProperty;
+import co.worklytics.psoxy.gateway.output.ApiDataOutputUtils;
 import co.worklytics.psoxy.impl.RESTApiSanitizerImpl;
 import co.worklytics.psoxy.rules.RESTRules;
 import co.worklytics.psoxy.rules.RulesUtils;
@@ -612,6 +614,32 @@ class ApiDataRequestHandlerTest {
             handler.getSanitizerForRequest(mock(HttpEventRequest.class))
                 .getPseudonymizer().getOptions()
                 .getPseudonymImplementation());
+    }
+
+    @Test
+    void sanitizedApiResponseMetadata_includesOnlyProcessedDataFields() {
+        Map<String, String> metadata = Map.of(
+            ProcessedDataMetadataFields.RULES_SHA.getMetadataKey(), "abc123",
+            ProcessedDataMetadataFields.PROXY_VERSION.getMetadataKey(), "v0.6.7",
+            ApiDataOutputUtils.OutputObjectMetadata.REQUEST_BODY.name(), "base64body",
+            ApiDataOutputUtils.OutputObjectMetadata.QUERY_STRING.name(), "foo=bar",
+            ApiDataOutputUtils.OutputObjectMetadata.PATH.name(), "users/me"
+        );
+
+        Map<String, String> responseMetadata =
+            ApiDataRequestHandler.sanitizedApiResponseMetadata(metadata);
+
+        assertEquals("abc123",
+            responseMetadata.get(ProcessedDataMetadataFields.RULES_SHA.getHttpHeader()));
+        assertEquals("v0.6.7",
+            responseMetadata.get(ProcessedDataMetadataFields.PROXY_VERSION.getHttpHeader()));
+        assertEquals(2, responseMetadata.size());
+        assertFalse(responseMetadata.containsKey(
+            ApiDataOutputUtils.OutputObjectMetadata.REQUEST_BODY.name()));
+        assertFalse(responseMetadata.containsKey(
+            ApiDataOutputUtils.OutputObjectMetadata.QUERY_STRING.name()));
+        assertFalse(responseMetadata.containsKey(
+            ApiDataOutputUtils.OutputObjectMetadata.PATH.name()));
     }
 
     @Test


### PR DESCRIPTION
### Fixes
 - [request metadata leak in sync API headers](https://github.com/Worklytics/psoxy/pull/1339/changes/74ae574edd899a771cf15af385105f2e3d271962) - introduced by a different PR in this release; never reached prod.

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md`: sync API responses no longer include request metadata in response headers. If any client relied on those headers, it will need to obtain that information another way.
   - breaking changes? **no** (unintentional exposure removed; not a documented API contract). If downstream tooling was depending on the leaked headers, treat that as a behavioral change rather than a semver-breaking module change.