### PR TITLE
fix gcp test files

### DIFF
--- a/infra/modules/gcp-host/main.tf
+++ b/infra/modules/gcp-host/main.tf
@@ -698,8 +698,9 @@ locals {
 }
 
 # script to test ALL connectors
-# Use test_script_filename (computed local in each connector module), not test_script — that
-# output interpolates local_file, and a content replace then deletes the file just written.
+# Use test_script_filename (computed local in each connector module). Do not interpolate
+# local_file.test_script via module outputs — gcp-host merges those outputs into api_instances,
+# Worklytics TODOs then depend on the file, and a content replace deletes it just after write.
 resource "local_file" "test_all_script" {
   count = var.todos_as_local_files ? 1 : 0
 

--- a/infra/modules/gcp-proxy-api/external_lb_endpoints.tftest.hcl
+++ b/infra/modules/gcp-proxy-api/external_lb_endpoints.tftest.hcl
@@ -50,3 +50,17 @@ run "alb_domain_used_in_todos_and_outputs" {
     condition     = strcontains(output.todo, "https://proxy.example.com/dev-test-instance") && !strcontains(output.todo, ".run.app")
   }
 }
+
+run "test_script_output_does_not_require_local_file" {
+  command = plan
+
+  variables {
+    external_lb_base_url = "https://proxy.example.com"
+    todos_as_local_files = true
+  }
+
+  assert {
+    error_message = "test_script must be the filename local (not local_file.filename) so content replace cannot delete the written file"
+    condition     = output.test_script == output.test_script_filename && output.test_script == "test-test-instance.sh"
+  }
+}

--- a/infra/modules/gcp-proxy-api/main.tf
+++ b/infra/modules/gcp-proxy-api/main.tf
@@ -471,6 +471,18 @@ locals {
 
   test_script_filename = "test-${trimprefix(var.instance_id, var.environment_id_prefix)}.sh"
   default_header_flags = length(local.example_api_get_requests_for_script) > 0 ? local.example_api_get_requests_for_script[0].header_flags : ""
+  # Keep content on a local so outputs/other files never interpolate local_file.test_script
+  # (that dependency causes a content replace to delete the file just written).
+  test_script = templatefile("${path.module}/test_script.tftpl", {
+    proxy_endpoint_url        = local.proxy_endpoint_url,
+    function_name             = var.instance_id,
+    impersonation_param       = local.impersonation_param,
+    command_cli_call          = local.command_cli_call,
+    default_header_flags      = local.default_header_flags,
+    example_api_get_requests  = local.example_api_get_requests_for_script,
+    example_api_post_requests = local.example_api_post_requests_for_script,
+    enable_async_processing   = var.enable_async_processing
+  })
 
   # Generate test calls from all example requests
   command_test_calls = [for request in local.all_example_api_requests :
@@ -549,16 +561,7 @@ resource "local_file" "test_script" {
 
   filename        = local.test_script_filename
   file_permission = "755"
-  content = templatefile("${path.module}/test_script.tftpl", {
-    proxy_endpoint_url        = local.proxy_endpoint_url,
-    function_name             = var.instance_id,
-    impersonation_param       = local.impersonation_param,
-    command_cli_call          = local.command_cli_call,
-    default_header_flags      = local.default_header_flags,
-    example_api_get_requests  = local.example_api_get_requests_for_script,
-    example_api_post_requests = local.example_api_post_requests_for_script,
-    enable_async_processing   = var.enable_async_processing
-  })
+  content         = local.test_script
 }
 
 resource "local_file" "review" {
@@ -606,7 +609,12 @@ output "test_script_filename" {
 }
 
 output "test_script" {
-  value = try(local_file.test_script[0].filename, null)
+  # Do not interpolate local_file.test_script (content replace then deletes the file).
+  value = var.todos_as_local_files ? local.test_script_filename : null
+}
+
+output "test_script_content" {
+  value = local.test_script
 }
 
 output "async_output_bucket_id" {

--- a/infra/modules/gcp-proxy-bulk/main.tf
+++ b/infra/modules/gcp-proxy-bulk/main.tf
@@ -484,7 +484,8 @@ output "test_script_filename" {
 }
 
 output "test_script" {
-  value = try(local_file.test_script[0].filename, null)
+  # Do not interpolate local_file.test_script (content replace then deletes the file).
+  value = var.todos_as_local_files ? local.test_script_filename : null
 }
 
 output "todo" {

--- a/infra/modules/gcp-webhook-collector/main.tf
+++ b/infra/modules/gcp-webhook-collector/main.tf
@@ -474,6 +474,17 @@ locals {
   signing_key_id       = var.provision_auth_key == null ? null : google_kms_crypto_key.webhook_auth_key[0].id
   command_test_logs    = "node ${var.path_to_repo_root}tools/psoxy-test/cli-logs.js -p \"${google_cloudfunctions2_function.function.project}\" -f \"${google_cloudfunctions2_function.function.name}\""
   test_script_filename = "test-${trimprefix(var.instance_id, var.environment_id_prefix)}.sh"
+  test_script = templatefile("${path.module}/test_script.tftpl", {
+    collector_endpoint_url = local.proxy_endpoint_url,
+    function_name          = var.instance_id,
+    command_cli_call       = local.command_cli_call,
+    signing_key_id         = local.signing_key_id,
+    example_payload        = coalesce(var.example_payload, "{\"test\": \"data\"}")
+    example_identity       = var.example_identity
+    collection_path        = "/"
+    scheduler_job_name     = google_cloud_scheduler_job.trigger_batch_processing.id
+    bucket_name            = module.sanitized_webhook_output.bucket_name
+  })
 }
 
 locals {
@@ -537,17 +548,7 @@ resource "local_file" "test_script" {
 
   filename        = local.test_script_filename
   file_permission = "755"
-  content = templatefile("${path.module}/test_script.tftpl", {
-    collector_endpoint_url = local.proxy_endpoint_url,
-    function_name          = var.instance_id,
-    command_cli_call       = local.command_cli_call,
-    signing_key_id         = local.signing_key_id,
-    example_payload        = coalesce(var.example_payload, "{\"test\": \"data\"}")
-    example_identity       = var.example_identity
-    collection_path        = "/"
-    scheduler_job_name     = google_cloud_scheduler_job.trigger_batch_processing.id
-    bucket_name            = module.sanitized_webhook_output.bucket_name
-  })
+  content         = local.test_script
 }
 
 resource "local_file" "test_todo" {
@@ -583,7 +584,8 @@ output "test_script_filename" {
 }
 
 output "test_script" {
-  value = try(local_file.test_script[0].filename, null)
+  # Do not interpolate local_file.test_script (content replace then deletes the file).
+  value = var.todos_as_local_files ? local.test_script_filename : null
 }
 
 output "output_sanitized_bucket_id" {


### PR DESCRIPTION
### Description

- Stop interpolating `local_file` in GCP `test_script` outputs for improved output consistency.

### Change implications

- dependencies added/changed? **no**
- something important to note in future release notes? **no**