### PR TITLE
misc 0.6.10 improvements

### DIFF
--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/original/Communications_callRecord_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/original/Communications_callRecord_v1.0.json
@@ -13,7 +13,8 @@
     "user": {
       "id": "821809f5-0000-0000-0000-3b5136c0e777",
       "displayName": "Abbie Wilkins",
-      "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+      "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+      "userPrincipalName": "AbbieW@contoso.com"
     }
   },
   "participants": [
@@ -21,14 +22,51 @@
       "user": {
         "id": "821809f5-0000-0000-0000-3b5136c0e777",
         "displayName": "Abbie Wilkins",
-        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName": "AbbieW@contoso.com"
       }
     },
     {
       "user": {
         "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
         "displayName": "Owen Franklin",
-        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName": "OwenF@contoso.com"
+      }
+    }
+  ],
+  "organizer_v2": {
+    "id": "821809f5-0000-0000-0000-3b5136c0e777",
+    "identity": {
+      "user": {
+        "id": "821809f5-0000-0000-0000-3b5136c0e777",
+        "displayName": "Abbie Wilkins",
+        "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName": "AbbieW@contoso.com"
+      }
+    }
+  },
+  "participants_v2": [
+    {
+      "id": "821809f5-0000-0000-0000-3b5136c0e777",
+      "identity": {
+        "user": {
+          "id": "821809f5-0000-0000-0000-3b5136c0e777",
+          "displayName": "Abbie Wilkins",
+          "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+          "userPrincipalName": "AbbieW@contoso.com"
+        }
+      }
+    },
+    {
+      "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+      "identity": {
+        "user": {
+          "id": "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+          "displayName": "Owen Franklin",
+          "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+          "userPrincipalName": "OwenF@contoso.com"
+        }
       }
     }
   ],

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/original/Communications_callRecords_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/original/Communications_callRecords_v1.0.json
@@ -25,10 +25,24 @@
           "user": {
             "id": "821809f5-0000-0000-0000-3b5136c0e777",
             "displayName": "Abbie Wilkins",
-            "tenantId": "dc368399-474c-4d40-900c-6265431fd81f"
+            "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+            "userPrincipalName": "AbbieW@contoso.com"
           }
         }
