### PR TITLE
MSFT rules update to include filter

### DIFF
--- a/docs/sources/microsoft-365/entra-id/entra-id.yaml
+++ b/docs/sources/microsoft-365/entra-id/entra-id.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/entra-id/entra-id.yaml
+++ b/docs/sources/microsoft-365/entra-id/entra-id.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -45,6 +47,8 @@ endpoints:
           - "$..identities[*].issuerAssignedId"
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -77,6 +81,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -50,6 +52,8 @@ endpoints:
         includeReversible: true
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -82,6 +86,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids_no-orig.yaml
+++ b/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids_no-orig.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids_no-orig.yaml
+++ b/docs/sources/microsoft-365/entra-id/entra-id_no-app-ids_no-orig.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -50,6 +52,8 @@ endpoints:
         includeReversible: true
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/(v1.0|beta)/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -86,6 +90,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-copilot/msft-copilot.yaml
+++ b/docs/sources/microsoft-365/msft-copilot/msft-copilot.yaml
@@ -46,6 +46,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-copilot/msft-copilot.yaml
+++ b/docs/sources/microsoft-365/msft-copilot/msft-copilot.yaml
@@ -45,6 +45,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-copilot/msft-copilot_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-copilot/msft-copilot_no-userIds.yaml
@@ -52,6 +52,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-copilot/msft-copilot_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-copilot/msft-copilot_no-userIds.yaml
@@ -51,6 +51,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
@@ -125,6 +125,7 @@ endpoints:
       - "$skiptoken"
       - "$orderby"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymize>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
@@ -1,180 +1,184 @@
 ---
 endpoints:
-  - pathTemplate: "/v1.0/drives/{driveId}/activities"
-    allowedQueryParams:
-      - "$expand"
-      - "$skiptoken"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/ItemActivity"
-  - pathTemplate: "/v1.0/drives/{driveId}/items/{itemId}/activities"
-    allowedQueryParams:
-      - "$expand"
-      - "$skiptoken"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/ItemActivity"
-  - pathTemplate: "/v1.0/drives/{driveId}/root/delta"
-    allowedQueryParams:
-      - "token"
-      - "$select"
-      - "$expand"
-      - "$top"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/DriveItem"
-  - pathTemplate: "/v1.0/groups"
-    allowedQueryParams:
-      - "$top"
-      - "$select"
-      - "$skiptoken"
-      - "$orderby"
-      - "$count"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..mail"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/GraphGroup"
-  - pathTemplate: "/v1.0/groups/{groupId}/drives"
-    allowedQueryParams:
-      - "$select"
-      - "$skiptoken"
-      - "$top"
-      - "$orderby"
-      - "$expand"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/Drive"
-  - pathTemplate: "/v1.0/users"
-    allowedQueryParams:
-      - "$top"
-      - "$select"
-      - "$skiptoken"
-      - "$orderby"
-      - "$count"
-      - "$filter"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..employeeId"
-          - "$..mail"
-          - "$..otherMails[*]"
-        encoding: "URL_SAFE_TOKEN"
-      - !<pseudonymizeRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        regex: "(?i)^smtp:(.*)$"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/GraphUser"
-  - pathTemplate: "/v1.0/users/{userId}/drives"
-    allowedQueryParams:
-      - "$select"
-      - "$skiptoken"
-      - "$top"
-      - "$orderby"
-      - "$expand"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/Drive"
+- pathTemplate: "/v1.0/drives/{driveId}/activities"
+  allowedQueryParams:
+  - "$expand"
+  - "$skiptoken"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/ItemActivity"
+- pathTemplate: "/v1.0/drives/{driveId}/items/{itemId}/activities"
+  allowedQueryParams:
+  - "$expand"
+  - "$skiptoken"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/ItemActivity"
+- pathTemplate: "/v1.0/drives/{driveId}/root/delta"
+  allowedQueryParams:
+  - "token"
+  - "$select"
+  - "$expand"
+  - "$top"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/DriveItem"
+- pathTemplate: "/v1.0/groups"
+  allowedQueryParams:
+  - "$top"
+  - "$select"
+  - "$skiptoken"
+  - "$orderby"
+  - "$count"
+  allowedRequestHeaders:
+  - "ConsistencyLevel"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..mail"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/GraphGroup"
+- pathTemplate: "/v1.0/groups/{groupId}/drives"
+  allowedQueryParams:
+  - "$select"
+  - "$skiptoken"
+  - "$top"
+  - "$orderby"
+  - "$expand"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/Drive"
+- pathTemplate: "/v1.0/users"
+  allowedQueryParams:
+  - "$top"
+  - "$select"
+  - "$skiptoken"
+  - "$orderby"
+  - "$count"
+  - "$filter"
+  allowedRequestHeaders:
+  - "ConsistencyLevel"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..employeeId"
+    - "$..mail"
+    - "$..otherMails[*]"
+    encoding: "URL_SAFE_TOKEN"
+  - !<pseudonymizeRegexMatches>
+    jsonPaths:
+    - "$..proxyAddresses[*]"
+    regex: "(?i)^smtp:(.*)$"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/GraphUser"
+- pathTemplate: "/v1.0/users/{userId}/drives"
+  allowedQueryParams:
+  - "$select"
+  - "$skiptoken"
+  - "$top"
+  - "$orderby"
+  - "$expand"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/Drive"
 definitions:
   ActivityItemRef:
     type: "object"

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
@@ -1,186 +1,190 @@
 ---
 endpoints:
