### PR TITLE
Anthropic rules update

### DIFF
--- a/docs/sources/anthropic/claude-enterprise-analytics/claude-enterprise-analytics.yaml
+++ b/docs/sources/anthropic/claude-enterprise-analytics/claude-enterprise-analytics.yaml
@@ -341,6 +341,7 @@ definitions:
         type: "integer"
       last_activity_date:
         type: "string"
+        format: "date"
       office_metrics:
         $ref: "#/definitions/OfficeMetrics"
       rbac_group_id:

--- a/docs/sources/anthropic/claude-enterprise-analytics/claude-enterprise-analytics.yaml
+++ b/docs/sources/anthropic/claude-enterprise-analytics/claude-enterprise-analytics.yaml
@@ -155,6 +155,8 @@ definitions:
         type: "integer"
       distinct_artifacts_created_count:
         type: "integer"
+      distinct_connectors_used_count:
+        type: "integer"
       distinct_conversation_count:
         type: "integer"
       distinct_files_uploaded_count:

--- a/docs/sources/anthropic/claude-enterprise-analytics/claude-enterprise-analytics.yaml
+++ b/docs/sources/anthropic/claude-enterprise-analytics/claude-enterprise-analytics.yaml
@@ -220,13 +220,40 @@ definitions:
         type: "integer"
       distinct_connectors_used_count:
         type: "integer"
+      distinct_plugins_used_count:
+        type: "integer"
       distinct_session_count:
         type: "integer"
       distinct_skills_used_count:
         type: "integer"
+      edit_tool_count:
+        type: "integer"
+      file_edit_count:
+        type: "integer"
       message_count:
         type: "integer"
+      multi_edit_tool_count:
+        type: "integer"
+      notebook_edit_tool_count:
+        type: "integer"
+      plugins_used_count:
+        type: "integer"
+      sessions_with_file_edits_count:
+        type: "integer"
       skills_used_count:
+        type: "integer"
+      write_tool_count:
+        type: "integer"
+  DesignMetrics:
+    type: "object"
+    properties:
+      distinct_projects_created_count:
+        type: "integer"
+      distinct_projects_used_count:
+        type: "integer"
+      distinct_session_count:
+        type: "integer"
+      message_count:
         type: "integer"
   LinesOfCode:
     type: "object"
@@ -261,6 +288,19 @@ definitions:
         $ref: "#/definitions/OfficeAppMetrics"
       word:
         $ref: "#/definitions/OfficeAppMetrics"
+  ScienceMetrics:
+    type: "object"
+    properties:
+      delegation_count:
+        type: "integer"
+      distinct_session_count:
+        type: "integer"
+      message_count:
+        type: "integer"
+      remote_compute_job_count:
+        type: "integer"
+      skills_used_count:
+        type: "integer"
   ServerToolUse:
     type: "object"
     properties:
@@ -269,9 +309,9 @@ definitions:
   ToolAction:
     type: "object"
     properties:
-      accepted:
+      accepted_count:
         type: "integer"
-      rejected:
+      rejected_count:
         type: "integer"
   ToolActions:
     type: "object"
@@ -293,11 +333,20 @@ definitions:
         $ref: "#/definitions/ClaudeCodeMetrics"
       cowork_metrics:
         $ref: "#/definitions/CoworkMetrics"
-      date:
+      design_metrics:
+        $ref: "#/definitions/DesignMetrics"
+      distinct_user_count:
+        type: "integer"
+      last_activity_date:
         type: "string"
-        format: "date"
       office_metrics:
         $ref: "#/definitions/OfficeMetrics"
+      rbac_group_id:
+        type: "string"
+      rbac_group_name:
+        type: "string"
+      science_metrics:
+        $ref: "#/definitions/ScienceMetrics"
       user:
         $ref: "#/definitions/AnalyticsUser"
       web_search_count:
@@ -358,4 +407,3 @@ definitions:
         type: "integer"
       uncached_input_tokens:
         type: "integer"
-

