### PR TITLE
request headers to override path/query 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -39,6 +39,7 @@
   * [Async API Data Sanitization](configuration/async-api-data.md)
   * [API Data Sanitization](configuration/api-data-sanitization.md)
   * [Bulk File Sanitization](configuration/bulk-file-sanitization.md)
+  * [Control Headers](configuration/control-headers.md)
   * [Email Handling](configuration/email-handling.md)
   * [JSON Filter](configuration/json-filter.md)
   * [Side Outputs](configuration/side-outputs.md)

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,3 +1,4 @@
 # Configuration
 
 * [Client IP Allowlisting](ip-allowlisting.md) — AWS (IAM + proxy) vs GCP (proxy only); Terraform variables `allowed_data_access_ip_blocks` and `allowed_webhook_ip_blocks`
+* [Control Headers](control-headers.md) — `X-Psoxy-*` headers that steer API-mode request handling (including `X-Psoxy-TargetPath` / `X-Psoxy-TargetQuery`)

--- a/docs/configuration/control-headers.md
+++ b/docs/configuration/control-headers.md
@@ -20,9 +20,10 @@ Values are used **as-is** (no base64 or other encoding round-trip). Percent-enco
 Both headers are treated as untrusted client input. Invalid values cause the proxy to respond with **HTTP 400** and `X-Psoxy-Error: INVALID_REQUEST`.
 
 - `X-Psoxy-TargetPath` must start with `/`
-- Neither header may contain CR/LF (header-injection defense)
+- Neither header may contain CR/LF (header-injection defense), whitespace, or `#`
+- `X-Psoxy-TargetPath` must not contain `?` (use `X-Psoxy-TargetQuery` for the query string)
 - Length is capped (4 KB)
-- Printable ASCII only (`0x20`–`0x7E`)
+- Printable ASCII only (`0x20`–`0x7E`; spaces are still rejected by the whitespace rule)
 
 When a valid `X-Psoxy-TargetPath` (or TargetQuery) is applied, the proxy logs the effective path/query and notes that it came from the control header (including the original request path/query for comparison).
 

--- a/docs/configuration/control-headers.md
+++ b/docs/configuration/control-headers.md
@@ -1,0 +1,41 @@
+# Control Headers
+
+API Data Connector mode accepts optional `X-Psoxy-*` **control headers**. These are consumed by the proxy itself (they are not forwarded to the source API) and steer how a request is interpreted.
+
+Anything sent as a control header should not carry secrets or other high-sensitivity material beyond what you would already put in the request URL.
+
+## Target path and query overrides
+
+When a caller cannot put the intended source path or query string on the HTTP request itself (for example, because of a load balancer, API gateway, or other fronting layer that rewrites or constrains the URL), it may send:
+
+| Header | Value | Effect |
+| --- | --- | --- |
+| `X-Psoxy-TargetPath` | Absolute path, e.g. `/v2/users/%7Bid%7D` | Used as the request path for rule matching and upstream URL construction. The actual HTTP request path is ignored. |
+| `X-Psoxy-TargetQuery` | Raw query string **without** a leading `?`, e.g. `status=active&page=1` | Used as the request query string for rule matching and upstream URL construction. Any actual query string on the request is ignored. An empty value means “no query string”. |
+
+Values are used **as-is** (no base64 or other encoding round-trip). Percent-encoded path segments should already be printable ASCII and can be sent directly.
+
+### Validation
+
+Both headers are treated as untrusted client input. Invalid values cause the proxy to respond with **HTTP 400** and `X-Psoxy-Error: INVALID_REQUEST`.
+
+- `X-Psoxy-TargetPath` must start with `/`
+- Neither header may contain CR/LF (header-injection defense)
+- Length is capped (4 KB)
+- Printable ASCII only (`0x20`–`0x7E`)
+
+When a valid `X-Psoxy-TargetPath` (or TargetQuery) is applied, the proxy logs the effective path/query and notes that it came from the control header (including the original request path/query for comparison).
+
+### Interaction with path-prefix trimming
+
+If the deployment also configures inbound path-prefix trimming (e.g. `REQUEST_PATH_PREFIX_TO_TRIM` for an ALB or gateway path prefix), a present `X-Psoxy-TargetPath` is the logical path for rules and upstream calls and should be used **exactly** — not run through prefix stripping. Prefer TargetPath when the client already knows the source API path; use path-prefix trimming when the HTTP path itself still includes a routing prefix that must be removed.
+
+## Other control headers
+
+| Header | Purpose |
+| --- | --- |
+| `X-Psoxy-Health-Check` | When present (any value), treated as a health check; not forwarded to the source. |
+| `X-Psoxy-User-To-Impersonate` | User to impersonate when calling the source API (e.g. Google Workspace). |
+| `X-Psoxy-Pseudonym-Implementation` | Selects pseudonym encoding implementation for the response. |
+| `X-Psoxy-Skip-Sanitizer` | Skip sanitization when also enabled via proxy configuration (testing only). |
+| `X-Psoxy-No-Response-Body` | Ask the proxy not to return a response body (useful with side outputs). See [Side Outputs](side-outputs.md). |