-  - pathTemplate: "/v1.0/drives/{driveId}/activities"
-    allowedQueryParams:
-      - "$expand"
-      - "$skiptoken"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.id"
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/ItemActivity"
-  - pathTemplate: "/v1.0/drives/{driveId}/items/{itemId}/activities"
-    allowedQueryParams:
-      - "$expand"
-      - "$skiptoken"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.id"
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/ItemActivity"
-  - pathTemplate: "/v1.0/drives/{driveId}/root/delta"
-    allowedQueryParams:
-      - "token"
-      - "$select"
-      - "$expand"
-      - "$top"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.id"
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/DriveItem"
-  - pathTemplate: "/v1.0/groups"
-    allowedQueryParams:
-      - "$top"
-      - "$select"
-      - "$skiptoken"
-      - "$orderby"
-      - "$count"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..mail"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/GraphGroup"
-  - pathTemplate: "/v1.0/groups/{groupId}/drives"
-    allowedQueryParams:
-      - "$select"
-      - "$skiptoken"
-      - "$top"
-      - "$orderby"
-      - "$expand"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.id"
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/Drive"
-  - pathTemplate: "/v1.0/users"
-    allowedQueryParams:
-      - "$top"
-      - "$select"
-      - "$skiptoken"
-      - "$orderby"
-      - "$count"
-      - "$filter"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..id"
-          - "$..employeeId"
-          - "$..mail"
-          - "$..otherMails[*]"
-        encoding: "URL_SAFE_TOKEN"
-      - !<pseudonymizeRegexMatches>
-        jsonPaths:
-          - "$..proxyAddresses[*]"
-        regex: "(?i)^smtp:(.*)$"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/GraphUser"
-  - pathTemplate: "/v1.0/users/{userId}/drives"
-    allowedQueryParams:
-      - "$select"
-      - "$skiptoken"
-      - "$top"
-      - "$orderby"
-      - "$expand"
-    transforms:
-      - !<pseudonymize>
-        jsonPaths:
-          - "$..user.id"
-          - "$..user.email"
-        encoding: "URL_SAFE_TOKEN"
-    responseSchema:
-      type: "object"
-      properties:
-        '@microsoft.graph.hasMoreData':
-          type: "boolean"
-        '@odata.deltaLink':
-          type: "string"
-        '@odata.nextLink':
-          type: "string"
-        value:
-          type: "array"
-          items:
-            $ref: "#/definitions/Drive"
+- pathTemplate: "/v1.0/drives/{driveId}/activities"
+  allowedQueryParams:
+  - "$expand"
+  - "$skiptoken"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.id"
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/ItemActivity"
+- pathTemplate: "/v1.0/drives/{driveId}/items/{itemId}/activities"
+  allowedQueryParams:
+  - "$expand"
+  - "$skiptoken"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.id"
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/ItemActivity"
+- pathTemplate: "/v1.0/drives/{driveId}/root/delta"
+  allowedQueryParams:
+  - "token"
+  - "$select"
+  - "$expand"
+  - "$top"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.id"
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/DriveItem"
+- pathTemplate: "/v1.0/groups"
+  allowedQueryParams:
+  - "$top"
+  - "$select"
+  - "$skiptoken"
+  - "$orderby"
+  - "$count"
+  allowedRequestHeaders:
+  - "ConsistencyLevel"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..mail"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/GraphGroup"
+- pathTemplate: "/v1.0/groups/{groupId}/drives"
+  allowedQueryParams:
+  - "$select"
+  - "$skiptoken"
+  - "$top"
+  - "$orderby"
+  - "$expand"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.id"
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/Drive"
+- pathTemplate: "/v1.0/users"
+  allowedQueryParams:
+  - "$top"
+  - "$select"
+  - "$skiptoken"
+  - "$orderby"
+  - "$count"
+  - "$filter"
+  allowedRequestHeaders:
+  - "ConsistencyLevel"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..id"
+    - "$..employeeId"
+    - "$..mail"
+    - "$..otherMails[*]"
+    encoding: "URL_SAFE_TOKEN"
+  - !<pseudonymizeRegexMatches>
+    jsonPaths:
+    - "$..proxyAddresses[*]"
+    regex: "(?i)^smtp:(.*)$"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/GraphUser"
+- pathTemplate: "/v1.0/users/{userId}/drives"
+  allowedQueryParams:
+  - "$select"
+  - "$skiptoken"
+  - "$top"
+  - "$orderby"
+  - "$expand"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.id"
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/Drive"
 definitions:
   ActivityItemRef:
     type: "object"

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
@@ -129,6 +129,7 @@ endpoints:
       - "$skiptoken"
       - "$orderby"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymize>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