--- a/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/original/users.json
+++ b/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/original/users.json
@@ -1,10 +1,7 @@
 {
   "data": [
     {
-      "user": {
-        "id": "t~Wd2U4lmivWESn4fNgZWtjnW3j4TXciQNif50hO_QMVM",
-        "email_address": "t~knxWE5tapsutcz6pLWSC3wfb5t34lCrXNZsKnhwyVXk@example.com"
-      },
+      "user": { "id": "user_abc123", "email_address": "alice@example.com" },
       "chat_metrics": {
         "distinct_conversation_count": 5,
         "message_count": 42,
@@ -16,217 +13,101 @@
         "thinking_message_count": 0,
         "distinct_skills_used_count": 2,
         "connectors_used_count": 1,
+        "distinct_connectors_used_count": 1,
         "shared_conversations_viewed_count": 0
       },
       "claude_code_metrics": {
         "core_metrics": {
           "commit_count": 3,
           "pull_request_count": 1,
-          "lines_of_code": {
-            "added_count": 120,
-            "removed_count": 45
-          },
+          "lines_of_code": { "added_count": 120, "removed_count": 45 },
           "distinct_session_count": 4
         },
         "tool_actions": {
-          "edit_tool": {
-            "accepted_count": 10,
-            "rejected_count": 2
-          },
-          "multi_edit_tool": {
-            "accepted_count": 3,
-            "rejected_count": 0
-          },
-          "write_tool": {
-            "accepted_count": 5,
-            "rejected_count": 1
-          },
-          "notebook_edit_tool": {
-            "accepted_count": 0,
-            "rejected_count": 0
-          }
+          "edit_tool": { "accepted_count": 10, "rejected_count": 2 },
+          "multi_edit_tool": { "accepted_count": 3, "rejected_count": 0 },
+          "write_tool": { "accepted_count": 5, "rejected_count": 1 },
+          "notebook_edit_tool": { "accepted_count": 0, "rejected_count": 0 }
         }
       },
       "web_search_count": 2,
       "office_metrics": {
-        "excel": {
-          "distinct_session_count": 2,
-          "message_count": 8,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        },
-        "powerpoint": {
-          "distinct_session_count": 0,
-          "message_count": 0,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        },
-        "word": {
-          "distinct_session_count": 1,
-          "message_count": 3,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        },
-        "outlook": {
-          "distinct_session_count": 0,
-          "message_count": 0,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        }
+        "excel": { "distinct_session_count": 2, "message_count": 8, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
+        "powerpoint": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
+        "word": { "distinct_session_count": 1, "message_count": 3, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
+        "outlook": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 }
       },
       "cowork_metrics": {
-        "distinct_session_count": 0,
-        "message_count": 0,
-        "action_count": 0,
-        "dispatch_turn_count": 0,
-        "skills_used_count": 0,
-        "distinct_skills_used_count": 0,
-        "connectors_used_count": 0,
-        "distinct_connectors_used_count": 0,
-        "distinct_plugins_used_count": 0,
-        "edit_tool_count": 0,
-        "file_edit_count": 0,
-        "multi_edit_tool_count": 0,
-        "notebook_edit_tool_count": 0,
-        "plugins_used_count": 0,
-        "sessions_with_file_edits_count": 0,
-        "write_tool_count": 0
+        "distinct_session_count": 0, "message_count": 0, "action_count": 0,
+        "dispatch_turn_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0,
+        "connectors_used_count": 0, "distinct_connectors_used_count": 0,
+        "distinct_plugins_used_count": 0, "edit_tool_count": 0, "file_edit_count": 0,
+        "multi_edit_tool_count": 0, "notebook_edit_tool_count": 0, "plugins_used_count": 0,
+        "sessions_with_file_edits_count": 0, "write_tool_count": 0
       },
       "design_metrics": {
-        "distinct_projects_created_count": 0,
-        "distinct_projects_used_count": 0,
-        "distinct_session_count": 0,
-        "message_count": 0
+        "distinct_projects_created_count": 0, "distinct_projects_used_count": 0,
+        "distinct_session_count": 0, "message_count": 0
       },
       "science_metrics": {
-        "delegation_count": 0,
-        "distinct_session_count": 0,
-        "message_count": 0,
-        "remote_compute_job_count": 0,
-        "skills_used_count": 0
-      }
+        "delegation_count": 0, "distinct_session_count": 0, "message_count": 0,
+        "remote_compute_job_count": 0, "skills_used_count": 0
+      },
+      "distinct_user_count": null,
+      "last_activity_date": "2026-06-01",
+      "rbac_group_id": "rbac_group_abc123",
+      "rbac_group_name": "Engineering"
     },
     {
-      "user": {
-        "id": "t~rUNP43joGY2IUQzpGJcOH7nY9pzIOXRLPOKi_PdHieA",
-        "email_address": "t~PFsxS8oxlBJ9dZkL1zNMvRIajvbO3VzZpbdT-ty6Gm0@example.com"
-      },
+      "user": { "id": "user_def456", "email_address": "bob@example.com" },
       "chat_metrics": {
-        "distinct_conversation_count": 2,
-        "message_count": 10,
-        "distinct_projects_created_count": 0,
-        "distinct_projects_used_count": 1,
-        "distinct_files_uploaded_count": 0,
-        "distinct_artifacts_created_count": 0,
-        "distinct_shared_artifacts_viewed_count": 0,
-        "thinking_message_count": 0,
-        "distinct_skills_used_count": 0,
-        "connectors_used_count": 0,
+        "distinct_conversation_count": 2, "message_count": 10, "distinct_projects_created_count": 0,
+        "distinct_projects_used_count": 1, "distinct_files_uploaded_count": 0,
+        "distinct_artifacts_created_count": 0, "distinct_shared_artifacts_viewed_count": 0,
+        "thinking_message_count": 0, "distinct_skills_used_count": 0,
+        "connectors_used_count": 0, "distinct_connectors_used_count": 0,
         "shared_conversations_viewed_count": 0
       },
       "claude_code_metrics": {
         "core_metrics": {
-          "commit_count": 0,
-          "pull_request_count": 0,
-          "lines_of_code": {
-            "added_count": 0,
-            "removed_count": 0
-          },
+          "commit_count": 0, "pull_request_count": 0,
+          "lines_of_code": { "added_count": 0, "removed_count": 0 },
           "distinct_session_count": 0
         },
         "tool_actions": {
-          "edit_tool": {
-            "accepted_count": 0,
-            "rejected_count": 0
-          },
-          "multi_edit_tool": {
-            "accepted_count": 0,
-            "rejected_count": 0
-          },
-          "write_tool": {
-            "accepted_count": 0,
-            "rejected_count": 0
-          },
-          "notebook_edit_tool": {
-            "accepted_count": 0,
-            "rejected_count": 0
-          }
+          "edit_tool": { "accepted_count": 0, "rejected_count": 0 },
+          "multi_edit_tool": { "accepted_count": 0, "rejected_count": 0 },
+          "write_tool": { "accepted_count": 0, "rejected_count": 0 },
+          "notebook_edit_tool": { "accepted_count": 0, "rejected_count": 0 }
         }
       },
       "web_search_count": 0,
       "office_metrics": {
-        "excel": {
-          "distinct_session_count": 0,
-          "message_count": 0,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        },
-        "powerpoint": {
-          "distinct_session_count": 1,
-          "message_count": 4,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        },
-        "word": {
-          "distinct_session_count": 0,
-          "message_count": 0,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        },
-        "outlook": {
-          "distinct_session_count": 0,
-          "message_count": 0,
-          "skills_used_count": 0,
-          "distinct_skills_used_count": 0,
-          "connectors_used_count": 0,
-          "distinct_connectors_used_count": 0
-        }
+        "excel": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
+        "powerpoint": { "distinct_session_count": 1, "message_count": 4, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
+        "word": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
+        "outlook": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 }
       },
       "cowork_metrics": {
-        "distinct_session_count": 0,
-        "message_count": 0,
-        "action_count": 0,
-        "dispatch_turn_count": 0,
-        "skills_used_count": 0,
-        "distinct_skills_used_count": 0,
-        "connectors_used_count": 0,
-        "distinct_connectors_used_count": 0,
-        "distinct_plugins_used_count": 0,
-        "edit_tool_count": 0,
-        "file_edit_count": 0,
-        "multi_edit_tool_count": 0,
-        "notebook_edit_tool_count": 0,
-        "plugins_used_count": 0,
-        "sessions_with_file_edits_count": 0,
-        "write_tool_count": 0
+        "distinct_session_count": 0, "message_count": 0, "action_count": 0,
+        "dispatch_turn_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0,
+        "connectors_used_count": 0, "distinct_connectors_used_count": 0,
+        "distinct_plugins_used_count": 0, "edit_tool_count": 0, "file_edit_count": 0,
+        "multi_edit_tool_count": 0, "notebook_edit_tool_count": 0, "plugins_used_count": 0,
+        "sessions_with_file_edits_count": 0, "write_tool_count": 0
       },
       "design_metrics": {
-        "distinct_projects_created_count": 0,
-        "distinct_projects_used_count": 0,
-        "distinct_session_count": 0,
-        "message_count": 0
+        "distinct_projects_created_count": 0, "distinct_projects_used_count": 0,
+        "distinct_session_count": 0, "message_count": 0
       },
       "science_metrics": {
-        "delegation_count": 0,
-        "distinct_session_count": 0,
-        "message_count": 0,
-        "remote_compute_job_count": 0,
-        "skills_used_count": 0
-      }
+        "delegation_count": 0, "distinct_session_count": 0, "message_count": 0,
+        "remote_compute_job_count": 0, "skills_used_count": 0
+      },
+      "distinct_user_count": null,
+      "last_activity_date": null,
+      "rbac_group_id": null,
+      "rbac_group_name": null
     }
   ],
   "next_page": "cursor_token_abc"