-      }
+      },
+      "participants_v2": [
+        {
+          "id": "821809f5-0000-0000-0000-3b5136c0e777",
+          "identity": {
+            "user": {
+              "id": "821809f5-0000-0000-0000-3b5136c0e777",
+              "displayName": "Abbie Wilkins",
+              "tenantId": "dc368399-474c-4d40-900c-6265431fd81f",
+              "userPrincipalName": "AbbieW@contoso.com"
+            }
+          }
+        }
+      ]
     },
     {
       "id": "c3ad8c4b-4a87-4ab1-bef0-284d2f40ed9f",

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Communications_callRecord_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Communications_callRecord_v1.0.json
@@ -12,20 +12,52 @@
   "organizer":{
     "user":{
       "id":"821809f5-0000-0000-0000-3b5136c0e777",
-      "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+      "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+      "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
     }
   },
   "participants":[
     {
       "user":{
         "id":"821809f5-0000-0000-0000-3b5136c0e777",
-        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
       }
     },
     {
       "user":{
         "id":"f69e2c00-0000-0000-0000-185e5f5f5d8a",
-        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName":"t~HnUckkG8qqo_r7qLTDg6x5qrpljcQNC2W2Dwtcpqrfg@contoso.com"
+      }
+    }
+  ],
+  "organizer_v2":{
+    "identity":{
+      "user":{
+        "id":"821809f5-0000-0000-0000-3b5136c0e777",
+        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
+      }
+    }
+  },
+  "participants_v2":[
+    {
+      "identity":{
+        "user":{
+          "id":"821809f5-0000-0000-0000-3b5136c0e777",
+          "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+          "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
+        }
+      }
+    },
+    {
+      "identity":{
+        "user":{
+          "id":"f69e2c00-0000-0000-0000-185e5f5f5d8a",
+          "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+          "userPrincipalName":"t~HnUckkG8qqo_r7qLTDg6x5qrpljcQNC2W2Dwtcpqrfg@contoso.com"
+        }
       }
     }
   ],

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Communications_callRecords_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized/Communications_callRecords_v1.0.json
@@ -21,10 +21,22 @@
         "identity":{
           "user":{
             "id":"821809f5-0000-0000-0000-3b5136c0e777",
-            "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+            "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+            "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
           }
         }
-      }
+      },
+      "participants_v2":[
+        {
+          "identity":{
+            "user":{
+              "id":"821809f5-0000-0000-0000-3b5136c0e777",
+              "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+              "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
+            }
+          }
+        }
+      ]
     },
     {
       "id":"c3ad8c4b-4a87-4ab1-bef0-284d2f40ed9f",

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Communications_callRecord_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Communications_callRecord_v1.0.json
@@ -11,20 +11,52 @@
   "organizer":{
     "user":{
       "id":"t~_NMipkQ9Oebtrm7A33WQtT_wp1HCdXFRkhibMxTZGpU",
-      "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+      "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+      "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
     }
   },
   "participants":[
     {
       "user":{
         "id":"t~_NMipkQ9Oebtrm7A33WQtT_wp1HCdXFRkhibMxTZGpU",
-        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
       }
     },
     {
       "user":{
         "id":"t~ejSHHUaRnhvrRPBjmJAxSudeydUkOaOBffHT-nIS1s0",
-        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName":"t~HnUckkG8qqo_r7qLTDg6x5qrpljcQNC2W2Dwtcpqrfg@contoso.com"
+      }
+    }
+  ],
+  "organizer_v2":{
+    "identity":{
+      "user":{
+        "id":"t~_NMipkQ9Oebtrm7A33WQtT_wp1HCdXFRkhibMxTZGpU",
+        "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+        "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
+      }
+    }
+  },
+  "participants_v2":[
+    {
+      "identity":{
+        "user":{
+          "id":"t~_NMipkQ9Oebtrm7A33WQtT_wp1HCdXFRkhibMxTZGpU",
+          "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+          "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
+        }
+      }
+    },
+    {
+      "identity":{
+        "user":{
+          "id":"t~ejSHHUaRnhvrRPBjmJAxSudeydUkOaOBffHT-nIS1s0",
+          "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+          "userPrincipalName":"t~HnUckkG8qqo_r7qLTDg6x5qrpljcQNC2W2Dwtcpqrfg@contoso.com"
+        }
       }
     }
   ],

--- a/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Communications_callRecords_v1.0.json
+++ b/docs/sources/microsoft-365/msft-teams/example-api-responses/sanitized_no-userIds/Communications_callRecords_v1.0.json
@@ -20,10 +20,22 @@
         "identity":{
           "user":{
             "id":"t~_NMipkQ9Oebtrm7A33WQtT_wp1HCdXFRkhibMxTZGpU",
-            "tenantId":"dc368399-474c-4d40-900c-6265431fd81f"
+            "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+            "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
           }
         }
-      }
+      },
+      "participants_v2":[
+        {
+          "identity":{
+            "user":{
+              "id":"t~_NMipkQ9Oebtrm7A33WQtT_wp1HCdXFRkhibMxTZGpU",
+              "tenantId":"dc368399-474c-4d40-900c-6265431fd81f",
+              "userPrincipalName":"t~DMenrVJ4oR_ItE9uwpbzQg8a03d451YKiTL-RvgvtFQ@contoso.com"
+            }
+          }
+        }
+      ]
     },
     {
       "id":"c3ad8c4b-4a87-4ab1-bef0-284d2f40ed9f",

--- a/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams.yaml
@@ -149,6 +149,10 @@ endpoints:
         jsonPaths:
           - "$..emailAddress"
         encoding: "URL_SAFE_TOKEN"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..user.userPrincipalName"
+        encoding: "URL_SAFE_TOKEN"
       - !<redact>
         jsonPaths:
           - "$..user.displayName"

--- a/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
+++ b/docs/sources/microsoft-365/msft-teams/msft-teams_no-userIds.yaml
@@ -181,6 +181,10 @@ endpoints:
           - "$..user.id"
           - "$..userId"
         encoding: "URL_SAFE_TOKEN"
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..user.userPrincipalName"
+        encoding: "URL_SAFE_TOKEN"
       - !<redact>
         jsonPaths:
           - "$..user.displayName"

--- a/infra/examples-dev/gcp/main.tf
+++ b/infra/examples-dev/gcp/main.tf
@@ -245,7 +245,6 @@ output "artifacts_bucket_id" {
 # output "external_api_alb" {
 #   description = "**beta** External Application Load Balancer (ALB) details from gcp-host (host, ip_address, todo_dns_setup, self_signed_ca_cert)."
 #   value       = module.psoxy.external_api_alb
-#   sensitive   = true
 # }
 
 output "todos_1" {

--- a/infra/modules/gcp-external-api-alb/outputs.tf
+++ b/infra/modules/gcp-external-api-alb/outputs.tf
@@ -22,7 +22,6 @@ output "todo_dns_setup" {
 }
 
 output "self_signed_ca_cert" {
-  description = "Self-signed server certificate (PEM). Trust with psoxy-test --cacert, or use --allow-insecure-tls for quick PoC checks."
+  description = "Self-signed server certificate PEM (public cert, not the private key). Trust with psoxy-test --cacert, or use --allow-insecure-tls for quick PoC checks."
   value       = try(tls_self_signed_cert.api_proxy[0].cert_pem, null)
-  sensitive   = true
 }

--- a/infra/modules/gcp-host/output.tf
+++ b/infra/modules/gcp-host/output.tf
@@ -85,5 +85,4 @@ output "external_api_alb" {
     todo_dns_setup      = try(module.external_api_alb[0].todo_dns_setup, null)
     self_signed_ca_cert = try(module.external_api_alb[0].self_signed_ca_cert, null)
   }
-  sensitive = true
 }

--- a/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/rules/msft/PrebuiltSanitizerRules.java
@@ -389,6 +389,11 @@ public class PrebuiltSanitizerRules {
         .jsonPath("$..emailAddress")
         .build();
 
+    // Graph callRecords may include UPN on identity.user under organizer_v2 / participants_v2 (and legacy organizer / participants)
+    static final Transform.Pseudonymize MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_PSEUDONYMIZE = Transform.Pseudonymize.builder()
+        .jsonPath("$..user.userPrincipalName")
+        .build();
+
     static final Transform.Redact MS_TEAMS_USERS_CHATS_REDACT = Transform.Redact.builder()
         .jsonPath("$..topic")
         .jsonPath("$..['lastMessagePreview@odata.context']")
@@ -507,6 +512,7 @@ public class PrebuiltSanitizerRules {
         .pathRegex(MS_TEAMS_PATH_TEMPLATES_COMMUNICATIONS_CALL_RECORDS_REGEX)
         .allowedQueryParams(List.of("$select", "$expand", "$filter"))
         .transform(MS_TEAMS_TEAMS_DEFAULT_PSEUDONYMIZE)
+        .transform(MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_PSEUDONYMIZE)
         .build();
 
     static final Endpoint MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_GET_DIRECT_ROUTING_CALLS = Endpoint.builder()
@@ -642,6 +648,7 @@ public class PrebuiltSanitizerRules {
                 .jsonPaths(REDACT_ODATA_TYPE.getJsonPaths())
                 .build())))
         .endpoint(MS_TEAMS_COMMUNICATIONS_CALL_RECORDS.withTransforms(Arrays.asList(PSEUDONYMIZE_USER_ID,
+            MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_PSEUDONYMIZE,
             MS_TEAMS_COMMUNICATIONS_CALL_RECORDS_REDACT
                 .toBuilder()
                 .jsonPaths(REDACT_ODATA_CONTEXT.getJsonPaths())

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/TeamsTests.java
@@ -297,6 +297,7 @@ public class TeamsTests extends JavaRulesTestBaseCase {
         );
 
         String sanitized = sanitize(endpoint, jsonResponse);
+        assertPseudonymized(sanitized, "AbbieW@contoso.com");
         assertRedacted(sanitized,
                 "Abbie Wilkins",
                 "Owen Franklin",
@@ -329,6 +330,7 @@ public class TeamsTests extends JavaRulesTestBaseCase {
         );
 
         String sanitized = sanitize(endpoint, jsonResponse);
+        assertPseudonymized(sanitized, "AbbieW@contoso.com", "OwenF@contoso.com");
         assertRedacted(sanitized,
                 "Abbie Wilkins",
                 "Owen Franklin",

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/Teams_NoUserIds_Tests.java
@@ -179,7 +179,7 @@ public class Teams_NoUserIds_Tests extends JavaRulesTestBaseCase {
         String jsonResponse = asJson("Communications_callRecords_" + "v1.0" + ".json");
 
         String sanitized = sanitize(endpoint, jsonResponse);
-        assertPseudonymized(sanitized, "821809f5-0000-0000-0000-3b5136c0e777");
+        assertPseudonymized(sanitized, "821809f5-0000-0000-0000-3b5136c0e777", "AbbieW@contoso.com");
         assertRedacted(sanitized,
                 "@odata.context", "https://graph.microsoft.com/v1.0/$metadata#communications/callRecords(sessions(segments()))/$entity",
                 "@odata.type", "#microsoft.graph.callRecords.participantEndpoint",
@@ -205,7 +205,8 @@ public class Teams_NoUserIds_Tests extends JavaRulesTestBaseCase {
         String jsonResponse = asJson("Communications_callRecord_" + "v1.0" + ".json");
 
         String sanitized = sanitize(endpoint, jsonResponse);
-        assertPseudonymized(sanitized, "821809f5-0000-0000-0000-3b5136c0e777", "f69e2c00-0000-0000-0000-185e5f5f5d8a");
+        assertPseudonymized(sanitized, "821809f5-0000-0000-0000-3b5136c0e777", "f69e2c00-0000-0000-0000-185e5f5f5d8a",
+                "AbbieW@contoso.com", "OwenF@contoso.com");
         assertRedacted(sanitized,
                 "@odata.context", "https://graph.microsoft.com/v1.0/$metadata#communications/callRecords(sessions(segments()))/$entity",
                 "@odata.type", "#microsoft.graph.callRecords.participantEndpoint",


### PR DESCRIPTION
 - Stop marking GCP external ALB Terraform outputs as sensitive so they display normally in plan/apply and downstream tooling.
 - teams UPN sanitization in _v2 containers

### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md`: GCP external ALB output values may appear in `terraform plan`/`apply` where they were previously redacted as sensitive
   - breaking changes? **no** — output values are unchanged; only sensitivity metadata is removed