--- a/java/core/src/main/java/co/worklytics/psoxy/ControlHeader.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/ControlHeader.java
@@ -49,6 +49,29 @@ public enum ControlHeader {
      * this is a header, but NOT something we forward to the source API. rather used
      */
     USER_TO_IMPERSONATE("User-To-Impersonate"),
+
+    /**
+     * Override the HTTP request path used for rule matching and upstream URL construction.
+     * When present (and valid), the proxy treats the request as if it were sent to this path
+     * and ignores the actual request path.
+     *
+     * <p>Value is used as-is (no base64 encoding). Must be a path beginning with {@code /}.
+     *
+     * <p>NOTE: when combined with inbound path-prefix trimming ({@code REQUEST_PATH_PREFIX_TO_TRIM}),
+     * a present TargetPath should be used exactly — not run through prefix stripping — because it
+     * already expresses the logical path for rules and upstream calls.
+     */
+    TARGET_PATH("TargetPath"),
+
+    /**
+     * Override the HTTP request query string used for rule matching and upstream URL construction.
+     * When present (and valid), the proxy treats the request as if it were sent with this query
+     * string and ignores any actual query string on the request.
+     *
+     * <p>Value should be the raw query string without a leading {@code ?} (a leading {@code ?}
+     * is stripped if present). An empty value means "no query string".
+     */
+    TARGET_QUERY("TargetQuery"),
     ;
 
     @NonNull

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolver.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolver.java
@@ -74,11 +74,12 @@ public class TargetOverrideRequestResolver {
     }
 
     String validateTargetPath(String path) {
-        if (StringUtils.isEmpty(path)) {
+        if (StringUtils.isBlank(path)) {
             throw new IllegalArgumentException(
                 ControlHeader.TARGET_PATH.getHttpHeader() + " must not be empty");
         }
-        validateUntrustedHeaderValue(ControlHeader.TARGET_PATH.getHttpHeader(), path);
+        // Path must not include query/fragment delimiters — those belong in TargetQuery / nowhere.
+        validateUntrustedHeaderValue(ControlHeader.TARGET_PATH.getHttpHeader(), path, false);
         if (!path.startsWith("/")) {
             throw new IllegalArgumentException(
                 ControlHeader.TARGET_PATH.getHttpHeader() + " must start with '/'");
@@ -93,12 +94,18 @@ public class TargetOverrideRequestResolver {
         String normalized = StringUtils.removeStart(query, "?");
         // empty string is a valid override meaning "no query"
         if (StringUtils.isNotEmpty(normalized)) {
-            validateUntrustedHeaderValue(ControlHeader.TARGET_QUERY.getHttpHeader(), normalized);
+            // Query may contain literal '?' only if embedded oddly; after stripping one leading '?',
+            // further '?' is unusual but not a fragment — still disallow '#' and whitespace.
+            validateUntrustedHeaderValue(ControlHeader.TARGET_QUERY.getHttpHeader(), normalized, true);
         }
         return normalized;
     }
 
-    void validateUntrustedHeaderValue(String headerName, String value) {
+    /**
+     * @param allowQuestionMark whether {@code ?} is permitted (false for TargetPath; true for
+     *        TargetQuery after a leading {@code ?} has been stripped)
+     */
+    void validateUntrustedHeaderValue(String headerName, String value, boolean allowQuestionMark) {
         if (value.length() > MAX_HEADER_VALUE_LENGTH) {
             throw new IllegalArgumentException(
                 headerName + " exceeds max length of " + MAX_HEADER_VALUE_LENGTH);
@@ -106,6 +113,18 @@ public class TargetOverrideRequestResolver {
         if (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
             throw new IllegalArgumentException(
                 headerName + " must not contain CR/LF");
+        }
+        if (value.indexOf(' ') >= 0 || value.indexOf('\t') >= 0) {
+            throw new IllegalArgumentException(
+                headerName + " must not contain whitespace");
+        }
+        if (value.indexOf('#') >= 0) {
+            throw new IllegalArgumentException(
+                headerName + " must not contain '#'");
+        }
+        if (!allowQuestionMark && value.indexOf('?') >= 0) {
+            throw new IllegalArgumentException(
+                headerName + " must not contain '?'");
         }
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolver.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolver.java
@@ -1,0 +1,187 @@
+package co.worklytics.psoxy.gateway;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
+import co.worklytics.psoxy.ControlHeader;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+
+/**
+ * Applies optional {@link ControlHeader#TARGET_PATH} / {@link ControlHeader#TARGET_QUERY} overrides
+ * to an inbound API-mode request.
+ *
+ * <p>Headers are untrusted client input and are validated before use. Valid values replace
+ * {@link HttpEventRequest#getPath()} / {@link HttpEventRequest#getQuery()} for rule matching and
+ * upstream URL construction — used exactly as provided (no encode/decode round-trip).
+ *
+ * <p>NOTE: conflicts with inbound path-prefix trimming ({@code REQUEST_PATH_PREFIX_TO_TRIM}): when
+ * TargetPath is present, use that string exactly and do not strip configured path prefixes from it.
+ */
+@Log
+@NoArgsConstructor(onConstructor_ = @Inject)
+public class TargetOverrideRequestResolver {
+
+    /**
+     * Max length for TargetPath / TargetQuery header values. Zoom and typical SaaS API paths are
+     * tiny; 4 KB leaves headroom while bounding header-injection / DoS surface.
+     */
+    public static final int MAX_HEADER_VALUE_LENGTH = 4096;
+
+    /**
+     * @param request inbound request
+     * @return same request, or a wrapper whose path/query come from validated control headers
+     * @throws IllegalArgumentException if a Target* header is present but invalid
+     */
+    public HttpEventRequest applyOverrides(HttpEventRequest request) {
+        Optional<String> pathOverride = request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader())
+            .map(StringUtils::trim)
+            .map(this::validateTargetPath);
+
+        Optional<String> queryOverride = request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader())
+            .map(StringUtils::trim)
+            .map(this::normalizeAndValidateTargetQuery);
+
+        if (pathOverride.isEmpty() && queryOverride.isEmpty()) {
+            return request;
+        }
+
+        String effectivePath = pathOverride.orElseGet(request::getPath);
+        Optional<String> effectiveQuery = queryOverride.isPresent()
+            ? queryOverride
+            : request.getQuery();
+
+        if (pathOverride.isPresent()) {
+            log.info(String.format(
+                "Processing path %s from %s header (request path was %s)",
+                effectivePath,
+                ControlHeader.TARGET_PATH.getHttpHeader(),
+                request.getPath()));
+        }
+        if (queryOverride.isPresent()) {
+            log.info(String.format(
+                "Processing query '%s' from %s header (request query was '%s')",
+                effectiveQuery.orElse(""),
+                ControlHeader.TARGET_QUERY.getHttpHeader(),
+                request.getQuery().orElse("")));
+        }
+
+        return new HttpEventRequestWithPathQueryOverrides(request, effectivePath, effectiveQuery);
+    }
+
+    String validateTargetPath(String path) {
+        if (StringUtils.isEmpty(path)) {
+            throw new IllegalArgumentException(
+                ControlHeader.TARGET_PATH.getHttpHeader() + " must not be empty");
+        }
+        validateUntrustedHeaderValue(ControlHeader.TARGET_PATH.getHttpHeader(), path);
+        if (!path.startsWith("/")) {
+            throw new IllegalArgumentException(
+                ControlHeader.TARGET_PATH.getHttpHeader() + " must start with '/'");
+        }
+        return path;
+    }
+
+    /**
+     * Strips a single leading {@code ?} if present (callers sometimes include it), then validates.
+     */
+    String normalizeAndValidateTargetQuery(String query) {
+        String normalized = StringUtils.removeStart(query, "?");
+        // empty string is a valid override meaning "no query"
+        if (StringUtils.isNotEmpty(normalized)) {
+            validateUntrustedHeaderValue(ControlHeader.TARGET_QUERY.getHttpHeader(), normalized);
+        }
+        return normalized;
+    }
+
+    void validateUntrustedHeaderValue(String headerName, String value) {
+        if (value.length() > MAX_HEADER_VALUE_LENGTH) {
+            throw new IllegalArgumentException(
+                headerName + " exceeds max length of " + MAX_HEADER_VALUE_LENGTH);
+        }
+        if (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException(
+                headerName + " must not contain CR/LF");
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 0x20 || c > 0x7E) {
+                throw new IllegalArgumentException(
+                    headerName + " must be printable ASCII only");
+            }
+        }
+    }
+
+    /**
+     * Delegates to the original request except for path and query, which may be overridden.
+     */
+    @RequiredArgsConstructor
+    static final class HttpEventRequestWithPathQueryOverrides implements HttpEventRequest {
+
+        @NonNull
+        private final HttpEventRequest delegate;
+        @NonNull
+        private final String path;
+        @NonNull
+        private final Optional<String> query;
+
+        @Override
+        public String getPath() {
+            return path;
+        }
+
+        @Override
+        public Optional<String> getQuery() {
+            return query;
+        }
+
+        @Override
+        public Optional<String> getHeader(String headerName) {
+            return delegate.getHeader(headerName);
+        }
+
+        @Override
+        public Optional<List<String>> getMultiValueHeader(String headerName) {
+            return delegate.getMultiValueHeader(headerName);
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaders() {
+            return delegate.getHeaders();
+        }
+
+        @Override
+        public String getHttpMethod() {
+            return delegate.getHttpMethod();
+        }
+
+        @Override
+        public byte[] getBody() {
+            return delegate.getBody();
+        }
+
+        @Override
+        public String prettyPrint() {
+            return delegate.prettyPrint();
+        }
+
+        @Override
+        public Optional<String> getClientIp() {
+            return delegate.getClientIp();
+        }
+
+        @Override
+        public Optional<Boolean> isHttps() {
+            return delegate.isHttps();
+        }
+
+        @Override
+        public Object getUnderlyingRepresentation() {
+            return delegate.getUnderlyingRepresentation();
+        }
+    }
+}

--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -74,6 +74,7 @@ import co.worklytics.psoxy.gateway.NetworkSecurityUtils;
 import co.worklytics.psoxy.gateway.ProcessedContent;
 import co.worklytics.psoxy.gateway.SecretStore;
 import co.worklytics.psoxy.gateway.SourceAuthStrategy;
+import co.worklytics.psoxy.gateway.TargetOverrideRequestResolver;
 import co.worklytics.psoxy.gateway.impl.output.OutputUtils;
 import co.worklytics.psoxy.gateway.output.ApiDataOutputUtils;
 import co.worklytics.psoxy.gateway.output.ApiDataSideOutput;
@@ -151,6 +152,8 @@ public class ApiDataRequestHandler {
     ProxyConstants proxyConstants;
     @Inject
     NetworkSecurityUtils networkSecurityUtils;
+    @Inject
+    TargetOverrideRequestResolver targetOverrideRequestResolver;
 
     /**
      * Basic headers to pass: content, caching, retries. Can be expanded by connection later.
@@ -245,7 +248,18 @@ public class ApiDataRequestHandler {
                     .build();
         }
 
-
+        // Apply X-Psoxy-TargetPath / X-Psoxy-TargetQuery overrides (validated untrusted input)
+        try {
+            requestToProxy = targetOverrideRequestResolver.applyOverrides(requestToProxy);
+        } catch (IllegalArgumentException e) {
+            log.warning("Invalid target override header: " + e.getMessage());
+            return HttpEventResponse.builder()
+                    .statusCode(HttpStatus.SC_BAD_REQUEST)
+                    .header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
+                            ErrorCauses.INVALID_REQUEST.name())
+                    .body(e.getMessage())
+                    .build();
+        }
 
         RequestUrls requestUrls;
         try {

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolverTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolverTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import co.worklytics.psoxy.ControlHeader;
+import co.worklytics.test.MockModules;
 
 class TargetOverrideRequestResolverTest {
 
@@ -17,7 +18,8 @@ class TargetOverrideRequestResolverTest {
     @BeforeEach
     void setUp() {
         resolver = new TargetOverrideRequestResolver();
-        request = mock(HttpEventRequest.class);
+        // Use SUBCLASS mock maker on Java 17+ (required for Java 25/26 CI)
+        request = MockModules.provideMock(HttpEventRequest.class);
         when(request.getPath()).thenReturn("/actual/path");
         when(request.getQuery()).thenReturn(Optional.of("a=1"));
         when(request.getHeader(anyString())).thenReturn(Optional.empty());
@@ -106,6 +108,15 @@ class TargetOverrideRequestResolverTest {
         assertThrows(IllegalArgumentException.class, () -> resolver.applyOverrides(request));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"/foo bar", "/path?query=1", "/path#frag"})
+    void targetPath_rejectsWhitespaceAndUrlDelimiters(String path) {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of(path));
+
+        assertThrows(IllegalArgumentException.class, () -> resolver.applyOverrides(request));
+    }
+
     @Test
     void targetPath_rejectsCrLf() {
         when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
@@ -141,6 +152,15 @@ class TargetOverrideRequestResolverTest {
     void targetQuery_rejectsCrLf() {
         when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
             .thenReturn(Optional.of("a=1\nb=2"));
+
+        assertThrows(IllegalArgumentException.class, () -> resolver.applyOverrides(request));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a=1 b=2", "a=1#frag"})
+    void targetQuery_rejectsWhitespaceAndFragmentDelimiter(String query) {
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of(query));
 
         assertThrows(IllegalArgumentException.class, () -> resolver.applyOverrides(request));
     }

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolverTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/TargetOverrideRequestResolverTest.java
@@ -1,0 +1,160 @@
+package co.worklytics.psoxy.gateway;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import co.worklytics.psoxy.ControlHeader;
+
+class TargetOverrideRequestResolverTest {
+
+    TargetOverrideRequestResolver resolver;
+    HttpEventRequest request;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new TargetOverrideRequestResolver();
+        request = mock(HttpEventRequest.class);
+        when(request.getPath()).thenReturn("/actual/path");
+        when(request.getQuery()).thenReturn(Optional.of("a=1"));
+        when(request.getHeader(anyString())).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void noHeaders_returnsSameRequest() {
+        HttpEventRequest result = resolver.applyOverrides(request);
+        assertSame(request, result);
+        assertEquals("/actual/path", result.getPath());
+        assertEquals(Optional.of("a=1"), result.getQuery());
+    }
+
+    @Test
+    void targetPath_overridesPath_keepsQuery() {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("/v2/users/%7Bid%7D"));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertNotSame(request, result);
+        assertEquals("/v2/users/%7Bid%7D", result.getPath());
+        assertEquals(Optional.of("a=1"), result.getQuery());
+    }
+
+    @Test
+    void targetQuery_overridesQuery_keepsPath() {
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of("page=2&size=10"));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertEquals("/actual/path", result.getPath());
+        assertEquals(Optional.of("page=2&size=10"), result.getQuery());
+    }
+
+    @Test
+    void bothHeaders_overridePathAndQuery() {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("/meetings"));
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of("type=scheduled"));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertEquals("/meetings", result.getPath());
+        assertEquals(Optional.of("type=scheduled"), result.getQuery());
+    }
+
+    @Test
+    void targetQuery_empty_clearsQuery() {
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of(""));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertEquals(Optional.of(""), result.getQuery());
+    }
+
+    @Test
+    void targetQuery_stripsLeadingQuestionMark() {
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of("?foo=bar"));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertEquals(Optional.of("foo=bar"), result.getQuery());
+    }
+
+    @Test
+    void targetPath_trimsWhitespace() {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("  /trimmed  "));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertEquals("/trimmed", result.getPath());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"missing-slash", "relative/path", ""})
+    void targetPath_rejectsMissingLeadingSlashOrEmpty(String path) {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of(path));
+
+        assertThrows(IllegalArgumentException.class, () -> resolver.applyOverrides(request));
+    }
+
+    @Test
+    void targetPath_rejectsCrLf() {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("/evil\r\nX-Injected: true"));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> resolver.applyOverrides(request));
+        assertTrue(e.getMessage().contains("CR/LF"));
+    }
+
+    @Test
+    void targetPath_rejectsNonAscii() {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("/café"));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> resolver.applyOverrides(request));
+        assertTrue(e.getMessage().contains("printable ASCII"));
+    }
+
+    @Test
+    void targetPath_rejectsOverMaxLength() {
+        String tooLong = "/" + "a".repeat(TargetOverrideRequestResolver.MAX_HEADER_VALUE_LENGTH);
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of(tooLong));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> resolver.applyOverrides(request));
+        assertTrue(e.getMessage().contains("max length"));
+    }
+
+    @Test
+    void targetQuery_rejectsCrLf() {
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of("a=1\nb=2"));
+
+        assertThrows(IllegalArgumentException.class, () -> resolver.applyOverrides(request));
+    }
+
+    @Test
+    void wrapper_delegatesOtherMethods() {
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("/override"));
+        when(request.getHttpMethod()).thenReturn("GET");
+        when(request.getClientIp()).thenReturn(Optional.of("1.2.3.4"));
+
+        HttpEventRequest result = resolver.applyOverrides(request);
+
+        assertEquals("GET", result.getHttpMethod());
+        assertEquals(Optional.of("1.2.3.4"), result.getClientIp());
+    }
+}

--- a/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandlerTest.java
@@ -2,6 +2,7 @@ package co.worklytics.psoxy.gateway.impl;
 
 import co.worklytics.psoxy.ConfigRulesModule;
 import co.worklytics.psoxy.ControlHeader;
+import co.worklytics.psoxy.ErrorCauses;
 import co.worklytics.psoxy.ProcessedDataMetadataFields;
 import co.worklytics.psoxy.Pseudonymizer;
 import co.worklytics.psoxy.PseudonymizerImplFactory;
@@ -238,6 +239,45 @@ class ApiDataRequestHandlerTest {
         when(request.getQuery()).thenReturn(Optional.empty());
 
         assertThrows(IllegalArgumentException.class, () -> handler.parseRequestedTarget(request));
+    }
+
+    @SneakyThrows
+    @Test
+    void parseTargetUrlUsesTargetPathAndQueryHeaders() {
+        setup("zoom", "api.zoom.us");
+        HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
+        when(request.getPath()).thenReturn("/ignored/path");
+        when(request.getQuery()).thenReturn(Optional.of("ignored=1"));
+        when(request.getHeader(anyString())).thenReturn(Optional.empty());
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("/v2/users"));
+        when(request.getHeader(ControlHeader.TARGET_QUERY.getHttpHeader()))
+            .thenReturn(Optional.of("status=active"));
+
+        HttpEventRequest withOverrides = handler.targetOverrideRequestResolver.applyOverrides(request);
+        URL url = new URL(handler.parseRequestedTarget(withOverrides));
+
+        assertEquals("https://api.zoom.us/v2/users?status=active", url.toString());
+        assertEquals("/v2/users", withOverrides.getPath());
+    }
+
+    @Test
+    void handle_rejectsInvalidTargetPathHeader() {
+        setup("zoom", "api.zoom.us");
+        HttpEventRequest request = MockModules.provideMock(HttpEventRequest.class);
+        when(request.isHttps()).thenReturn(Optional.of(true));
+        when(request.getHttpMethod()).thenReturn("GET");
+        when(request.getClientIp()).thenReturn(Optional.empty());
+        when(request.getHeader(anyString())).thenReturn(Optional.empty());
+        when(request.getHeader(ControlHeader.TARGET_PATH.getHttpHeader()))
+            .thenReturn(Optional.of("no-leading-slash"));
+
+        HttpEventResponse response = handler.handle(request,
+            ApiDataRequestHandler.ProcessingContext.synchronous(clock.instant()));
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorCauses.INVALID_REQUEST.name(),
+            response.getHeaders().get(ProcessedDataMetadataFields.ERROR.getHttpHeader()));
     }
 
     @Test


### PR DESCRIPTION
Adds support for request headers that override the proxied path and query string, enabling fallback routing or request shaping without changing the underlying connector configuration.

Use case: GCP does some decoding of path / query string values we don't want; as well as weird routing with //.  have had similar issues with AWS lambda/api gateway, although could more reliably work around those; still worth having feature everywhere in case needed.

### Features
 - `x-Psoxy-TargetPath` header - overrides path that request will be sent to in source
 - `x-Psoxy-TargetQuery` header - overrides querystring that will be sent with request to source


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op?
     - Unlikely unless new env vars or Terraform inputs were added for the override headers (not evident from the commit message alone).
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version change
     - **No** — this appears to be additive behavior (new override headers), not a change to existing defaults.