--- a/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/original/users.json
+++ b/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/original/users.json
@@ -1,8 +1,10 @@
 {
   "data": [
     {
-      "user": { "id": "user_abc123", "email_address": "alice@example.com" },
-      "date": "2026-06-01",
+      "user": {
+        "id": "t~Wd2U4lmivWESn4fNgZWtjnW3j4TXciQNif50hO_QMVM",
+        "email_address": "t~knxWE5tapsutcz6pLWSC3wfb5t34lCrXNZsKnhwyVXk@example.com"
+      },
       "chat_metrics": {
         "distinct_conversation_count": 5,
         "message_count": 42,
@@ -20,63 +22,210 @@
         "core_metrics": {
           "commit_count": 3,
           "pull_request_count": 1,
-          "lines_of_code": { "added_count": 120, "removed_count": 45 },
+          "lines_of_code": {
+            "added_count": 120,
+            "removed_count": 45
+          },
           "distinct_session_count": 4
         },
         "tool_actions": {
-          "edit_tool": { "accepted": 10, "rejected": 2 },
-          "multi_edit_tool": { "accepted": 3, "rejected": 0 },
-          "write_tool": { "accepted": 5, "rejected": 1 },
-          "notebook_edit_tool": { "accepted": 0, "rejected": 0 }
+          "edit_tool": {
+            "accepted_count": 10,
+            "rejected_count": 2
+          },
+          "multi_edit_tool": {
+            "accepted_count": 3,
+            "rejected_count": 0
+          },
+          "write_tool": {
+            "accepted_count": 5,
+            "rejected_count": 1
+          },
+          "notebook_edit_tool": {
+            "accepted_count": 0,
+            "rejected_count": 0
+          }
         }
       },
       "web_search_count": 2,
       "office_metrics": {
-        "excel": { "distinct_session_count": 2, "message_count": 8, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
-        "powerpoint": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
-        "word": { "distinct_session_count": 1, "message_count": 3, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
-        "outlook": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 }
+        "excel": {
+          "distinct_session_count": 2,
+          "message_count": 8,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        },
+        "powerpoint": {
+          "distinct_session_count": 0,
+          "message_count": 0,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        },
+        "word": {
+          "distinct_session_count": 1,
+          "message_count": 3,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        },
+        "outlook": {
+          "distinct_session_count": 0,
+          "message_count": 0,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        }
       },
       "cowork_metrics": {
-        "distinct_session_count": 0, "message_count": 0, "action_count": 0,
-        "dispatch_turn_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0,
-        "connectors_used_count": 0, "distinct_connectors_used_count": 0
+        "distinct_session_count": 0,
+        "message_count": 0,
+        "action_count": 0,
+        "dispatch_turn_count": 0,
+        "skills_used_count": 0,
+        "distinct_skills_used_count": 0,
+        "connectors_used_count": 0,
+        "distinct_connectors_used_count": 0,
+        "distinct_plugins_used_count": 0,
+        "edit_tool_count": 0,
+        "file_edit_count": 0,
+        "multi_edit_tool_count": 0,
+        "notebook_edit_tool_count": 0,
+        "plugins_used_count": 0,
+        "sessions_with_file_edits_count": 0,
+        "write_tool_count": 0
+      },
+      "design_metrics": {
+        "distinct_projects_created_count": 0,
+        "distinct_projects_used_count": 0,
+        "distinct_session_count": 0,
+        "message_count": 0
+      },
+      "science_metrics": {
+        "delegation_count": 0,
+        "distinct_session_count": 0,
+        "message_count": 0,
+        "remote_compute_job_count": 0,
+        "skills_used_count": 0
       }
     },
     {
-      "user": { "id": "user_def456", "email_address": "bob@example.com" },
-      "date": "2026-06-01",
+      "user": {
+        "id": "t~rUNP43joGY2IUQzpGJcOH7nY9pzIOXRLPOKi_PdHieA",
+        "email_address": "t~PFsxS8oxlBJ9dZkL1zNMvRIajvbO3VzZpbdT-ty6Gm0@example.com"
+      },
       "chat_metrics": {
-        "distinct_conversation_count": 2, "message_count": 10, "distinct_projects_created_count": 0,
-        "distinct_projects_used_count": 1, "distinct_files_uploaded_count": 0,
-        "distinct_artifacts_created_count": 0, "distinct_shared_artifacts_viewed_count": 0,
-        "thinking_message_count": 0, "distinct_skills_used_count": 0,
-        "connectors_used_count": 0, "shared_conversations_viewed_count": 0
+        "distinct_conversation_count": 2,
+        "message_count": 10,
+        "distinct_projects_created_count": 0,
+        "distinct_projects_used_count": 1,
+        "distinct_files_uploaded_count": 0,
+        "distinct_artifacts_created_count": 0,
+        "distinct_shared_artifacts_viewed_count": 0,
+        "thinking_message_count": 0,
+        "distinct_skills_used_count": 0,
+        "connectors_used_count": 0,
+        "shared_conversations_viewed_count": 0
       },
       "claude_code_metrics": {
         "core_metrics": {
-          "commit_count": 0, "pull_request_count": 0,
-          "lines_of_code": { "added_count": 0, "removed_count": 0 },
+          "commit_count": 0,
+          "pull_request_count": 0,
+          "lines_of_code": {
+            "added_count": 0,
+            "removed_count": 0
+          },
           "distinct_session_count": 0
         },
         "tool_actions": {
-          "edit_tool": { "accepted": 0, "rejected": 0 },
-          "multi_edit_tool": { "accepted": 0, "rejected": 0 },
-          "write_tool": { "accepted": 0, "rejected": 0 },
-          "notebook_edit_tool": { "accepted": 0, "rejected": 0 }
+          "edit_tool": {
+            "accepted_count": 0,
+            "rejected_count": 0
+          },
+          "multi_edit_tool": {
+            "accepted_count": 0,
+            "rejected_count": 0
+          },
+          "write_tool": {
+            "accepted_count": 0,
+            "rejected_count": 0
+          },
+          "notebook_edit_tool": {
+            "accepted_count": 0,
+            "rejected_count": 0
+          }
         }
       },
       "web_search_count": 0,
       "office_metrics": {
-        "excel": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
-        "powerpoint": { "distinct_session_count": 1, "message_count": 4, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
-        "word": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 },
-        "outlook": { "distinct_session_count": 0, "message_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0, "connectors_used_count": 0, "distinct_connectors_used_count": 0 }
+        "excel": {
+          "distinct_session_count": 0,
+          "message_count": 0,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        },
+        "powerpoint": {
+          "distinct_session_count": 1,
+          "message_count": 4,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        },
+        "word": {
+          "distinct_session_count": 0,
+          "message_count": 0,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        },
+        "outlook": {
+          "distinct_session_count": 0,
+          "message_count": 0,
+          "skills_used_count": 0,
+          "distinct_skills_used_count": 0,
+          "connectors_used_count": 0,
+          "distinct_connectors_used_count": 0
+        }
       },
       "cowork_metrics": {
-        "distinct_session_count": 0, "message_count": 0, "action_count": 0,
-        "dispatch_turn_count": 0, "skills_used_count": 0, "distinct_skills_used_count": 0,
-        "connectors_used_count": 0, "distinct_connectors_used_count": 0
+        "distinct_session_count": 0,
+        "message_count": 0,
+        "action_count": 0,
+        "dispatch_turn_count": 0,
+        "skills_used_count": 0,
+        "distinct_skills_used_count": 0,
+        "connectors_used_count": 0,
+        "distinct_connectors_used_count": 0,
+        "distinct_plugins_used_count": 0,
+        "edit_tool_count": 0,
+        "file_edit_count": 0,
+        "multi_edit_tool_count": 0,
+        "notebook_edit_tool_count": 0,
+        "plugins_used_count": 0,
+        "sessions_with_file_edits_count": 0,
+        "write_tool_count": 0
+      },
+      "design_metrics": {
+        "distinct_projects_created_count": 0,
+        "distinct_projects_used_count": 0,
+        "distinct_session_count": 0,
+        "message_count": 0
+      },
+      "science_metrics": {
+        "delegation_count": 0,
+        "distinct_session_count": 0,
+        "message_count": 0,
+        "remote_compute_job_count": 0,
+        "skills_used_count": 0
       }
     }
   ],

--- a/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/sanitized/users.json
+++ b/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/sanitized/users.json
@@ -2,10 +2,9 @@
   "data":[
     {
       "user":{
-        "id":"t~Wd2U4lmivWESn4fNgZWtjnW3j4TXciQNif50hO_QMVM",
-        "email_address":"t~knxWE5tapsutcz6pLWSC3wfb5t34lCrXNZsKnhwyVXk@example.com"
+        "id":"t~qFnFEOaoBWsR-lekuUE6S6ctlJNemXLpS_nmVApKoUo",
+        "email_address":"t~zujbdRSV4D7ir226W9xCgPFWN4wxPRPaztX6Ggvwdr4@example.com"
       },
-      "date":"2026-06-01",
       "chat_metrics":{
         "distinct_conversation_count":5,
         "message_count":42,
@@ -31,20 +30,20 @@
         },
         "tool_actions":{
           "edit_tool":{
-            "accepted":10,
-            "rejected":2
+            "accepted_count":10,
+            "rejected_count":2
           },
           "multi_edit_tool":{
-            "accepted":3,
-            "rejected":0
+            "accepted_count":3,
+            "rejected_count":0
           },
           "write_tool":{
-            "accepted":5,
-            "rejected":1
+            "accepted_count":5,
+            "rejected_count":1
           },
           "notebook_edit_tool":{
-            "accepted":0,
-            "rejected":0
+            "accepted_count":0,
+            "rejected_count":0
           }
         }
       },
@@ -91,15 +90,35 @@
         "skills_used_count":0,
         "distinct_skills_used_count":0,
         "connectors_used_count":0,
-        "distinct_connectors_used_count":0
+        "distinct_connectors_used_count":0,
+        "distinct_plugins_used_count":0,
+        "edit_tool_count":0,
+        "file_edit_count":0,
+        "multi_edit_tool_count":0,
+        "notebook_edit_tool_count":0,
+        "plugins_used_count":0,
+        "sessions_with_file_edits_count":0,
+        "write_tool_count":0
+      },
+      "design_metrics":{
+        "distinct_projects_created_count":0,
+        "distinct_projects_used_count":0,
+        "distinct_session_count":0,
+        "message_count":0
+      },
+      "science_metrics":{
+        "delegation_count":0,
+        "distinct_session_count":0,
+        "message_count":0,
+        "remote_compute_job_count":0,
+        "skills_used_count":0
       }
     },
     {
       "user":{
-        "id":"t~rUNP43joGY2IUQzpGJcOH7nY9pzIOXRLPOKi_PdHieA",
-        "email_address":"t~PFsxS8oxlBJ9dZkL1zNMvRIajvbO3VzZpbdT-ty6Gm0@example.com"
+        "id":"t~ip33sD9DvRLmyuW2WJI8mH7kjgWZziny4Ngo3J1uoXE",
+        "email_address":"t~u2XaNryhHo82tTI1r6Ug-xqLIwsi68Naen7ZK4B60hE@example.com"
       },
-      "date":"2026-06-01",
       "chat_metrics":{
         "distinct_conversation_count":2,
         "message_count":10,
@@ -125,20 +144,20 @@
         },
         "tool_actions":{
           "edit_tool":{
-            "accepted":0,
-            "rejected":0
+            "accepted_count":0,
+            "rejected_count":0
           },
           "multi_edit_tool":{
-            "accepted":0,
-            "rejected":0
+            "accepted_count":0,
+            "rejected_count":0
           },
           "write_tool":{
-            "accepted":0,
-            "rejected":0
+            "accepted_count":0,
+            "rejected_count":0
           },
           "notebook_edit_tool":{
-            "accepted":0,
-            "rejected":0
+            "accepted_count":0,
+            "rejected_count":0
           }
         }
       },
@@ -185,7 +204,28 @@
         "skills_used_count":0,
         "distinct_skills_used_count":0,
         "connectors_used_count":0,
-        "distinct_connectors_used_count":0
+        "distinct_connectors_used_count":0,
+        "distinct_plugins_used_count":0,
+        "edit_tool_count":0,
+        "file_edit_count":0,
+        "multi_edit_tool_count":0,
+        "notebook_edit_tool_count":0,
+        "plugins_used_count":0,
+        "sessions_with_file_edits_count":0,
+        "write_tool_count":0
+      },
+      "design_metrics":{
+        "distinct_projects_created_count":0,
+        "distinct_projects_used_count":0,
+        "distinct_session_count":0,
+        "message_count":0
+      },
+      "science_metrics":{
+        "delegation_count":0,
+        "distinct_session_count":0,
+        "message_count":0,
+        "remote_compute_job_count":0,
+        "skills_used_count":0
       }
     }
   ],