@@ -37,6 +37,8 @@ endpoints:
       - "$filter"
       - "$orderby"
       - "$expand"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymize>
         jsonPaths:
@@ -286,6 +288,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
@@ -285,6 +285,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
@@ -340,6 +340,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
@@ -40,6 +40,8 @@ endpoints:
           - "$..['@odata.type']"
           - "$..['@odata.count']"
   - pathRegex: "^/v1.0/users(/p~[a-zA-Z0-9_-]+?)?[^/]*/chats(\\?.*)?"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymize>
         jsonPaths:
@@ -341,6 +343,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-cal/outlook-cal.yaml
+++ b/docs/sources/microsoft-365/outlook-cal/outlook-cal.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-cal/outlook-cal.yaml
+++ b/docs/sources/microsoft-365/outlook-cal/outlook-cal.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -45,6 +47,8 @@ endpoints:
           - "$..identities[*].issuerAssignedId"
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -77,6 +81,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -50,6 +52,8 @@ endpoints:
         includeReversible: true
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -82,6 +86,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids_no-groups.yaml
+++ b/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids_no-groups.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids_no-groups.yaml
+++ b/docs/sources/microsoft-365/outlook-cal/outlook-cal_no-app-ids_no-groups.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-mail/outlook-mail.yaml
+++ b/docs/sources/microsoft-365/outlook-mail/outlook-mail.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -45,6 +47,8 @@ endpoints:
           - "$..identities[*].issuerAssignedId"
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -77,6 +81,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -136,6 +142,8 @@ endpoints:
           - "$..emailAddress.address"
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/users/[^/]*/mailFolders(/SentItems|\\('SentItems'\\))/messages.*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<redact>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-mail/outlook-mail.yaml
+++ b/docs/sources/microsoft-365/outlook-mail/outlook-mail.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -50,6 +52,8 @@ endpoints:
         includeReversible: true
         encoding: "URL_SAFE_TOKEN"
   - pathRegex: "^/v1.0/groups/?[^/]*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -82,6 +86,8 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -156,6 +162,8 @@ endpoints:
           - "$..['@odata.context']"
   - pathRegex: "^/v1.0/users(/p~[a-zA-Z0-9_-]+?)?[^/]*/mailFolders(/SentItems|\\('SentItems'\\\
     ))/messages.*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<redact>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids_no-groups.yaml
+++ b/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids_no-groups.yaml
@@ -7,6 +7,7 @@ endpoints:
       - "$skiptoken"
       - "$orderBy"
       - "$count"
