### PR TITLE
Trying to redact PII on error messages if not successful response

### DIFF
--- a/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/gateway/impl/ApiDataRequestHandler.java
@@ -85,6 +85,7 @@ import co.worklytics.psoxy.rules.RESTRules;
 import co.worklytics.psoxy.rules.RulesUtils;
 import co.worklytics.psoxy.utils.ComposedHttpRequestInitializer;
 import co.worklytics.psoxy.utils.GzipedContentHttpRequestInitializer;
+import co.worklytics.psoxy.utils.LogSanitizationUtils;
 import co.worklytics.psoxy.utils.URLUtils;
 import dagger.Lazy;
 import lombok.AllArgsConstructor;
@@ -633,12 +634,17 @@ public class ApiDataRequestHandler {
 
                 }
             } else {
-                // write error, which shouldn't contain PII, directly
-                log.log(Level.WARNING, "Source API Error " + original.getContentAsString());
+                // source API error bodies aren't validated against a schema, so we can't rely on
+                // RESTApiSanitizer (schema-driven) to strip PII from them; instead, redact
+                // patterns commonly used as PII (emails, GUIDs used as user ids by some source
+                // APIs, eg MSFT Graph) on a best-effort basis before logging or returning it
+                String redactedError =
+                        LogSanitizationUtils.redactPotentialPii(original.getContentAsString());
+                log.log(Level.WARNING, "Source API Error " + redactedError);
 
                 builder.header(ProcessedDataMetadataFields.ERROR.getHttpHeader(),
                         ErrorCauses.API_ERROR.name());
-                proxyResponseContent = original.getContentAsString();
+                proxyResponseContent = redactedError;
 
                 // q: in async case, perhaps we should write the error to the async output, too, for
                 // clarity??? could do it with metadata indicating the error to the caller, so it

--- a/java/core/src/main/java/co/worklytics/psoxy/utils/LogSanitizationUtils.java
+++ b/java/core/src/main/java/co/worklytics/psoxy/utils/LogSanitizationUtils.java
@@ -1,0 +1,29 @@
+package co.worklytics.psoxy.utils;
+
+import java.util.regex.Pattern;
+
+/**
+ * Redacts patterns that commonly correspond to PII (email addresses; UUIDs/GUIDs, which some
+ * source APIs use as user ids) from free-text content before it's written to logs.
+ *
+ * Intended for content whose structure/schema isn't known ahead of time - eg, error response
+ * bodies from source APIs - so schema-based sanitization (see RESTApiSanitizer) isn't
+ * applicable. This is a best-effort text scrub, NOT a substitute for schema-based sanitization.
+ */
+public class LogSanitizationUtils {
+
+    static final Pattern EMAIL_PATTERN =
+        Pattern.compile("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b");
+
+    static final Pattern UUID_PATTERN =
+        Pattern.compile("\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b");
+
+    public static String redactPotentialPii(String content) {
+        if (content == null) {
+            return null;
+        }
+        String redacted = EMAIL_PATTERN.matcher(content).replaceAll("{redacted-email}");
+        redacted = UUID_PATTERN.matcher(redacted).replaceAll("{redacted-uuid}");
+        return redacted;
+    }
+}

--- a/java/core/src/test/java/co/worklytics/psoxy/utils/LogSanitizationUtilsTest.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/utils/LogSanitizationUtilsTest.java
@@ -1,0 +1,38 @@
+package co.worklytics.psoxy.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LogSanitizationUtilsTest {
+
+    @Test
+    public void redactPotentialPii_null() {
+        assertNull(LogSanitizationUtils.redactPotentialPii(null));
+    }
+
+    @Test
+    public void redactPotentialPii_msftGraphCopilotError() {
+        String input = "{\"error\":{\"code\":\"Forbidden\",\"message\":\"User "
+                + "'d290f1ee-6c54-4b01-90e6-d701748f0851' does not have a valid Copilot "
+                + "license.\"}}";
+
+        String redacted = LogSanitizationUtils.redactPotentialPii(input);
+
+        assertEquals("{\"error\":{\"code\":\"Forbidden\",\"message\":\"User "
+                + "'{redacted-uuid}' does not have a valid Copilot license.\"}}", redacted);
+    }
+
+    @Test
+    public void redactPotentialPii_email() {
+        assertEquals("user '{redacted-email}' not found",
+                LogSanitizationUtils.redactPotentialPii("user 'jane.doe@example.com' not found"));
+    }
+
+    @Test
+    public void redactPotentialPii_noMatches_unchanged() {
+        String input = "ERROR at Row:1:Column:136 No such column 'Ownership' on entity 'Account'";
+        assertEquals(input, LogSanitizationUtils.redactPotentialPii(input));
+    }
+}


### PR DESCRIPTION
In case the response is not successful, trying to redact emails or UUIDs from the message to avoid putting in logs/response payload potential PII data

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[copilot errors](https://app.asana.com/1/27145998307022/project/1213797956438900/task/1217467688370057)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change