--- a/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/sanitized/users.json
+++ b/docs/sources/anthropic/claude-enterprise-analytics/example-api-responses/sanitized/users.json
@@ -2,8 +2,8 @@
   "data":[
     {
       "user":{
-        "id":"t~qFnFEOaoBWsR-lekuUE6S6ctlJNemXLpS_nmVApKoUo",
-        "email_address":"t~zujbdRSV4D7ir226W9xCgPFWN4wxPRPaztX6Ggvwdr4@example.com"
+        "id":"t~Wd2U4lmivWESn4fNgZWtjnW3j4TXciQNif50hO_QMVM",
+        "email_address":"t~knxWE5tapsutcz6pLWSC3wfb5t34lCrXNZsKnhwyVXk@example.com"
       },
       "chat_metrics":{
         "distinct_conversation_count":5,
@@ -16,6 +16,7 @@
         "thinking_message_count":0,
         "distinct_skills_used_count":2,
         "connectors_used_count":1,
+        "distinct_connectors_used_count":1,
         "shared_conversations_viewed_count":0
       },
       "claude_code_metrics":{
@@ -112,12 +113,16 @@
         "message_count":0,
         "remote_compute_job_count":0,
         "skills_used_count":0
-      }
+      },
+      "distinct_user_count":null,
+      "last_activity_date":"2026-06-01",
+      "rbac_group_id":"rbac_group_abc123",
+      "rbac_group_name":"Engineering"
     },
     {
       "user":{
-        "id":"t~ip33sD9DvRLmyuW2WJI8mH7kjgWZziny4Ngo3J1uoXE",
-        "email_address":"t~u2XaNryhHo82tTI1r6Ug-xqLIwsi68Naen7ZK4B60hE@example.com"
+        "id":"t~rUNP43joGY2IUQzpGJcOH7nY9pzIOXRLPOKi_PdHieA",
+        "email_address":"t~PFsxS8oxlBJ9dZkL1zNMvRIajvbO3VzZpbdT-ty6Gm0@example.com"
       },
       "chat_metrics":{
         "distinct_conversation_count":2,
@@ -130,6 +135,7 @@
         "thinking_message_count":0,
         "distinct_skills_used_count":0,
         "connectors_used_count":0,
+        "distinct_connectors_used_count":0,
         "shared_conversations_viewed_count":0
       },
       "claude_code_metrics":{
@@ -226,7 +232,11 @@
         "message_count":0,
         "remote_compute_job_count":0,
         "skills_used_count":0
-      }
+      },
+      "distinct_user_count":null,
+      "last_activity_date":null,
+      "rbac_group_id":null,
+      "rbac_group_name":null
     }
   ],
   "next_page":"cursor_token_abc"

