### PR TITLE
GCP support for application load balancer in front of API connector deployments

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -52,6 +52,7 @@
   * [HTTP Compression](development/compression.md)
   * [Java Annotation Proccessing](development/intellij.md)
   * [Releases](development/releases.md)
+  * [GCP External ALB + Cloud Armor](development/gcp-external-alb.md)
   * [Alpha Features](development/alpha-features/README.md)
     * [Webhook Collectors](development/alpha-features/webhook-collectors.md)
 * [Data Sources](sources/README.md)

--- a/docs/configuration/ip-allowlisting.md
+++ b/docs/configuration/ip-allowlisting.md
@@ -28,7 +28,11 @@ On **AWS**, both layers apply when you set the Terraform variables: callers must
 
 On **GCP**, only the **application layer** is enforced by the shipped Terraform. Cloud Run IAM conditions do not support source-IP checks on `roles/run.invoker`, and GCS bucket IAM does not support the `inIpRange` patterns used on AWS. The proxy reads allowlists from environment variables set at deploy time.
 
-For **additional** network ingress restriction on GCP (outside the proxy process), you can attach [Cloud Armor](https://cloud.google.com/run/docs/securing/cloud-armor) in front of a load balancer — see [GCP Private Service Connect and connectivity options](../development/gcp-private-service-connect.md#enhancing-public-internet-options-with-ip-allowlisting). That is separate from the `allowed_*_ip_blocks` Terraform variables.
+For **additional** network ingress restriction on GCP (outside the proxy process), you can attach [Cloud Armor](https://cloud.google.com/run/docs/securing/cloud-armor) in front of a load balancer.
+
+The example GCP root can compose a global external ALB + Cloud Armor policy that uses the same `allowed_data_access_ip_blocks` list, while `api_connector_external_lb_host` tells `gcp-host` to publish ALB URLs and set `ALLOW_INTERNAL_AND_GCLB` (beta; see [GCP External ALB + Cloud Armor](../development/gcp-external-alb.md) and the commented section in `infra/examples-dev/gcp/networking.tf`). That path is compositional (not provisioned inside `gcp-host` today).
+
+Related design notes: [GCP Private Service Connect and connectivity options](../development/gcp-private-service-connect.md#enhancing-public-internet-options-with-ip-allowlisting).
 
 ## AWS infrastructure-level detail
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -14,6 +14,7 @@ This directory contains documentation for developers working on or with Psoxy.
 - [Webhook Collectors](webhook-collectors.md) - Webhook collector development
 - [Compression](compression.md) - Data compression handling
 - [GCP Parameter Manager](gcp-parameter-manager.md) - Why GCP Parameter Manager is not used for configuration
+- [GCP External ALB + Cloud Armor](gcp-external-alb.md) - Beta composition pattern for public ALB + IP allowlist (not PSC)
 
 ## Alpha Features
 

--- a/docs/development/gcp-external-alb.md
+++ b/docs/development/gcp-external-alb.md
@@ -1,0 +1,89 @@
+# GCP External ALB + Cloud Armor (TLS + IP allowlist)
+
+> **Status**: Beta — composition pattern only; not a first-class module we commit to maintaining in this form
+> **Last Updated**: 2026-07-20
+
+## Motivation
+
+Some customers need Worklytics to reach API connectors over the **public internet** from **static egress IPs** that the customer allowlists, while optionally using VPC egress (Direct VPC + Cloud NAT) for outbound calls to data sources.
+
+This is **not** Private Service Connect / a regional internal load balancer (ILB). An internal ILB is for VPC-private consumers. Worklytics dialing in from the public internet needs a **global external Application Load Balancer** (`EXTERNAL_MANAGED`).
+
+## Connectivity options (summary)
+
+| Architecture | Ingress | TLS | IP restriction | VPC required? |
+|---|---|---|---|---|
+| Default | `*.run.app` | Google-managed | App-layer only (`allowed_data_access_ip_blocks`) | No |
+| **External ALB + Cloud Armor** (this doc) | Global external ALB | Managed domain **or** self-signed PoC | Cloud Armor + app-layer | No (egress VPC optional) |
+| mTLS | External ALB | Mutual TLS | Cloud Armor optional | No |
+| PSC | Internal ILB + service attachment | Private | Inherent | Yes |
+
+See also [GCP Private Service Connect and connectivity options](gcp-private-service-connect.md).
+
+**Do not** use a regional internal LB for Worklytics static-IP egress over the internet.
+
+## Current approach (v0.6.8): customer composition
+
+Psoxy does **not** provision the ALB inside `gcp-host`. Customers (or the example template) own ALB/Cloud Armor Terraform in root `networking.tf`, then tell the modules the LB host.
+
+1. Uncomment / adapt the ALB section in [`infra/examples-dev/gcp/networking.tf`](../../infra/examples-dev/gcp/networking.tf) (syncs to `psoxy-example-gcp`).
+2. Set `allowed_data_access_ip_blocks` to Worklytics egress IPs (same list for Cloud Armor and the proxy).
+3. Pass into `gcp-host`:
+
+```hcl
+api_connector_external_lb_host = var.api_proxy_domain != null ? var.api_proxy_domain : google_compute_global_address.api_proxy[0].address
+```
+
+When `api_connector_external_lb_host` is non-null, `gcp-host`:
+
+- Sets each API connector’s Cloud Functions `ingress_settings` to `ALLOW_INTERNAL_AND_GCLB` (required for external ALB → Cloud Functions; **not** `ALLOW_INTERNAL_ONLY`, which is for PSC).
+- Overrides public `endpoint_url` to `https://<host>/<function-name>/` (with `ALLOW_INTERNAL_AND_GCLB`, that is the internet-reachable path).
+- Passes `external_lb_base_url = https://<host>` into connectors for test-script / TODO generation (deprecated plumbing; prefer lifting tests higher later).
+- Leaves Pub/Sub push endpoints on the Cloud Function `*.run.app` URI.
+- Leaves bulk connectors unchanged.
+
+Worklytics `"Psoxy Base URL"` follows `endpoint_url` via the existing connection module wiring.
+
+### Resource inventory (root composition)
+
+From the commented example / internal PoCs:
+
+- `google_compute_global_address`
+- `google_compute_security_policy` (allow `allowed_data_access_ip_blocks`, default deny)
+- Per connector: serverless NEG + `EXTERNAL_MANAGED` backend service with `security_policy`
+- URL map: path rules `/<function-name>` and `/<function-name>/*`
+- TLS: Certificate Manager (domain) **or** Terraform `tls_*` + `google_compute_ssl_certificate` (PoC on global IP)
+- `google_compute_global_forwarding_rule` on `:443`
+
+Path routing relies on the proxy stripping the function-name prefix via `K_SERVICE` in `CloudFunctionRequest.getPath()`.
+
+### Dual IP allowlist
+
+`allowed_data_access_ip_blocks` does double duty:
+
+1. **Cloud Armor** (network) — customer attaches the same CIDRs in `networking.tf`.
+2. **Psoxy app check** — still set on connectors (covers direct `*.run.app` bypass until ingress is locked down).
+
+### Testing
+
+Generated test scripts use the ALB URL when the host is set. For self-signed PoC (IP host), scripts add `--allow-insecure-tls`. Prefer `--cacert` with the PEM from `external_alb_self_signed_ca_cert` when available. Non-`*.run.app` URLs also need `-f gcp`. See [Psoxy test tool](../guides/psoxy-test-tool.md).
+
+Your caller IP must be in the Cloud Armor allowlist (and usually in `allowed_data_access_ip_blocks`) for local health checks through the ALB.
+
+## Future work: provision ALB inside `gcp-host`
+
+Fold ALB + Cloud Armor provisioning into `gcp-host` (or a submodule it invokes) so customers set a high-level flag/object instead of copying ~300 lines of root Terraform. Left out of 0.6.8 on purpose; composition + `api_connector_external_lb_host` is the interim contract.
+
+Possible future shape (illustrative only):
+
+```hcl
+external_api_alb = {
+  domain = optional(string) # null => self-signed PoC on reserved IP
+}
+```
+
+## Non-goals (this path)
+
+- PSC producer module (internal ILB + `ALLOW_INTERNAL_ONLY`)
+- mTLS on the external ALB (see [gcp-private-service-connect.md](gcp-private-service-connect.md))
+- Provisioning customer VPC inside modules (keep egress compositional via `vpc_config`)

--- a/docs/development/gcp-private-service-connect.md
+++ b/docs/development/gcp-private-service-connect.md
@@ -12,8 +12,11 @@ output. It covers three architectures:
 | Architecture | Transport | Authentication | Applicability |
 |---|---|---|---|
 | **TLS over Public Internet** (current) | Google-managed TLS | GCP IAM | All deployments |
+| **External ALB + Cloud Armor** (beta) | Public external ALB + TLS | GCP IAM + IP allowlist | Worklytics (or similar) with static egress IPs — see [gcp-external-alb.md](gcp-external-alb.md) |
 | **mTLS over Public Internet** (enhanced) | Mutual TLS via External ALB | Client certificate + GCP IAM | Customers requiring transport-layer client auth |
 | **Private Service Connect** (private) | GCP private backbone | GCP IAM | GCP-hosted clients needing private connectivity |
+
+> **External ALB (public) ≠ Internal ILB (PSC).** A regional internal load balancer is for VPC-private / PSC backends (`ingress_settings = ALLOW_INTERNAL_ONLY`). Worklytics reaching the customer over the public internet from static egress IPs needs a **global external** ALB (`ALLOW_INTERNAL_AND_GCLB`). Shared building blocks (serverless NEGs, URL map, path routing by function name) differ in frontend and ingress settings.
 
 **Worklytics** is one such client service. As a GCP-hosted analytics platform, Worklytics can
 leverage these options to reach customer Psoxy instances. The examples throughout this doc use
@@ -41,7 +44,7 @@ For public-internet connectivity (TLS and mTLS), customers can restrict which cl
 
 1. **Application-level (Terraform `allowed_data_access_ip_blocks` / `allowed_webhook_ip_blocks`)** — enforced inside the Cloud Function on each request. This is what the shipped Psoxy GCP modules configure. See [Client IP Allowlisting](../configuration/ip-allowlisting.md).
 
-2. **Network ingress (Cloud Armor)** — optional, separate from the variables above. When the client service dials out from known static egress IPs, you can attach [Cloud Run ingress with Cloud Armor](https://cloud.google.com/run/docs/securing/cloud-armor) in front of a load balancer to block disallowed IPs before traffic reaches Cloud Run:
+2. **Network ingress (Cloud Armor)** — optional. When the client service dials out from known static egress IPs, attach Cloud Armor on an external ALB. A beta composition pattern (root `networking.tf` + `api_connector_external_lb_host`) is documented in [GCP External ALB + Cloud Armor](gcp-external-alb.md). You can also attach [Cloud Run ingress with Cloud Armor](https://cloud.google.com/run/docs/securing/cloud-armor) manually:
 
 Some client services (including Worklytics, as a paid feature) support dialing out from a
 determined set of static egress IPs. Cloud Armor adds a network-layer control even without PSC or VPC:

--- a/docs/gcp/README.md
+++ b/docs/gcp/README.md
@@ -4,4 +4,7 @@
 
 - [Getting Started](getting-started.md)
 - [Authentication & Authorization](authentication-authorization.md)
+- [VPC (egress)](vpc.md)
 - [Troubleshooting](troubleshooting.md)
+
+Related (development / beta): [External ALB + Cloud Armor](../development/gcp-external-alb.md)

--- a/docs/gcp/authentication-authorization.md
+++ b/docs/gcp/authentication-authorization.md
@@ -22,6 +22,6 @@ When `allowed_data_access_ip_blocks` or `allowed_webhook_ip_blocks` is set in Te
 
 Worklytics can ensure fixed egress IP addresses for outbound requests from your tenant as a paid add-on. Contact [sales@worklytics.co](mailto:sales@worklytics.co) for details.
 
-For network ingress filtering in front of Cloud Run (for example Cloud Armor on a load balancer), see [GCP Private Service Connect and connectivity options](../development/gcp-private-service-connect.md#enhancing-public-internet-options-with-ip-allowlisting). That is separate from the Terraform allowlist variables.
+For network ingress filtering in front of Cloud Run (for example Cloud Armor on a load balancer), see [GCP External ALB + Cloud Armor](../development/gcp-external-alb.md) (beta composition) and [GCP Private Service Connect and connectivity options](../development/gcp-private-service-connect.md#enhancing-public-internet-options-with-ip-allowlisting).
 
 See [Client IP Allowlisting](../configuration/ip-allowlisting.md).

--- a/docs/gcp/vpc.md
+++ b/docs/gcp/vpc.md
@@ -1,9 +1,11 @@
 
 # VPC ***beta***
 
-As of v0.5.6, GCP-hosted proxy instances are [Cloud Run Functions](https://cloud.google.com/run/docs/functions/comparison) (gen2). Ingress to the functions is managed by Google and secured by GCP IAM; we do not support VPC-level ingress controls.
+As of v0.5.6, GCP-hosted proxy instances are [Cloud Run Functions](https://cloud.google.com/run/docs/functions/comparison) (gen2).
 
 For **egress**, Psoxy supports [Direct VPC egress](https://cloud.google.com/functions/docs/running/direct-vpc): Cloud Functions attach a network interface directly to your VPC subnet and route outbound traffic through it. This does **not** require a Serverless VPC Access connector.
+
+This document covers **egress** only. For optional **ingress** via a customer-composed external Application Load Balancer + Cloud Armor (beta), see [GCP External ALB + Cloud Armor](../development/gcp-external-alb.md). VPC-level ingress controls are not provided by these modules; default ingress remains Google-managed (`*.run.app`) with GCP IAM.
 
 The legacy `serverless_connector` path remains supported but is deprecated (TODO: remove in 0.7.x).
 

--- a/docs/guides/psoxy-test-tool.md
+++ b/docs/guides/psoxy-test-tool.md
@@ -45,6 +45,19 @@ Outlook Calendar example (token option omitted):
 node cli-call.js -u https://us-central1-acme.cloudfunctions.net/outlook-cal/v1.0/users
 ```
 
+#### External ALB URLs (beta)
+
+When API connectors are fronted by a customer-composed external ALB, test URLs look like `https://<domain-or-ip>/<function-name>/...` rather than `*.run.app`. Use:
+
+- `-f gcp` so the tool treats the host as a GCP-hosted deployment (required when the hostname is not `*.run.app` / `*.cloudfunctions.net`)
+- `--allow-insecure-tls` for PoC self-signed certs on a reserved global IP, **or** `--cacert <path>` to trust the PEM from Terraform output `external_alb_self_signed_ca_cert`
+
+```shell
+node cli-call.js -u https://203.0.113.10/myenv-outlook-cal/ -f gcp --allow-insecure-tls --health-check
+```
+
+Generated test scripts from Terraform add these flags when `api_connector_external_lb_host` is set. Your client IP must be allowlisted in Cloud Armor / `allowed_data_access_ip_blocks` to reach the ALB. See [GCP External ALB + Cloud Armor](../development/gcp-external-alb.md).
+
 (*) You can obtain it by running `gcloud auth print-identity-token` (using [Google Cloud SDK])
 
 ### End-to-End Verification (Webhook Collection)

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -133,20 +133,21 @@ module "psoxy" {
   email_canonicalization          = var.email_canonicalization
   bulk_input_expiration_days      = var.bulk_input_expiration_days
   bulk_sanitized_expiration_days  = var.bulk_sanitized_expiration_days
-  allowed_data_access_ip_blocks   = var.allowed_data_access_ip_blocks
-  allowed_webhook_ip_blocks       = var.allowed_webhook_ip_blocks
-  custom_bulk_connector_rules     = var.custom_bulk_connector_rules
-  custom_bulk_connector_arguments = var.custom_bulk_connector_arguments
-  lookup_tables                   = var.lookup_tables
-  custom_artifacts_bucket_name    = var.custom_artifacts_bucket_name
-  custom_side_outputs             = var.custom_side_outputs
-  todos_as_local_files            = var.todos_as_local_files
-  todo_step                       = local.max_auth_todo_step
-  bucket_force_destroy            = var.bucket_force_destroy
-  tf_gcp_principal_email          = var.gcp_terraform_sa_account_email
-  provision_project_level_iam     = var.provision_project_level_iam
-  bucket_access_logs_destination  = var.bucket_access_logs_destination
-  enable_remote_resources         = true
+  allowed_data_access_ip_blocks    = var.allowed_data_access_ip_blocks
+  allowed_webhook_ip_blocks        = var.allowed_webhook_ip_blocks
+  api_connector_external_lb_host   = var.api_connector_external_lb_host
+  custom_bulk_connector_rules      = var.custom_bulk_connector_rules
+  custom_bulk_connector_arguments  = var.custom_bulk_connector_arguments
+  lookup_tables                    = var.lookup_tables
+  custom_artifacts_bucket_name     = var.custom_artifacts_bucket_name
+  custom_side_outputs              = var.custom_side_outputs
+  todos_as_local_files             = var.todos_as_local_files
+  todo_step                        = local.max_auth_todo_step
+  bucket_force_destroy             = var.bucket_force_destroy
+  tf_gcp_principal_email           = var.gcp_terraform_sa_account_email
+  provision_project_level_iam      = var.provision_project_level_iam
+  bucket_access_logs_destination   = var.bucket_access_logs_destination
+  enable_remote_resources          = true
 }
 
 locals {
@@ -201,7 +202,8 @@ output "path_to_deployment_jar" {
 
 output "api_connector_instances" {
   value = { for k, v in module.psoxy.api_connector_instances : k => merge({
-    endpoint_url = v.endpoint_url
+    endpoint_url         = v.endpoint_url
+    cloud_function_name  = v.cloud_function_name
     }, v.sanitized_bucket != null ? {
     sanitized_bucket = v.sanitized_bucket
     } : {}, {

--- a/infra/examples-dev/gcp/networking.tf
+++ b/infra/examples-dev/gcp/networking.tf
@@ -1,0 +1,364 @@
+# Customer networking (optional): VPC egress and/or external ALB ingress.
+#
+# Status: External ALB + Cloud Armor is beta (composition pattern; not a first-class module). See:
+#   docs/development/gcp-external-alb.md
+#   docs/gcp/vpc.md
+#
+# Uncomment and adapt sections below as needed. By default nothing here is applied.
+# After enabling the ALB section, pass the LB hostname or IP into module.psoxy via
+# `api_connector_external_lb_host` (see main.tf / variables.tf).
+
+# ------------------------------------------------------------------------------
+# VPC egress (optional) — Direct VPC egress for Cloud Functions; outbound via NAT
+# ------------------------------------------------------------------------------
+# Use when data sources must allowlist a fixed egress IP. Then set:
+#   vpc_config = {
+#     network = google_compute_network.vpc.name
+#     subnet  = google_compute_subnetwork.default.name
+#   }
+
+# resource "google_compute_network" "vpc" {
+#   project                 = var.gcp_project_id
+#   name                    = "${var.environment_name}-vpc"
+#   auto_create_subnetworks = false
+#   mtu                     = 1460
+# }
+#
+# resource "google_compute_subnetwork" "default" {
+#   project                  = var.gcp_project_id
+#   name                     = "${var.environment_name}-subnet"
+#   ip_cidr_range            = "10.10.0.0/24"
+#   region                   = var.gcp_region
+#   network                  = google_compute_network.vpc.id
+#   private_ip_google_access = true
+# }
+#
+# resource "google_compute_router" "router" {
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-router"
+#   region  = var.gcp_region
+#   network = google_compute_network.vpc.id
+# }
+#
+# resource "google_compute_router_nat" "nat" {
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-nat"
+#   router  = google_compute_router.router.name
+#   region  = var.gcp_region
+#
+#   nat_ip_allocate_option             = "AUTO_ONLY"
+#   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+#
+#   log_config {
+#     enable = true
+#     filter = "ERRORS_ONLY"
+#   }
+# }
+
+# ------------------------------------------------------------------------------
+# External ALB ingress (optional, beta)
+# ------------------------------------------------------------------------------
+# Worklytics reaches API connectors over the public internet from static egress IPs.
+# Cloud Armor enforces allowed_data_access_ip_blocks at the network layer; pass the
+# same list into module.psoxy for application-layer enforcement.
+#
+# URL map routes /<function-name>/* to each connector; the proxy strips that prefix
+# using K_SERVICE.
+#
+# TLS:
+#   - Production: set api_proxy_domain + DNS A record → Google-managed cert
+#   - PoC: omit domain → self-signed cert with SAN = reserved global IP
+#     (test with psoxy-test --allow-insecure-tls or --cacert)
+#
+# Prerequisites when enabling:
+#   allowed_data_access_ip_blocks = ["<worklytics-egress-ip>/32"]
+#   api_connector_external_lb_host = var.api_proxy_domain != null ? var.api_proxy_domain : google_compute_global_address.api_proxy[0].address
+#
+# Future work: provision this ALB inside gcp-host instead of root composition
+# (see docs/development/gcp-external-alb.md).
+
+# variable "enable_external_api_alb" {
+#   type        = bool
+#   description = "Provision the commented external ALB resources below."
+#   default     = false
+# }
+#
+# variable "api_proxy_domain" {
+#   type        = string
+#   description = "Optional. Google-managed HTTPS when set; self-signed HTTPS on global IP when null (PoC only)."
+#   default     = null
+# }
+#
+# locals {
+#   api_connector_function_names = {
+#     for k, v in module.psoxy.api_connector_instances :
+#     k => v.cloud_function_name
+#   }
+#
+#   external_api_alb_enabled = (
+#     var.enable_external_api_alb
+#     && length(local.api_connector_function_names) > 0
+#     && var.allowed_data_access_ip_blocks != null
+#   )
+#
+#   external_api_alb_managed_https = local.external_api_alb_enabled && var.api_proxy_domain != null
+#   external_api_alb_self_signed   = local.external_api_alb_enabled && var.api_proxy_domain == null
+# }
+#
+# check "external_api_alb_config" {
+#   assert {
+#     condition     = !var.enable_external_api_alb || var.allowed_data_access_ip_blocks != null
+#     error_message = "When enable_external_api_alb is true, set allowed_data_access_ip_blocks (Worklytics static egress IPs, or your own IP for demo)."
+#   }
+# }
+#
+# resource "google_project_service" "certificatemanager" {
+#   count = local.external_api_alb_managed_https ? 1 : 0
+#
+#   project                    = var.gcp_project_id
+#   service                    = "certificatemanager.googleapis.com"
+#   disable_dependent_services = false
+#   disable_on_destroy         = false
+# }
+#
+# resource "google_compute_global_address" "api_proxy" {
+#   count = local.external_api_alb_enabled ? 1 : 0
+#
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-api-alb"
+# }
+#
+# resource "google_compute_security_policy" "worklytics_ingress" {
+#   count = local.external_api_alb_enabled ? 1 : 0
+#
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-worklytics-ingress"
+#
+#   rule {
+#     action   = "allow"
+#     priority = 1000
+#     match {
+#       versioned_expr = "SRC_IPS_V1"
+#       config {
+#         src_ip_ranges = var.allowed_data_access_ip_blocks
+#       }
+#     }
+#     description = "Allow Worklytics static egress IPs"
+#   }
+#
+#   rule {
+#     action   = "deny(403)"
+#     priority = 2147483647
+#     match {
+#       versioned_expr = "SRC_IPS_V1"
+#       config {
+#         src_ip_ranges = ["*"]
+#       }
+#     }
+#     description = "Default deny"
+#   }
+# }
+#
+# resource "google_compute_region_network_endpoint_group" "api_connector" {
+#   for_each = local.external_api_alb_enabled ? local.api_connector_function_names : {}
+#
+#   project               = var.gcp_project_id
+#   name                  = "${each.value}-neg"
+#   region                = var.gcp_region
+#   network_endpoint_type = "SERVERLESS"
+#
+#   cloud_run {
+#     service = each.value
+#   }
+#
+#   depends_on = [module.psoxy]
+# }
+#
+# resource "google_compute_backend_service" "api_connector" {
+#   for_each = local.external_api_alb_enabled ? local.api_connector_function_names : {}
+#
+#   project               = var.gcp_project_id
+#   name                  = "${each.value}-backend"
+#   protocol              = "HTTP"
+#   load_balancing_scheme = "EXTERNAL_MANAGED"
+#   security_policy       = google_compute_security_policy.worklytics_ingress[0].id
+#
+#   backend {
+#     group           = google_compute_region_network_endpoint_group.api_connector[each.key].id
+#     balancing_mode  = "UTILIZATION"
+#     capacity_scaler = 1.0
+#   }
+#
+#   log_config {
+#     enable      = true
+#     sample_rate = 1.0
+#   }
+# }
+#
+# resource "google_compute_url_map" "api_connectors" {
+#   count = local.external_api_alb_enabled ? 1 : 0
+#
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-api-connectors"
+#
+#   default_service = values(google_compute_backend_service.api_connector)[0].id
+#
+#   host_rule {
+#     hosts        = local.external_api_alb_managed_https ? [var.api_proxy_domain] : ["*"]
+#     path_matcher = "api-connectors"
+#   }
+#
+#   path_matcher {
+#     name            = "api-connectors"
+#     default_service = values(google_compute_backend_service.api_connector)[0].id
+#
+#     dynamic "path_rule" {
+#       for_each = local.api_connector_function_names
+#       content {
+#         paths = [
+#           "/${path_rule.value}",
+#           "/${path_rule.value}/*",
+#         ]
+#         service = google_compute_backend_service.api_connector[path_rule.key].id
+#       }
+#     }
+#   }
+# }
+#
+# # Google-managed TLS (production): set api_proxy_domain + DNS A record
+#
+# resource "google_certificate_manager_certificate" "api_proxy" {
+#   count = local.external_api_alb_managed_https ? 1 : 0
+#
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-api-proxy-cert"
+#
+#   managed {
+#     domains = [var.api_proxy_domain]
+#   }
+#
+#   depends_on = [google_project_service.certificatemanager]
+# }
+#
+# resource "google_certificate_manager_certificate_map" "api_proxy" {
+#   count = local.external_api_alb_managed_https ? 1 : 0
+#
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-api-proxy-cert-map"
+# }
+#
+# resource "google_certificate_manager_certificate_map_entry" "api_proxy" {
+#   count = local.external_api_alb_managed_https ? 1 : 0
+#
+#   project      = var.gcp_project_id
+#   name         = "${var.environment_name}-api-proxy-cert-entry"
+#   map          = google_certificate_manager_certificate_map.api_proxy[0].name
+#   certificates = [google_certificate_manager_certificate.api_proxy[0].id]
+#   hostname     = var.api_proxy_domain
+# }
+#
+# resource "google_compute_target_https_proxy" "api_connectors_managed" {
+#   count = local.external_api_alb_managed_https ? 1 : 0
+#
+#   project         = var.gcp_project_id
+#   name            = "${var.environment_name}-api-connectors-https"
+#   url_map         = google_compute_url_map.api_connectors[0].id
+#   certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.api_proxy[0].id}"
+# }
+#
+# # Self-signed TLS (PoC): omit api_proxy_domain; cert SAN includes the reserved global IP
+# # Requires hashicorp/tls in required_providers.
+#
+# resource "tls_private_key" "api_proxy" {
+#   count = local.external_api_alb_self_signed ? 1 : 0
+#
+#   algorithm = "RSA"
+#   rsa_bits  = 2048
+# }
+#
+# resource "tls_self_signed_cert" "api_proxy" {
+#   count = local.external_api_alb_self_signed ? 1 : 0
+#
+#   private_key_pem = tls_private_key.api_proxy[0].private_key_pem
+#
+#   subject {
+#     common_name = "${var.environment_name}-api-proxy.poc"
+#   }
+#
+#   validity_period_hours = 8760
+#
+#   allowed_uses = [
+#     "key_encipherment",
+#     "digital_signature",
+#     "server_auth",
+#   ]
+#
+#   ip_addresses = [google_compute_global_address.api_proxy[0].address]
+# }
+#
+# resource "google_compute_ssl_certificate" "api_proxy_self_signed" {
+#   count = local.external_api_alb_self_signed ? 1 : 0
+#
+#   project     = var.gcp_project_id
+#   name        = "${var.environment_name}-api-proxy-self-signed"
+#   private_key = tls_private_key.api_proxy[0].private_key_pem
+#   certificate = tls_self_signed_cert.api_proxy[0].cert_pem
+#
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
+#
+# resource "google_compute_target_https_proxy" "api_connectors_self_signed" {
+#   count = local.external_api_alb_self_signed ? 1 : 0
+#
+#   project = var.gcp_project_id
+#   name    = "${var.environment_name}-api-connectors-https"
+#   url_map = google_compute_url_map.api_connectors[0].id
+#
+#   ssl_certificates = [google_compute_ssl_certificate.api_proxy_self_signed[0].id]
+# }
+#
+# resource "google_compute_global_forwarding_rule" "api_connectors_https" {
+#   count = local.external_api_alb_enabled ? 1 : 0
+#
+#   project               = var.gcp_project_id
+#   name                  = "${var.environment_name}-api-connectors-https"
+#   load_balancing_scheme = "EXTERNAL_MANAGED"
+#   ip_protocol           = "TCP"
+#   port_range            = "443"
+#   ip_address            = google_compute_global_address.api_proxy[0].id
+#   target = coalesce(
+#     try(google_compute_target_https_proxy.api_connectors_managed[0].id, null),
+#     try(google_compute_target_https_proxy.api_connectors_self_signed[0].id, null),
+#   )
+# }
+#
+# # Wire into module.psoxy (main.tf):
+# #   api_connector_external_lb_host = local.external_api_alb_enabled ? (
+# #     var.api_proxy_domain != null ? var.api_proxy_domain : google_compute_global_address.api_proxy[0].address
+# #   ) : null
+#
+# output "external_alb_ip_address" {
+#   description = "Reserved global IP for the external load balancer."
+#   value       = try(google_compute_global_address.api_proxy[0].address, null)
+# }
+#
+# output "external_alb_dns_setup" {
+#   description = "DNS record required before the Google-managed certificate can provision (managed TLS mode only)."
+#   value = local.external_api_alb_managed_https ? trimspace(<<-EOT
+#     Create a DNS record for ${var.api_proxy_domain}:
+#       Type:  A
+#       Name:  ${var.api_proxy_domain}
+#       Value: ${google_compute_global_address.api_proxy[0].address}
+#
+#     Certificate provisioning may take 15–60 minutes after DNS propagates.
+#   EOT
+#   ) : null
+# }
+#
+# output "external_alb_self_signed_ca_cert" {
+#   description = "Self-signed server certificate (PEM). Trust with psoxy-test --cacert, or use --allow-insecure-tls for quick PoC checks."
+#   value       = try(tls_self_signed_cert.api_proxy[0].cert_pem, null)
+#   sensitive   = true
+# }

--- a/infra/examples-dev/gcp/variables.tf
+++ b/infra/examples-dev/gcp/variables.tf
@@ -464,7 +464,7 @@ variable "todos_as_local_files" {
 
 variable "allowed_data_access_ip_blocks" {
   description = <<-EOT
-    IPs or CIDR blocks allowed to make data access requests at the application layer (not IAM on Cloud Run). Use null (default) for no restriction. If set, the list must contain at least one value. See docs/configuration/ip-allowlisting.md.
+    IPs or CIDR blocks allowed to make data access requests at the application layer (not IAM on Cloud Run). Use null (default) for no restriction. If set, the list must contain at least one value. See docs/configuration/ip-allowlisting.md. When using the external ALB composition in networking.tf, use the same list for Cloud Armor.
   EOT
   type        = list(string)
   nullable    = true
@@ -474,6 +474,15 @@ variable "allowed_data_access_ip_blocks" {
     condition     = var.allowed_data_access_ip_blocks == null || try(length(var.allowed_data_access_ip_blocks) > 0, false)
     error_message = "allowed_data_access_ip_blocks must be null (allow all) or a non-empty list; an empty list is invalid."
   }
+}
+
+variable "api_connector_external_lb_host" {
+  type        = string
+  description = <<-EOT
+    Hostname or IP of a customer-provisioned external ALB fronting API connectors (beta; see networking.tf and docs/development/gcp-external-alb.md). After uncommenting the ALB composition, set to the domain (managed TLS) or reserved global IP (self-signed PoC).
+  EOT
+  default     = null
+  nullable    = true
 }
 
 variable "allowed_webhook_ip_blocks" {

--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -236,6 +236,26 @@ locals {
   }
 }
 
+check "api_connector_external_lb_host_ip_allowlist" {
+  assert {
+    condition     = var.api_connector_external_lb_host == null || var.allowed_data_access_ip_blocks != null
+    error_message = "When api_connector_external_lb_host is set, also set allowed_data_access_ip_blocks (Worklytics static egress IPs). Use the same list for Cloud Armor in your root networking.tf."
+  }
+}
+
+locals {
+  api_connector_external_lb_enabled = var.api_connector_external_lb_host != null
+  # Shared LB base (no per-connector path); gcp-proxy-api appends /<function-name>
+  api_connector_external_lb_base_url = local.api_connector_external_lb_enabled ? "https://${var.api_connector_external_lb_host}" : null
+  api_connector_function_names = {
+    for k in keys(var.api_connectors) : k => "${local.environment_id_prefix}${k}"
+  }
+  api_connector_external_endpoint_urls = local.api_connector_external_lb_enabled ? {
+    for k, function_name in local.api_connector_function_names :
+    k => "${local.api_connector_external_lb_base_url}/${function_name}/"
+  } : {}
+}
+
 module "api_connector" {
   for_each = var.api_connectors
 
@@ -275,6 +295,8 @@ module "api_connector" {
   instance_concurrency                  = var.api_connector_instance_concurrency
   max_instance_count                    = var.max_instances_per_api_connector
   timeout_seconds                       = coalesce(try(each.value.timeout_seconds, null), 180)
+  ingress_settings     = local.api_connector_external_lb_enabled ? "ALLOW_INTERNAL_AND_GCLB" : "ALLOW_ALL"
+  external_lb_base_url = local.api_connector_external_lb_base_url
 
 
   environment_variables = merge(
@@ -581,12 +603,16 @@ locals {
   api_instances = { for instance in module.api_connector :
     instance.instance_id => merge(
       {
-        endpoint_url     = instance.cloud_function_url,
         sanitized_bucket = try(instance.async_output_bucket_name, null),
         test_examples    = local.api_connector_test_examples[instance.instance_id],
       },
       instance,
-      var.api_connectors[instance.instance_id]
+      var.api_connectors[instance.instance_id],
+      {
+        # With external LB: only ALB path is reachable from the internet (ALLOW_INTERNAL_AND_GCLB).
+        # Without: Cloud Function URI for direct invocation.
+        endpoint_url = try(local.api_connector_external_endpoint_urls[instance.instance_id], instance.cloud_function_url)
+      }
     )
   }
 

--- a/infra/modules/gcp-host/variables.tf
+++ b/infra/modules/gcp-host/variables.tf
@@ -466,3 +466,17 @@ variable "enable_remote_resources" {
   description = "**beta** Whether to enable remote resource loading from the artifacts GCS bucket (rules, NLP models, etc.). When true, sets REMOTE_RESOURCE_BUCKET env var and grants roles/storage.objectViewer to each Cloud Function. Provisions an artifacts bucket if one is not already created or provided."
   default     = false
 }
+
+variable "api_connector_external_lb_host" {
+  type        = string
+  description = <<-EOT
+    Hostname or IP of a customer-provisioned external Application Load Balancer that fronts API connectors (beta; see docs/development/gcp-external-alb.md and the commented example in networking.tf). When non-null, API connectors use ingress ALLOW_INTERNAL_AND_GCLB and public endpoint URLs become https://<host>/<function-name>/. Does not provision the ALB.
+  EOT
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.api_connector_external_lb_host == null || try(length(trimspace(var.api_connector_external_lb_host)) > 0, false)
+    error_message = "api_connector_external_lb_host must be null or a non-empty hostname/IP."
+  }
+}

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -393,12 +393,27 @@ locals {
   proxy_endpoint_is_cloud_function = can(regex("\\.run\\.app", local.proxy_endpoint_url)) || can(regex("\\.cloudfunctions\\.net", local.proxy_endpoint_url))
   # Prefer split/trimprefix over regex capture groups (capture groups return a list when >1 group)
   proxy_endpoint_host = split("/", trimprefix(trimprefix(local.proxy_endpoint_url, "https://"), "http://"))[0]
-  proxy_endpoint_is_ip = can(regex("^[0-9.]+$", local.proxy_endpoint_host)) || can(regex("^\\[[0-9a-fA-F:]+\\]$", local.proxy_endpoint_host))
+  # Strip IPv6 brackets before cidrhost (URL host form is [::1])
+  proxy_endpoint_host_for_ip = trimsuffix(trimprefix(local.proxy_endpoint_host, "["), "]")
+  proxy_endpoint_is_ip = (
+    can(cidrhost("${local.proxy_endpoint_host_for_ip}/32", 0))
+    || can(cidrhost("${local.proxy_endpoint_host_for_ip}/128", 0))
+  )
   command_cli_call_flags = trimspace(join(" ", compact([
     local.proxy_endpoint_is_cloud_function ? "" : "-f gcp",
     local.proxy_endpoint_is_ip ? "--allow-insecure-tls" : "",
   ])))
   command_cli_call = "node ${var.path_to_repo_root}tools/psoxy-test/cli-call.js${local.command_cli_call_flags != "" ? " ${local.command_cli_call_flags}" : ""}"
+}
+
+check "proxy_endpoint_requires_https" {
+  assert {
+    condition     = startswith(local.proxy_endpoint_url, "https://")
+    error_message = "API connector proxy endpoint URL must use https:// (got a non-TLS URL). For PoC self-signed ALB certs, keep https:// and use psoxy-test --allow-insecure-tls or --cacert."
+  }
+}
+
+locals {
 
   # Merge example_api_calls into example_api_requests for unified processing
   all_example_api_requests = concat(

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -391,8 +391,9 @@ locals {
   # -f gcp: non-*.run.app / non-*.cloudfunctions.net hosts must be flagged explicitly as a GCP-hosted deployment
   # --allow-insecure-tls: IP hosts (self-signed PoC ALB) proceed despite untrusted cert
   proxy_endpoint_is_cloud_function = can(regex("\\.run\\.app", local.proxy_endpoint_url)) || can(regex("\\.cloudfunctions\\.net", local.proxy_endpoint_url))
-  proxy_endpoint_host              = try(regex("^https?://([^/]+)", local.proxy_endpoint_url), "")
-  proxy_endpoint_is_ip             = can(regex("^[0-9.]+$", local.proxy_endpoint_host)) || can(regex("^\\[[0-9a-fA-F:]+\\]$", local.proxy_endpoint_host))
+  # Prefer split/trimprefix over regex capture groups (capture groups return a list when >1 group)
+  proxy_endpoint_host = split("/", trimprefix(trimprefix(local.proxy_endpoint_url, "https://"), "http://"))[0]
+  proxy_endpoint_is_ip = can(regex("^[0-9.]+$", local.proxy_endpoint_host)) || can(regex("^\\[[0-9a-fA-F:]+\\]$", local.proxy_endpoint_host))
   command_cli_call_flags = trimspace(join(" ", compact([
     local.proxy_endpoint_is_cloud_function ? "" : "-f gcp",
     local.proxy_endpoint_is_ip ? "--allow-insecure-tls" : "",

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -410,7 +410,8 @@ locals {
 # path is always https:// from Google but is unknown until apply, which breaks terraform test.
 check "external_lb_base_url_requires_https" {
   assert {
-    condition     = var.external_lb_base_url == null || startswith(var.external_lb_base_url, "https://")
+    # Ternary (not ||) so older Terraform does not evaluate startswith(null)
+    condition     = var.external_lb_base_url == null ? true : startswith(var.external_lb_base_url, "https://")
     error_message = "external_lb_base_url must use https:// (got a non-TLS URL). For PoC self-signed ALB certs, keep https:// and use psoxy-test --allow-insecure-tls or --cacert."
   }
 }

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -406,10 +406,12 @@ locals {
   command_cli_call = "node ${var.path_to_repo_root}tools/psoxy-test/cli-call.js${local.command_cli_call_flags != "" ? " ${local.command_cli_call_flags}" : ""}"
 }
 
-check "proxy_endpoint_requires_https" {
+# Only assert on the customer-provided LB base URL (known at plan time). The Cloud Function URI
+# path is always https:// from Google but is unknown until apply, which breaks terraform test.
+check "external_lb_base_url_requires_https" {
   assert {
-    condition     = startswith(local.proxy_endpoint_url, "https://")
-    error_message = "API connector proxy endpoint URL must use https:// (got a non-TLS URL). For PoC self-signed ALB certs, keep https:// and use psoxy-test --allow-insecure-tls or --cacert."
+    condition     = var.external_lb_base_url == null || startswith(var.external_lb_base_url, "https://")
+    error_message = "external_lb_base_url must use https:// (got a non-TLS URL). For PoC self-signed ALB certs, keep https:// and use psoxy-test --allow-insecure-tls or --cacert."
   }
 }
 

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -91,13 +91,13 @@ resource "google_pubsub_subscription" "async_output_subscription" {
   name    = "${var.environment_id_prefix}${var.instance_id}-async-output-subscription"
   topic   = google_pubsub_topic.async_output_topic[0].name
 
-  # Push config: deliver messages to the Cloud Function's HTTP endpoint
+  # Push config: deliver messages to the Cloud Function's HTTP endpoint (not an external ALB URL)
   push_config {
-    push_endpoint = local.proxy_endpoint_url
+    push_endpoint = local.cloud_function_url
 
     oidc_token {
       service_account_email = var.service_account_email
-      audience              = local.proxy_endpoint_url
+      audience              = local.cloud_function_url
     }
   }
 
@@ -250,7 +250,7 @@ resource "google_cloudfunctions2_function" "function" {
     service_account_email = var.service_account_email
     available_memory      = "${var.available_memory_mb}M"
     timeout_seconds       = var.timeout_seconds
-    ingress_settings      = "ALLOW_ALL"
+    ingress_settings      = var.ingress_settings
 
     max_instance_request_concurrency = var.instance_concurrency
     available_cpu                    = var.instance_concurrency > 1 ? "1" : null
@@ -378,10 +378,26 @@ resource "google_cloud_run_service_iam_binding" "invokers" {
 }
 
 locals {
-  proxy_endpoint_url  = google_cloudfunctions2_function.function.service_config[0].uri
+  cloud_function_url = google_cloudfunctions2_function.function.service_config[0].uri
+  # Public URL for tests/TODOs: per-connector path on shared external LB, else Cloud Function URI
+  proxy_endpoint_url = trimsuffix(
+    var.external_lb_base_url != null
+    ? "${trimsuffix(var.external_lb_base_url, "/")}/${google_cloudfunctions2_function.function.name}"
+    : local.cloud_function_url,
+    "/"
+  )
   impersonation_param = var.example_api_calls_user_to_impersonate == null ? "" : " -i \"${var.example_api_calls_user_to_impersonate}\""
   command_npm_install = "npm --prefix ${var.path_to_repo_root}tools/psoxy-test install"
-  command_cli_call    = "node ${var.path_to_repo_root}tools/psoxy-test/cli-call.js"
+  # -f gcp: non-*.run.app / non-*.cloudfunctions.net hosts must be flagged explicitly as a GCP-hosted deployment
+  # --allow-insecure-tls: IP hosts (self-signed PoC ALB) proceed despite untrusted cert
+  proxy_endpoint_is_cloud_function = can(regex("\\.run\\.app", local.proxy_endpoint_url)) || can(regex("\\.cloudfunctions\\.net", local.proxy_endpoint_url))
+  proxy_endpoint_host              = try(regex("^https?://([^/]+)", local.proxy_endpoint_url), "")
+  proxy_endpoint_is_ip             = can(regex("^[0-9.]+$", local.proxy_endpoint_host)) || can(regex("^\\[[0-9a-fA-F:]+\\]$", local.proxy_endpoint_host))
+  command_cli_call_flags = trimspace(join(" ", compact([
+    local.proxy_endpoint_is_cloud_function ? "" : "-f gcp",
+    local.proxy_endpoint_is_ip ? "--allow-insecure-tls" : "",
+  ])))
+  command_cli_call = "node ${var.path_to_repo_root}tools/psoxy-test/cli-call.js${local.command_cli_call_flags != "" ? " ${local.command_cli_call_flags}" : ""}"
 
   # Merge example_api_calls into example_api_requests for unified processing
   all_example_api_requests = concat(
@@ -542,7 +558,12 @@ output "cloud_function_name" {
 }
 
 output "cloud_function_url" {
-  value = local.proxy_endpoint_url
+  value = local.cloud_function_url
+}
+
+output "proxy_endpoint_url" {
+  description = "Public URL used for tests / TODOs (per-connector path on external_lb_base_url when set, otherwise Cloud Function URI)."
+  value       = local.proxy_endpoint_url
 }
 
 output "proxy_kind" {

--- a/infra/modules/gcp-proxy-api/variables.tf
+++ b/infra/modules/gcp-proxy-api/variables.tf
@@ -310,7 +310,7 @@ variable "ingress_settings" {
 variable "external_lb_base_url" {
   type        = string
   description = <<-EOT
-    Deprecated (used only for test scripts / TODOs generated in this module; prefer lifting those to gcp-host or higher). Base URL of the shared external load balancer that fronts API connectors in this deployment (e.g. `https://proxy.example.com` or `https://203.0.113.10`), without a per-connector path. When set, example calls use `${external_lb_base_url}/${function_name}` instead of the Cloud Function URI. Pub/Sub push always uses the Cloud Function URI.
+    Deprecated (used only for test scripts / TODOs generated in this module; prefer lifting those to gcp-host or higher). Base URL of the shared external load balancer that fronts API connectors in this deployment (e.g. https://proxy.example.com or https://203.0.113.10), without a per-connector path. When set, example calls use that base plus /function-name instead of the Cloud Function URI. Pub/Sub push always uses the Cloud Function URI.
   EOT
   default     = null
   nullable    = true

--- a/infra/modules/gcp-proxy-api/variables.tf
+++ b/infra/modules/gcp-proxy-api/variables.tf
@@ -293,3 +293,25 @@ variable "remote_resource_shared_path" {
   description = "**beta** Path prefix within remote_resource_bucket for shared resources (NLP models, etc.). Used to scope IAM grants."
   default     = null
 }
+
+variable "ingress_settings" {
+  type        = string
+  description = <<-EOT
+    Cloud Functions `ingress_settings` value. Parent modules set this from a higher-level signal (e.g. gcp-host sets ALLOW_INTERNAL_AND_GCLB when `api_connector_external_lb_host` is non-null). Not intended as a per-connector customer knob.
+  EOT
+  default     = "ALLOW_ALL"
+
+  validation {
+    condition     = contains(["ALLOW_ALL", "ALLOW_INTERNAL_AND_GCLB", "ALLOW_INTERNAL_ONLY"], var.ingress_settings)
+    error_message = "ingress_settings must be one of: ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB, ALLOW_INTERNAL_ONLY."
+  }
+}
+
+variable "external_lb_base_url" {
+  type        = string
+  description = <<-EOT
+    Deprecated (used only for test scripts / TODOs generated in this module; prefer lifting those to gcp-host or higher). Base URL of the shared external load balancer that fronts API connectors in this deployment (e.g. `https://proxy.example.com` or `https://203.0.113.10`), without a per-connector path. When set, example calls use `${external_lb_base_url}/${function_name}` instead of the Cloud Function URI. Pub/Sub push always uses the Cloud Function URI.
+  EOT
+  default     = null
+  nullable    = true
+}

--- a/tools/psoxy-test/cli-call.js
+++ b/tools/psoxy-test/cli-call.js
@@ -36,6 +36,8 @@ const AWS_ACCESS_DENIED_EXCEPTION_REGEXP = new RegExp(/(?<arn>arn:aws:iam::\d+:\
     .option('-v, --verbose', 'Verbose output', false)
     .option('-z, --gzip [type]', 'Add gzip compression header (default: true, "-z false" to remove)', true)
     .option('--health-check', 'Health Check call: check Psoxy deploy is running')
+    .option('--allow-insecure-tls', 'Allow requests when the server presents an untrusted/self-signed TLS cert (PoC ALB only; do not use in production)', false)
+    .option('--cacert <path>', 'Path to PEM file to trust as CA (e.g. self-signed ALB cert from Terraform output)')
     .option('--signing-key <key-ref>', 'Signing key reference to use for signing requests (e.g. "aws-kms:arn:aws:kms:us-east-1:123456789012:key/abcd1234-12ab-34cd-56ef-1234567890ab")')
     .option('--identity-issuer <issuer>', 'issuer of JWT (iss claim)')
     .option('--identity-subject <sub>', 'subject (sub) claim to include in JWT claims to be signed')

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -95,6 +95,9 @@ async function call(options = {}) {
   }
 
   logger.info(`Calling Psoxy and waiting response: ${options.url.toString()}`);
+  if (options.allowInsecureTls) {
+    logger.info('WARNING: --allow-insecure-tls disables TLS certificate verification (PoC / self-signed only)');
+  }
   logger.verbose('Request Options:', { additional: options });
   logger.verbose('Request Headers: ', { additional: headers });
 

--- a/tools/psoxy-test/lib/aws.js
+++ b/tools/psoxy-test/lib/aws.js
@@ -98,7 +98,7 @@ async function call(options = {}) {
   logger.verbose('Request Options:', { additional: options });
   logger.verbose('Request Headers: ', { additional: headers });
 
-  return await request(url, method, headers, options.body);
+  return await request(url, method, headers, options.body, _.pick(options, ['allowInsecureTls', 'cacert']));
 }
 
 /**

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -103,7 +103,7 @@ async function call(options = {}) {
   const url = new URL(options.url);
   const method = options.method || resolveHTTPMethod(url.pathname, options);
 
-  return await request(url, method, headers, options.body);
+  return await request(url, method, headers, options.body, _.pick(options, ['allowInsecureTls', 'cacert']));
 }
 
 /**
@@ -147,8 +147,11 @@ async function getLogs(options = {}) {
  * Tries to parse region without zone
  * ref: https://cloud.google.com/compute/docs/regions-zones
  *
+ * Only derives a console URL from Cloud Function hosts (`*.run.app` / `*.cloudfunctions.net`).
+ * External ALB / custom domain URLs return undefined — use `cli-logs.js -p <project> -f <function>` instead.
+ *
  * @param {string} cloudFunctionURL
- * @returns {string} - URL to logs
+ * @returns {string|undefined} - URL to logs
  */
 function getLogsURL(cloudFunctionURL = '') {
   try {

--- a/tools/psoxy-test/lib/gcp.js
+++ b/tools/psoxy-test/lib/gcp.js
@@ -97,6 +97,9 @@ async function call(options = {}) {
   };
 
   logger.info(`Calling Psoxy and waiting response: ${options.url}`);
+  if (options.allowInsecureTls) {
+    logger.info('WARNING: --allow-insecure-tls disables TLS certificate verification (PoC / self-signed only)');
+  }
   logger.verbose('Request Options:', { additional: options });
   logger.verbose('Request Headers:', { additional: headers });
 

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -10,7 +10,7 @@ import isgzipBuffer from '@stdlib/assert-is-gzip-buffer';
 import aws4 from 'aws4';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
-import { createReadStream, createWriteStream } from 'fs';
+import { createReadStream, createWriteStream, readFileSync } from 'fs';
 import https from 'https';
 import _ from 'lodash';
 import crypto from 'node:crypto';
@@ -106,27 +106,55 @@ function getCommonHTTPHeaders(options = {}) {
 }
 
 /**
- * Wrapper for requests using Node.js HTTP interfaces: focused on
- * Psoxy use-case (*)
+ * Build Node.js https.request options for a Psoxy call.
  *
  * @param {String|URL} url
- * @param {Object} headers
  * @param {String} method
- * @param {Object} body
- * @return {Promise}
+ * @param {Object} headers
+ * @param {Object} [tlsOptions]
+ * @param {boolean} [tlsOptions.allowInsecureTls]
+ * @param {string} [tlsOptions.cacert]
+ * @return {Object}
  */
-function requestWrapper(url, method = 'GET', headers, body = {}) {
+function buildHttpsRequestOptions(url, method = 'GET', headers = {}, tlsOptions = {}) {
   url = typeof url === 'string' ? new URL(url) : url;
   const params = url.searchParams.toString();
-  const responseBody = [];
   const requestOptions = {
-    hostname: url.host,
-    port: 443,
+    hostname: url.hostname,
+    port: url.port || 443,
     path: url.pathname + (params !== '' ? `?${params}` : ''),
     method: method,
     headers: headers,
     timeout: REQUEST_TIMEOUT_MS,
+  };
+
+  if (tlsOptions.allowInsecureTls) {
+    requestOptions.rejectUnauthorized = false;
   }
+  if (tlsOptions.cacert) {
+    requestOptions.ca = readFileSync(tlsOptions.cacert);
+  }
+
+  return requestOptions;
+}
+
+/**
+ * Wrapper for requests using Node.js HTTP interfaces: focused on
+ * Psoxy use-case (*)
+ *
+ * @param {String|URL} url
+ * @param {String} method
+ * @param {Object} headers
+ * @param {Object} body
+ * @param {Object} [tlsOptions]
+ * @param {boolean} [tlsOptions.allowInsecureTls] - allow untrusted/self-signed server certs (PoC only)
+ * @param {string} [tlsOptions.cacert] - path to PEM file to trust as CA
+ * @return {Promise}
+ */
+function requestWrapper(url, method = 'GET', headers, body = {}, tlsOptions = {}) {
+  url = typeof url === 'string' ? new URL(url) : url;
+  const responseBody = [];
+  const requestOptions = buildHttpsRequestOptions(url, method, headers, tlsOptions);
 
   return new Promise((resolve, reject) => {
     const req = https.request(requestOptions,
@@ -942,6 +970,7 @@ function sleep(ms) {
 
 export {
   addFilenameSuffix,
+  buildHttpsRequestOptions,
   compareContent,
   environmentCheck,
   executeCommand,

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -118,11 +118,13 @@ function getCommonHTTPHeaders(options = {}) {
  */
 function buildHttpsRequestOptions(url, method = 'GET', headers = {}, tlsOptions = {}) {
   url = typeof url === 'string' ? new URL(url) : url;
-  const params = url.searchParams.toString();
+  if (url.protocol !== 'https:') {
+    throw new Error(`Psoxy test calls require https:// (got ${url.protocol}//${url.host})`);
+  }
   const requestOptions = {
     hostname: url.hostname,
     port: url.port || 443,
-    path: url.pathname + (params !== '' ? `?${params}` : ''),
+    path: url.pathname + url.search,
     method: method,
     headers: headers,
     timeout: REQUEST_TIMEOUT_MS,

--- a/tools/psoxy-test/lib/utils.js
+++ b/tools/psoxy-test/lib/utils.js
@@ -129,6 +129,8 @@ function buildHttpsRequestOptions(url, method = 'GET', headers = {}, tlsOptions 
   };
 
   if (tlsOptions.allowInsecureTls) {
+    // Intentional: --allow-insecure-tls for PoC self-signed ALB testing only.
+    // codeql[js/disabling-certificate-verification]
     requestOptions.rejectUnauthorized = false;
   }
   if (tlsOptions.cacert) {
@@ -152,11 +154,18 @@ function buildHttpsRequestOptions(url, method = 'GET', headers = {}, tlsOptions 
  * @return {Promise}
  */
 function requestWrapper(url, method = 'GET', headers, body = {}, tlsOptions = {}) {
-  url = typeof url === 'string' ? new URL(url) : url;
-  const responseBody = [];
-  const requestOptions = buildHttpsRequestOptions(url, method, headers, tlsOptions);
-
   return new Promise((resolve, reject) => {
+    let parsedUrl;
+    let requestOptions;
+    try {
+      parsedUrl = typeof url === 'string' ? new URL(url) : url;
+      requestOptions = buildHttpsRequestOptions(parsedUrl, method, headers, tlsOptions);
+    } catch (error) {
+      reject({ status: error.code, statusMessage: error.message });
+      return;
+    }
+
+    const responseBody = [];
     const req = https.request(requestOptions,
       (res) => {
         res.on('data', (data) => {

--- a/tools/psoxy-test/test/aws.test.js
+++ b/tools/psoxy-test/test/aws.test.js
@@ -115,6 +115,7 @@ test.serial('Psoxy call: works as expected', async (t) => {
       td.matchers.isA(URL),
       td.matchers.contains('GET'),
       td.matchers.contains(signedRequest.headers),
+      td.matchers.anything(),
       td.matchers.anything()
     )
   ).thenReturn({ status: httpCodes.HTTP_STATUS_OK });
@@ -134,6 +135,7 @@ test.serial('Psoxy call: pathless URL results 500', async (t) => {
       td.matchers.isA(URL),
       td.matchers.contains('GET'),
       td.matchers.contains(signedRequest.headers),
+      td.matchers.anything(),
       td.matchers.anything(),
     )
   ).thenReturn({
@@ -183,7 +185,8 @@ test.serial('Psoxy call: with POST, signingKey, and identitySubject options (Web
           // if signing works this header must be included in the request,
           'Authorization': jwtSignatureExample,
         }),
-        td.matchers.contains(options.body)
+        td.matchers.contains(options.body),
+        td.matchers.anything()
       )
     ).thenReturn({ status: httpCodes.HTTP_STATUS_OK });
 

--- a/tools/psoxy-test/test/gcp.test.js
+++ b/tools/psoxy-test/test/gcp.test.js
@@ -41,6 +41,10 @@ test('Get logs link based on cloud function URL', (t) => {
     gcp.getLogsURL('https://psoxy-dev-gcal-boff2f476q-uc.a.run.app'))
 
   t.is('https://console.cloud.google.com', gcp.getLogsURL('https://foo76q-ux.a.run.app/'));
+
+  // External ALB / IP / custom domain: no console URL from request host
+  t.is(undefined, gcp.getLogsURL('https://203.0.113.10/myenv-outlook-cal/'));
+  t.is(undefined, gcp.getLogsURL('https://proxy.example.com/myenv-outlook-cal/'));
 })
 
 test('Psoxy Logs: parse log entries', (t) => {
@@ -84,6 +88,7 @@ test.serial('Psoxy Call: get identity token when option missing', async (t) => {
       td.matchers.contains({
         Authorization: `Bearer ${TOKEN}`,
       }),
+      td.matchers.anything(),
       td.matchers.anything()
     )
   ).thenReturn({ status: httpCodes.HTTP_STATUS_OK });

--- a/tools/psoxy-test/test/utils.test.js
+++ b/tools/psoxy-test/test/utils.test.js
@@ -116,14 +116,14 @@ test('Resolve AWS region', (t) => {
 
 test('buildHttpsRequestOptions: IP host and allowInsecureTls', (t) => {
   const opts = buildHttpsRequestOptions(
-    'https://203.0.113.10/myenv-outlook-cal/calendar/v3/calendars/primary',
+    'https://203.0.113.10/myenv-outlook-cal/calendar/v3/calendars/primary?page=1',
     'GET',
     { Authorization: 'Bearer x' },
     { allowInsecureTls: true }
   );
   t.is(opts.hostname, '203.0.113.10');
   t.is(opts.port, 443);
-  t.is(opts.path, '/myenv-outlook-cal/calendar/v3/calendars/primary');
+  t.is(opts.path, '/myenv-outlook-cal/calendar/v3/calendars/primary?page=1');
   t.false(opts.rejectUnauthorized);
 });
 
@@ -135,6 +135,13 @@ test('buildHttpsRequestOptions: custom domain without allowInsecureTls', (t) => 
   );
   t.is(opts.hostname, 'proxy.example.com');
   t.is(opts.rejectUnauthorized, undefined);
+});
+
+test('buildHttpsRequestOptions: rejects non-https URLs', (t) => {
+  t.throws(
+    () => buildHttpsRequestOptions('http://203.0.113.10/path', 'GET', {}),
+    { message: /require https/i }
+  );
 });
 
 test('request: invalid cacert path rejects the Promise', async (t) => {

--- a/tools/psoxy-test/test/utils.test.js
+++ b/tools/psoxy-test/test/utils.test.js
@@ -4,6 +4,7 @@ import {
   addFilenameSuffix,
   buildHttpsRequestOptions,
   executeWithRetry,
+  request,
   resolveHTTPMethod,
   resolveAWSRegion,
   transformSpecWithResponse,
@@ -134,6 +135,18 @@ test('buildHttpsRequestOptions: custom domain without allowInsecureTls', (t) => 
   );
   t.is(opts.hostname, 'proxy.example.com');
   t.is(opts.rejectUnauthorized, undefined);
+});
+
+test('request: invalid cacert path rejects the Promise', async (t) => {
+  try {
+    await request('https://203.0.113.10/', 'GET', {}, {}, {
+      cacert: '/nonexistent/path/to/cacert.pem',
+    });
+    t.fail('expected request to reject');
+  } catch (err) {
+    t.is(err.status, 'ENOENT');
+    t.regex(err.statusMessage, /no such file/i);
+  }
 });
 
 test('Add filename suffix', (t) => {

--- a/tools/psoxy-test/test/utils.test.js
+++ b/tools/psoxy-test/test/utils.test.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import * as td from 'testdouble';
 import {
   addFilenameSuffix,
+  buildHttpsRequestOptions,
   executeWithRetry,
   resolveHTTPMethod,
   resolveAWSRegion,
@@ -111,6 +112,29 @@ test('Resolve AWS region', (t) => {
   t.is('us-east-1', resolveAWSRegion(new URL('https://foo.com')));
   t.is('us-east-1', resolveAWSRegion(''));
 })
+
+test('buildHttpsRequestOptions: IP host and allowInsecureTls', (t) => {
+  const opts = buildHttpsRequestOptions(
+    'https://203.0.113.10/myenv-outlook-cal/calendar/v3/calendars/primary',
+    'GET',
+    { Authorization: 'Bearer x' },
+    { allowInsecureTls: true }
+  );
+  t.is(opts.hostname, '203.0.113.10');
+  t.is(opts.port, 443);
+  t.is(opts.path, '/myenv-outlook-cal/calendar/v3/calendars/primary');
+  t.false(opts.rejectUnauthorized);
+});
+
+test('buildHttpsRequestOptions: custom domain without allowInsecureTls', (t) => {
+  const opts = buildHttpsRequestOptions(
+    'https://proxy.example.com/myenv-outlook-cal/',
+    'GET',
+    {}
+  );
+  t.is(opts.hostname, 'proxy.example.com');
+  t.is(opts.rejectUnauthorized, undefined);
+});
 
 test('Add filename suffix', (t) => {
   t.is(addFilenameSuffix('foo.csv', 'bar'), 'foo-bar.csv');


### PR DESCRIPTION

### Features
 - adds beta support for composing GCP API connectors behind an external Application Load Balancer, using `api_connector_external_lb_host` to wire the connector to the ALB host
 - test tool support for arbitrary IP/domain *other* than those obv aws/gcp-hosted gateway/lamba/cf

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md`: new beta option for GCP deployments that route connector traffic through an external ALB; customers using this should set `api_connector_external_lb_host` and expect Terraform changes when enabling it.
   - breaking changes? **no** (beta feature; not a breaking change to stable/GA modules)