### PR TITLE
generated test script improvements

### DIFF
--- a/infra/modules/aws-proxy-api/test_script.tftpl
+++ b/infra/modules/aws-proxy-api/test_script.tftpl
@@ -4,7 +4,11 @@ METHOD=$${1:-"GET"}
 API_PATH=$${2:-${try(example_api_get_requests[0].path, "")}}
 CONTENT_TYPE=$${3:-""}
 BODY=$${4:-""}
+%{ if trimspace(default_header_flags) != "" ~}
 HEADER_FLAGS=$${5:-'${replace(default_header_flags, "'", "'\\''")}'}
+%{ else ~}
+HEADER_FLAGS=$${5:-}
+%{ endif ~}
 
 echo "Quick test of ${function_name} ..."
 

--- a/infra/modules/aws-proxy-bulk/main.tf
+++ b/infra/modules/aws-proxy-bulk/main.tf
@@ -362,11 +362,11 @@ Check that the Psoxy works as expected, and it transforms the files of your inpu
 the rules you have defined:
 
 ```shell
-node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js \\
-  -f ${local.example_files_csv} \\
-  -d AWS \\
-  -i ${aws_s3_bucket.input.bucket} \\
-  -o ${aws_s3_bucket.sanitized.bucket} \\
+node ${var.psoxy_base_dir}tools/psoxy-test/cli-file-upload.js \
+  -f ${local.example_files_csv} \
+  -d AWS \
+  -i ${aws_s3_bucket.input.bucket} \
+  -o ${aws_s3_bucket.sanitized.bucket} \
 ${local.cli_file_upload_role_args_todo != "" ? "${local.cli_file_upload_role_args_todo}\n" : ""}  --region ${data.aws_region.current.region}
 ```
 EOT

--- a/infra/modules/gcp-proxy-api/test_script.tftpl
+++ b/infra/modules/gcp-proxy-api/test_script.tftpl
@@ -4,7 +4,11 @@ METHOD=$${1:-"GET"}
 API_PATH=$${2:-${try(example_api_get_requests[0].path, "")}}
 CONTENT_TYPE=$${3:-""}
 BODY=$${4:-""}
+%{ if trimspace(default_header_flags) != "" ~}
 HEADER_FLAGS=$${5:-'${replace(default_header_flags, "'", "'\\''")}'}
+%{ else ~}
+HEADER_FLAGS=$${5:-}
+%{ endif ~}
 
 echo "Quick test of ${function_name} ..."
 


### PR DESCRIPTION
### Fixes
 - Generated test-script `HEADER_FLAGS` default
 - Bulk TODO line continuations in generated test scripts

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't obviously a no-op? **No**
   - breaking changes? **No** — script-generation fix only; no module/API contract changes