--- a/docs/sources/anthropic/claude/claude.yaml
+++ b/docs/sources/anthropic/claude/claude.yaml
@@ -513,8 +513,6 @@ endpoints:
           type: "string"
         name:
           type: "string"
-        organization_id:
-          type: "string"
         organization_uuid:
           type: "string"
         project_id:
@@ -727,8 +725,6 @@ definitions:
       model:
         type: "string"
       name:
-        type: "string"
-      organization_id:
         type: "string"
       organization_uuid:
         type: "string"

--- a/docs/sources/anthropic/claude/example-api-responses/sanitized/chat-messages-response.json
+++ b/docs/sources/anthropic/claude/example-api-responses/sanitized/chat-messages-response.json
@@ -1,55 +1,54 @@
 {
-  "id":"claude_chat_abc123",
-  "name":"{\"length\":31,\"word_count\":3}",
-  "created_at":"2025-06-07T08:09:10Z",
-  "updated_at":"2025-06-07T08:09:11Z",
-  "organization_id":"org_abc123",
-  "organization_uuid":"abcdef0123-4567-89ab-cdef-0123456789ab",
-  "project_id":"claude_proj_xyz789",
-  "model":"claude-opus-4-7",
-  "user":{
-    "id":"t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
-    "email_address":"t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
+  "id": "claude_chat_abc123",
+  "name": "{\"length\":31,\"word_count\":3}",
+  "created_at": "2025-06-07T08:09:10Z",
+  "updated_at": "2025-06-07T08:09:11Z",
+  "organization_uuid": "abcdef0123-4567-89ab-cdef-0123456789ab",
+  "project_id": "claude_proj_xyz789",
+  "model": "claude-opus-4-7",
+  "user": {
+    "id": "t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
+    "email_address": "t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
   },
-  "chat_messages":[
+  "chat_messages": [
     {
-      "id":"claude_chat_msg_abc123",
-      "role":"user",
-      "created_at":"2025-06-07T08:09:10Z",
-      "content":[
+      "id": "claude_chat_msg_abc123",
+      "role": "user",
+      "created_at": "2025-06-07T08:09:10Z",
+      "content": [
         {
-          "type":"text",
-          "text":"{\"keywords\":{\"draft\":1},\"length\":65,\"word_count\":11}"
+          "type": "text",
+          "text": "{\"keywords\":{\"draft\":1},\"length\":65,\"word_count\":11}"
         }
       ],
-      "files":[
+      "files": [
         {
-          "id":"claude_file_xyz789",
-          "mime_type":"application/pdf"
+          "id": "claude_file_xyz789",
+          "mime_type": "application/pdf"
         }
       ]
     },
     {
-      "id":"claude_chat_msg_def456",
-      "role":"assistant",
-      "created_at":"2025-06-07T08:09:11Z",
-      "content":[
+      "id": "claude_chat_msg_def456",
+      "role": "assistant",
+      "created_at": "2025-06-07T08:09:11Z",
+      "content": [
         {
-          "type":"text",
-          "text":"{\"keywords\":{\"draft\":1},\"length\":73,\"word_count\":12}"
+          "type": "text",
+          "text": "{\"keywords\":{\"draft\":1},\"length\":73,\"word_count\":12}"
         }
       ],
-      "artifacts":[
+      "artifacts": [
         {
-          "id":"claude_artifact_abc123",
-          "version_id":"claude_artifact_version_xyz789",
-          "title":"{\"keywords\":{\"draft\":1},\"length\":28,\"word_count\":3}",
-          "artifact_type":"text/markdown"
+          "id": "claude_artifact_abc123",
+          "version_id": "claude_artifact_version_xyz789",
+          "title": "{\"keywords\":{\"draft\":1},\"length\":28,\"word_count\":3}",
+          "artifact_type": "text/markdown"
         }
       ]
     }
   ],
-  "has_more":false,
-  "first_id":"eyJtc2dfdXVpZCI6ICIwZjcwYjA2Ni0uLi4ifQ==",
-  "last_id":"eyJtc2dfdXVpZCI6ICJhNGUwYjE3Mi0uLi4ifQ=="
+  "has_more": false,
+  "first_id": "eyJtc2dfdXVpZCI6ICIwZjcwYjA2Ni0uLi4ifQ==",
+  "last_id": "eyJtc2dfdXVpZCI6ICJhNGUwYjE3Mi0uLi4ifQ=="
 }

--- a/docs/sources/anthropic/claude/example-api-responses/sanitized/chat-messages-response.json
+++ b/docs/sources/anthropic/claude/example-api-responses/sanitized/chat-messages-response.json
@@ -1,54 +1,54 @@
 {
-  "id": "claude_chat_abc123",
-  "name": "{\"length\":31,\"word_count\":3}",
-  "created_at": "2025-06-07T08:09:10Z",
-  "updated_at": "2025-06-07T08:09:11Z",
-  "organization_uuid": "abcdef0123-4567-89ab-cdef-0123456789ab",
-  "project_id": "claude_proj_xyz789",
-  "model": "claude-opus-4-7",
-  "user": {
-    "id": "t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
-    "email_address": "t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
+  "id":"claude_chat_abc123",
+  "name":"{\"length\":31,\"word_count\":3}",
+  "created_at":"2025-06-07T08:09:10Z",
+  "updated_at":"2025-06-07T08:09:11Z",
+  "organization_uuid":"abcdef0123-4567-89ab-cdef-0123456789ab",
+  "project_id":"claude_proj_xyz789",
+  "model":"claude-opus-4-7",
+  "user":{
+    "id":"t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
+    "email_address":"t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
   },
-  "chat_messages": [
+  "chat_messages":[
     {
-      "id": "claude_chat_msg_abc123",
-      "role": "user",
-      "created_at": "2025-06-07T08:09:10Z",
-      "content": [
+      "id":"claude_chat_msg_abc123",
+      "role":"user",
+      "created_at":"2025-06-07T08:09:10Z",
+      "content":[
         {
-          "type": "text",
-          "text": "{\"keywords\":{\"draft\":1},\"length\":65,\"word_count\":11}"
+          "type":"text",
+          "text":"{\"keywords\":{\"draft\":1},\"length\":65,\"word_count\":11}"
         }
       ],
-      "files": [
+      "files":[
         {
-          "id": "claude_file_xyz789",
-          "mime_type": "application/pdf"
+          "id":"claude_file_xyz789",
+          "mime_type":"application/pdf"
         }
       ]
     },
     {
-      "id": "claude_chat_msg_def456",
-      "role": "assistant",
-      "created_at": "2025-06-07T08:09:11Z",
-      "content": [
+      "id":"claude_chat_msg_def456",
+      "role":"assistant",
+      "created_at":"2025-06-07T08:09:11Z",
+      "content":[
         {
-          "type": "text",
-          "text": "{\"keywords\":{\"draft\":1},\"length\":73,\"word_count\":12}"
+          "type":"text",
+          "text":"{\"keywords\":{\"draft\":1},\"length\":73,\"word_count\":12}"
         }
       ],
-      "artifacts": [
+      "artifacts":[
         {
-          "id": "claude_artifact_abc123",
-          "version_id": "claude_artifact_version_xyz789",
-          "title": "{\"keywords\":{\"draft\":1},\"length\":28,\"word_count\":3}",
-          "artifact_type": "text/markdown"
+          "id":"claude_artifact_abc123",
+          "version_id":"claude_artifact_version_xyz789",
+          "title":"{\"keywords\":{\"draft\":1},\"length\":28,\"word_count\":3}",
+          "artifact_type":"text/markdown"
         }
       ]
     }
   ],
-  "has_more": false,
-  "first_id": "eyJtc2dfdXVpZCI6ICIwZjcwYjA2Ni0uLi4ifQ==",
-  "last_id": "eyJtc2dfdXVpZCI6ICJhNGUwYjE3Mi0uLi4ifQ=="
+  "has_more":false,
+  "first_id":"eyJtc2dfdXVpZCI6ICIwZjcwYjA2Ni0uLi4ifQ==",
+  "last_id":"eyJtc2dfdXVpZCI6ICJhNGUwYjE3Mi0uLi4ifQ=="
 }

--- a/docs/sources/anthropic/claude/example-api-responses/sanitized/chats-response.json
+++ b/docs/sources/anthropic/claude/example-api-responses/sanitized/chats-response.json
@@ -1,20 +1,20 @@
 {
-  "data": [
+  "data":[
     {
-      "id": "claude_chat_abc123",
-      "name": "{\"length\":31,\"word_count\":3}",
-      "created_at": "2025-06-07T08:09:10Z",
-      "updated_at": "2025-06-07T09:10:11Z",
-      "deleted_at": null,
-      "organization_uuid": "abcdef0123-4567-89ab-cdef-0123456789ab",
-      "project_id": "claude_proj_xyz789",
-      "user": {
-        "id": "t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
-        "email_address": "t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
+      "id":"claude_chat_abc123",
+      "name":"{\"length\":31,\"word_count\":3}",
+      "created_at":"2025-06-07T08:09:10Z",
+      "updated_at":"2025-06-07T09:10:11Z",
+      "deleted_at":null,
+      "organization_uuid":"abcdef0123-4567-89ab-cdef-0123456789ab",
+      "project_id":"claude_proj_xyz789",
+      "user":{
+        "id":"t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
+        "email_address":"t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
       }
     }
   ],
-  "has_more": false,
-  "first_id": "claude_chat_abc123",
-  "last_id": "claude_chat_abc123"
+  "has_more":false,
+  "first_id":"claude_chat_abc123",
+  "last_id":"claude_chat_abc123"
 }

--- a/docs/sources/anthropic/claude/example-api-responses/sanitized/chats-response.json
+++ b/docs/sources/anthropic/claude/example-api-responses/sanitized/chats-response.json
@@ -1,21 +1,20 @@
 {
-  "data":[
+  "data": [
     {
-      "id":"claude_chat_abc123",
-      "name":"{\"length\":31,\"word_count\":3}",
-      "created_at":"2025-06-07T08:09:10Z",
-      "updated_at":"2025-06-07T09:10:11Z",
-      "deleted_at":null,
-      "organization_id":"org_abc123",
-      "organization_uuid":"abcdef0123-4567-89ab-cdef-0123456789ab",
-      "project_id":"claude_proj_xyz789",
-      "user":{
-        "id":"t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
-        "email_address":"t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
+      "id": "claude_chat_abc123",
+      "name": "{\"length\":31,\"word_count\":3}",
+      "created_at": "2025-06-07T08:09:10Z",
+      "updated_at": "2025-06-07T09:10:11Z",
+      "deleted_at": null,
+      "organization_uuid": "abcdef0123-4567-89ab-cdef-0123456789ab",
+      "project_id": "claude_proj_xyz789",
+      "user": {
+        "id": "t~hzNx42jBr-4nE9px0Ear3NuRyZW9y0_o7pegL6tNN-Y",
+        "email_address": "t~_Mqo2yH0QgDytVpmJhxPaE36fR9YYF4mJyAMtmlLUAY@example.com"
       }
     }
   ],
-  "has_more":false,
-  "first_id":"claude_chat_abc123",
-  "last_id":"claude_chat_abc123"
+  "has_more": false,
+  "first_id": "claude_chat_abc123",
+  "last_id": "claude_chat_abc123"
 }


### PR DESCRIPTION
Rules updated for Claude and Claude Enterprise Analytics:
- Claude: from https://github.com/Worklytics/evalengin/pull/8799, just dropping a field in the schema which is marked as deprecated
- Claude Enterprise Analytics: fixing some mapping and adding new fields that we don't have

### Fixes
[Psoxy updated](https://app.asana.com/1/27145998307022/task/1216231387486074)

### Features
> paste links to issues/tasks in project management
 - []()

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216231387486074