+      - "$filter"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:

--- a/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids_no-groups.yaml
+++ b/docs/sources/microsoft-365/outlook-mail/outlook-mail_no-app-ids_no-groups.yaml
@@ -8,6 +8,8 @@ endpoints:
       - "$orderBy"
       - "$count"
       - "$filter"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<pseudonymizeRegexMatches>
         jsonPaths:
@@ -83,6 +85,8 @@ endpoints:
           - "$..['@odata.context']"
   - pathRegex: "^/v1.0/users(/p~[a-zA-Z0-9_-]+?)?[^/]*/mailFolders(/SentItems|\\('SentItems'\\\
     ))/messages.*"
+    allowedRequestHeaders:
+      - "ConsistencyLevel"
     transforms:
       - !<redact>
         jsonPaths:

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -85,13 +85,13 @@ public class PrebuiltSanitizerRules {
     );
     static final Endpoint ENTRA_ID_USERS = Endpoint.builder()
         .pathRegex(ENTRA_ID_REGEX_USERS)
-        .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count"))
+        .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count", "$filter"))
         .transforms(USER_TRANSFORMS)
         .build();
 
     static final Endpoint ENTRA_ID_USERS_NO_APP_IDS = Endpoint.builder()
         .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO)
-        .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count"))
+        .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count", "$filter"))
         .transforms(USER_TRANSFORMS)
         .build();
 

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -15,10 +15,14 @@ import com.google.common.collect.Streams;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class PrebuiltSanitizerRules {
+
+    // required by Graph API for `$filter`/`$search`/`$count` "advanced query" support on directory listings
+    static final Set<String> CONSISTENCY_LEVEL_HEADER = Set.of("ConsistencyLevel");
 
     static final Transform.Tokenize TOKENIZE_ODATA_LINKS = Transform.Tokenize.builder()
         .jsonPath("$.['@odata.nextLink', '@odata.prevLink', 'sessions@odata.nextLink']")
@@ -86,17 +90,20 @@ public class PrebuiltSanitizerRules {
     static final Endpoint ENTRA_ID_USERS = Endpoint.builder()
         .pathRegex(ENTRA_ID_REGEX_USERS)
         .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count", "$filter"))
+        .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
         .transforms(USER_TRANSFORMS)
         .build();
 
     static final Endpoint ENTRA_ID_USERS_NO_APP_IDS = Endpoint.builder()
         .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO)
         .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count", "$filter"))
+        .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
         .transforms(USER_TRANSFORMS)
         .build();
 
     static final Endpoint ENTRA_ID_GROUPS = Endpoint.builder()
         .pathRegex("^/v1.0/groups/?[^/]*")
+        .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
         .transform(PSEUDONYMIZE_PROXY_ADDRESSES)
         .transform(Transform.Redact.builder()
             .jsonPath("$..owners")
@@ -123,6 +130,7 @@ public class PrebuiltSanitizerRules {
     static final Endpoint ENTRA_ID_GROUP_MEMBERS = Endpoint.builder()
         .pathRegex(ENTRA_ID_REGEX_GROUP_MEMBERS)
         .allowedQueryParams(List.of("$top", "$select", "$skiptoken", "$orderBy", "$count"))
+        .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
         .transforms(USER_TRANSFORMS)
         .build();
 
@@ -190,6 +198,7 @@ public class PrebuiltSanitizerRules {
             .build(),
         Endpoint.builder()
             .pathRegex(OUTLOOK_MAIL_PATH_REGEX_SENT_MESSAGES)
+            .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
             .transform(Transform.Redact.builder()
                 .jsonPath("$..subject")
                 .jsonPath("$..body")
@@ -230,6 +239,7 @@ public class PrebuiltSanitizerRules {
             .build(),
         Endpoint.builder()
             .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO + "/mailFolders(/SentItems|\\('SentItems'\\))/messages.*")
+            .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
             .transform(Transform.Redact.builder()
                 .jsonPath("$..subject")
                 .jsonPath("$..body")
@@ -464,6 +474,7 @@ public class PrebuiltSanitizerRules {
     static final Endpoint MS_TEAMS_USERS_CHATS = Endpoint.builder()
         .pathTemplate(MS_TEAMS_PATH_TEMPLATES_USERS_CHATS)
         .allowedQueryParams(List.of("$select", "$top", "$skiptoken", "$filter", "$orderby", "$expand"))
+        .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
         .transform(MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE)
         .transform(MS_TEAMS_TEAMS_REDACT)
         .build();
@@ -583,6 +594,7 @@ public class PrebuiltSanitizerRules {
                 .build())))
         .endpoint(Endpoint.builder()
             .pathRegex(ENTRA_ID_REGEX_USERS_BY_PSEUDO + "/chats(\\?.*)?")
+            .allowedRequestHeaders(CONSISTENCY_LEVEL_HEADER)
             .transforms(Arrays.asList(MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE,
                 // id of the chat may contain MSFT user GUIDS
                 Transform.Tokenize.builder()

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/EntraIDTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/EntraIDTests.java
@@ -100,8 +100,21 @@ public class EntraIDTests extends JavaRulesTestBaseCase {
 
     @Test
     void users_filter() {
-        String endpoint = "https://graph.microsoft.com/v1.0/users?$filter=accountEnabled eq true";
-        assertUrlBlocked(endpoint);
+        String jsonString = asJson(ENTRA_ID_API_EXAMPLES_PATH, "users.json");
+
+        // $filter, as used to partition user enumeration across parallel jobs by userPrincipalName prefix
+        String endpoint = "https://graph.microsoft.com/v1.0/users?$filter=startswith(userPrincipalName,'a')";
+
+        Collection<String> PII = Arrays.asList(
+                "john@worklytics.onmicrosoft.com",
+                "Paul Allen"
+        );
+        assertNotSanitized(jsonString, PII);
+
+        String sanitized = this.sanitize(endpoint, jsonString);
+
+        assertPseudonymized(sanitized, "john@worklytics.onmicrosoft.com");
+        assertRedacted(sanitized, "Paul Allen");
     }
 
     @Test

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
@@ -33,6 +33,8 @@ public class OneDriveTests extends JavaRulesTestBaseCase {
             // /v1.0/users - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/users", "users.json"),
             InvocationExample.of(baseEndpoint + "/users?$top=999&$select=id,mail,employeeId,otherMails,proxyAddresses&$skiptoken=abcXYZ123&$orderby=id&$count=true", "users.json"),
+            // /v1.0/users - $filter, as used to partition user enumeration across parallel jobs by userPrincipalName prefix
+            InvocationExample.of(baseEndpoint + "/users?$filter=startswith(userPrincipalName,'a')&$top=999&$select=id,mail,employeeId,otherMails,proxyAddresses", "users.json"),
             // /v1.0/groups - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/groups", "groups.json"),
             InvocationExample.of(baseEndpoint + "/groups?$top=999&$select=id,mail&$skiptoken=abcXYZ123&$orderby=id&$count=true", "groups.json"),

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
@@ -35,6 +35,8 @@ public class OneDrive_NoAppIds_Tests extends JavaRulesTestBaseCase {
             // /v1.0/users - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/users", "users.json"),
             InvocationExample.of(baseEndpoint + "/users?$top=999&$select=id,mail,employeeId,otherMails,proxyAddresses&$skiptoken=abcXYZ123&$orderby=id&$count=true", "users.json"),
+            // /v1.0/users - $filter, as used to partition user enumeration across parallel jobs by userPrincipalName prefix
+            InvocationExample.of(baseEndpoint + "/users?$filter=startswith(userPrincipalName,'a')&$top=999&$select=id,mail,employeeId,otherMails,proxyAddresses", "users.json"),
             // /v1.0/groups - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/groups", "groups.json"),
             InvocationExample.of(baseEndpoint + "/groups?$top=999&$select=id,mail&$skiptoken=abcXYZ123&$orderby=id&$count=true", "groups.json"),


### PR DESCRIPTION
Two things added in all MSFT rules:
- `$filter`: for supporting https://github.com/Worklytics/evalengin/pull/8919
- adding header support for `ConsistencyLevel`: now they have to be declared, otherwise they will be ignored

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Psoxy rules update](https://app.asana.com/1/27145998307022/task/1217013434068743)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217013434068743