### PR TITLE
OneDrive: support token in path for deltas and fix pseudonymizing delta link when listing user drives

### DIFF
--- a/docs/sources/microsoft-365/msft-onedrive/example-api-responses/original/list_groups_drives.json
+++ b/docs/sources/microsoft-365/msft-onedrive/example-api-responses/original/list_groups_drives.json
@@ -1,4 +1,5 @@
 {
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/groups/6257b47d-9e87-418b-9ac2-031f09397de7/drives?$top=1&$skiptoken=aWQ9OUZCRjU2OUEtN0UwOC00RDFELTlFREMtMkY3ODg3MTUzNjY3",
   "value": [
     {
       "id": "b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",

--- a/docs/sources/microsoft-365/msft-onedrive/example-api-responses/original/list_user_drives.json
+++ b/docs/sources/microsoft-365/msft-onedrive/example-api-responses/original/list_user_drives.json
@@ -1,0 +1,46 @@
+{
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/users/6257b47d-9e87-418b-9ac2-031f09397de7/drives?$top=1&$skiptoken=aWQ9OUZCRjU2OUEtN0UwOC00RDFELTlFREMtMkY3ODg3MTUzNjY3",
+  "value": [
+    {
+      "id": "b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",
+      "driveType": "documentLibrary",
+      "createdDateTime": "2017-07-27T02:41:36Z",
+      "createdBy": {
+        "user": {
+          "id": "CE251278-EF9E-4FE5-833C-1D89EEAE68E0",
+          "displayName": "Ryan Gregg",
+          "email": "ryan@contoso.com"
+        }
+      },
+      "lastModifiedDateTime": "2018-03-27T07:34:38Z",
+      "lastModifiedBy": {
+        "user": {
+          "id": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+          "displayName": "Dana Lee",
+          "email": "dana@contoso.com"
+        }
+      }
+    },
+    {
+      "id": "b!kjtJnMGCeEeNkZsY18PtOiNjCV0Z9s9Fqyly8jKvPEB2kal9T5pOT5y7TXClirlE",
+      "driveType": "documentLibrary",
+      "system": {},
+      "createdDateTime": "2017-07-27T02:41:36Z",
+      "createdBy": {
+        "user": {
+          "id": "CE251278-EF9E-4FE5-833C-1D89EEAE68E0",
+          "displayName": "Ryan Gregg",
+          "email": "ryan@contoso.com"
+        }
+      },
+      "lastModifiedDateTime": "2017-07-27T02:41:36Z",
+      "lastModifiedBy": {
+        "user": {
+          "id": "CE251278-EF9E-4FE5-833C-1D89EEAE68E0",
+          "displayName": "Ryan Gregg",
+          "email": "ryan@contoso.com"
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized/list_groups_drives.json
+++ b/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized/list_groups_drives.json
@@ -1,4 +1,5 @@
 {
+  "@odata.nextLink":"https://graph.microsoft.com/v1.0/groups/6257b47d-9e87-418b-9ac2-031f09397de7/drives?$top=1&$skiptoken=aWQ9OUZCRjU2OUEtN0UwOC00RDFELTlFREMtMkY3ODg3MTUzNjY3",
   "value":[
     {
       "id":"b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",

--- a/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized/list_user_drives.json
+++ b/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized/list_user_drives.json
@@ -1,4 +1,5 @@
 {
+  "@odata.nextLink":"https://graph.microsoft.com/v1.0/users/6257b47d-9e87-418b-9ac2-031f09397de7/drives?$top=1&$skiptoken=aWQ9OUZCRjU2OUEtN0UwOC00RDFELTlFREMtMkY3ODg3MTUzNjY3",
   "value":[
     {
       "id":"b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",
@@ -6,14 +7,14 @@
       "createdDateTime":"2017-07-27T02:41:36Z",
       "createdBy":{
         "user":{
-          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "id":"CE251278-EF9E-4FE5-833C-1D89EEAE68E0",
           "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
         }
       },
       "lastModifiedDateTime":"2018-03-27T07:34:38Z",
       "lastModifiedBy":{
         "user":{
-          "id":"t~DTbvYdTNRIQXAF1SvLNyAIENog0-Dy0dxTEB2Yoo5Ys",
+          "id":"9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
           "email":"t~1ECTeY42RlWDU6D4DtrXKyFmVrUHbEEpdYzI34l0y9Q@contoso.com"
         }
       }
@@ -25,14 +26,14 @@
       "createdDateTime":"2017-07-27T02:41:36Z",
       "createdBy":{
         "user":{
-          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "id":"CE251278-EF9E-4FE5-833C-1D89EEAE68E0",
           "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
         }
       },
       "lastModifiedDateTime":"2017-07-27T02:41:36Z",
       "lastModifiedBy":{
         "user":{
-          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "id":"CE251278-EF9E-4FE5-833C-1D89EEAE68E0",
           "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
         }
       }

--- a/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized_no-app-ids/list_groups_drives.json
+++ b/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized_no-app-ids/list_groups_drives.json
@@ -1,0 +1,42 @@
+{
+  "@odata.nextLink":"https://graph.microsoft.com/v1.0/groups/6257b47d-9e87-418b-9ac2-031f09397de7/drives?$top=1&$skiptoken=aWQ9OUZCRjU2OUEtN0UwOC00RDFELTlFREMtMkY3ODg3MTUzNjY3",
+  "value":[
+    {
+      "id":"b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",
+      "driveType":"documentLibrary",
+      "createdDateTime":"2017-07-27T02:41:36Z",
+      "createdBy":{
+        "user":{
+          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
+        }
+      },
+      "lastModifiedDateTime":"2018-03-27T07:34:38Z",
+      "lastModifiedBy":{
+        "user":{
+          "id":"t~DTbvYdTNRIQXAF1SvLNyAIENog0-Dy0dxTEB2Yoo5Ys",
+          "email":"t~1ECTeY42RlWDU6D4DtrXKyFmVrUHbEEpdYzI34l0y9Q@contoso.com"
+        }
+      }
+    },
+    {
+      "id":"b!kjtJnMGCeEeNkZsY18PtOiNjCV0Z9s9Fqyly8jKvPEB2kal9T5pOT5y7TXClirlE",
+      "driveType":"documentLibrary",
+      "system":{ },
+      "createdDateTime":"2017-07-27T02:41:36Z",
+      "createdBy":{
+        "user":{
+          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
+        }
+      },
+      "lastModifiedDateTime":"2017-07-27T02:41:36Z",
+      "lastModifiedBy":{
+        "user":{
+          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized_no-app-ids/list_user_drives.json
+++ b/docs/sources/microsoft-365/msft-onedrive/example-api-responses/sanitized_no-app-ids/list_user_drives.json
@@ -1,0 +1,42 @@
+{
+  "@odata.nextLink":"https://graph.microsoft.com/v1.0/users/p~G-O6qnggmabXX7oVLICcae1h1B_h3yud3zcNymQoGVqSOg0H9jqiKau9wvs7oToujvTK_Woudb8vCT95nqMWc89UQSbrUBZGukrZoydhHl8/drives?$top=1&$skiptoken=aWQ9OUZCRjU2OUEtN0UwOC00RDFELTlFREMtMkY3ODg3MTUzNjY3",
+  "value":[
+    {
+      "id":"b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",
+      "driveType":"documentLibrary",
+      "createdDateTime":"2017-07-27T02:41:36Z",
+      "createdBy":{
+        "user":{
+          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
+        }
+      },
+      "lastModifiedDateTime":"2018-03-27T07:34:38Z",
+      "lastModifiedBy":{
+        "user":{
+          "id":"t~DTbvYdTNRIQXAF1SvLNyAIENog0-Dy0dxTEB2Yoo5Ys",
+          "email":"t~1ECTeY42RlWDU6D4DtrXKyFmVrUHbEEpdYzI34l0y9Q@contoso.com"
+        }
+      }
+    },
+    {
+      "id":"b!kjtJnMGCeEeNkZsY18PtOiNjCV0Z9s9Fqyly8jKvPEB2kal9T5pOT5y7TXClirlE",
+      "driveType":"documentLibrary",
+      "system":{ },
+      "createdDateTime":"2017-07-27T02:41:36Z",
+      "createdBy":{
+        "user":{
+          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
+        }
+      },
+      "lastModifiedDateTime":"2017-07-27T02:41:36Z",
+      "lastModifiedBy":{
+        "user":{
+          "id":"t~jL-PZwZ7AqMLlWzY4F0nkDdSpci8cF1GzIzZC51Y9Rg",
+          "email":"t~rhHXsIpQCoOYdgzj6URY4x8oUcvnLMLR5d71_wRuVAA@contoso.com"
+        }
+      }
+    }
+  ]
+}

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
@@ -44,7 +44,7 @@ endpoints:
         type: "array"
         items:
           $ref: "#/definitions/ItemActivity"
-- pathRegex: "^/v1\\.0/drives/[^/]+/root/delta(\\(token=[^)]*\\))?(\\?.*)?$"
+- pathTemplate: "/v1.0/drives/{driveId}/root/delta"
   allowedQueryParams:
   - "token"
   - "$select"
@@ -55,6 +55,34 @@ endpoints:
     jsonPaths:
     - "$..user.email"
     encoding: "URL_SAFE_TOKEN"
+  responseSchema:
+    type: "object"
+    properties:
+      '@microsoft.graph.hasMoreData':
+        type: "boolean"
+      '@odata.deltaLink':
+        type: "string"
+      '@odata.nextLink':
+        type: "string"
+      value:
+        type: "array"
+        items:
+          $ref: "#/definitions/DriveItem"
+# OData function-call continuation shape for /root/delta, eg "/root/delta(token=abc123)"
+- pathTemplate: "/v1.0/drives/{driveId}/root/{deltaExpression}"
+  allowedQueryParams:
+  - "token"
+  - "$select"
+  - "$expand"
+  - "$top"
+  transforms:
+  - !<pseudonymize>
+    jsonPaths:
+    - "$..user.email"
+    encoding: "URL_SAFE_TOKEN"
+  pathParameterSchemas:
+    deltaExpression:
+      pattern: "^delta\\(token=[^)]+\\)$"
   responseSchema:
     type: "object"
     properties:

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive.yaml
@@ -44,7 +44,7 @@ endpoints:
         type: "array"
         items:
           $ref: "#/definitions/ItemActivity"
-- pathTemplate: "/v1.0/drives/{driveId}/root/delta"
+- pathRegex: "^/v1\\.0/drives/[^/]+/root/delta(\\(token=[^)]*\\))?(\\?.*)?$"
   allowedQueryParams:
   - "token"
   - "$select"

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
@@ -46,7 +46,7 @@ endpoints:
           type: "array"
           items:
             $ref: "#/definitions/ItemActivity"
-  - pathTemplate: "/v1.0/drives/{driveId}/root/delta"
+  - pathRegex: "^/v1\\.0/drives/[^/]+/root/delta(\\(token=[^)]*\\))?(\\?.*)?$"
     allowedQueryParams:
       - "token"
       - "$select"

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
@@ -176,6 +176,10 @@ endpoints:
           - "$..user.id"
           - "$..user.email"
         encoding: "URL_SAFE_TOKEN"
+      - !<tokenize>
+        jsonPaths:
+          - "$.['@odata.nextLink']"
+        regex: "^https://graph.microsoft.com/v1.0/users/([a-zA-Z0-9_-]+)/.*$"
     pathParameterSchemas:
       userId:
         anyOf:

--- a/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
+++ b/docs/sources/microsoft-365/msft-onedrive/msft-onedrive_no-app-ids.yaml
@@ -46,7 +46,7 @@ endpoints:
           type: "array"
           items:
             $ref: "#/definitions/ItemActivity"
-  - pathRegex: "^/v1\\.0/drives/[^/]+/root/delta(\\(token=[^)]*\\))?(\\?.*)?$"
+  - pathTemplate: "/v1.0/drives/{driveId}/root/delta"
     allowedQueryParams:
       - "token"
       - "$select"
@@ -58,6 +58,35 @@ endpoints:
           - "$..user.id"
           - "$..user.email"
         encoding: "URL_SAFE_TOKEN"
+    responseSchema:
+      type: "object"
+      properties:
+        '@microsoft.graph.hasMoreData':
+          type: "boolean"
+        '@odata.deltaLink':
+          type: "string"
+        '@odata.nextLink':
+          type: "string"
+        value:
+          type: "array"
+          items:
+            $ref: "#/definitions/DriveItem"
+  # OData function-call continuation shape for /root/delta, eg "/root/delta(token=abc123)"
+  - pathTemplate: "/v1.0/drives/{driveId}/root/{deltaExpression}"
+    allowedQueryParams:
+      - "token"
+      - "$select"
+      - "$expand"
+      - "$top"
+    transforms:
+      - !<pseudonymize>
+        jsonPaths:
+          - "$..user.id"
+          - "$..user.email"
+        encoding: "URL_SAFE_TOKEN"
+    pathParameterSchemas:
+      deltaExpression:
+        pattern: "^delta\\(token=[^)]+\\)$"
     responseSchema:
       type: "object"
       properties:

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
@@ -46,8 +46,11 @@ public class OneDriveTests extends JavaRulesTestBaseCase {
             InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_drives.json"),
             // /v1.0/drives/{driveId}/root/delta - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta", "get_drive_delta.json"),
+            // real pagination continuation shape confirmed via live testing against the Graph API
+            // (a "?token=..." query param, matching MSFT's own docs example)
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta?token=abcXYZ123&", "get_drive_delta.json"),
-            // real pagination continuation shape (OData function-call token, from this fixture's own @odata.nextLink)
+            // the OTHER real continuation shape, from this fixture's own captured @odata.nextLink
+            // (an OData function-call path segment -- rules must accept both)
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta(token=1230919asd190410jlka)", "get_drive_delta.json"),
             // /v1.0/drives/{driveId}/items/{itemId}/activities - no query params allowed by rules
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/items/" + itemId + "/activities", "list_itemActivity.json"),

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
@@ -47,6 +47,8 @@ public class OneDriveTests extends JavaRulesTestBaseCase {
             // /v1.0/drives/{driveId}/root/delta - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta", "get_drive_delta.json"),
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta?token=abcXYZ123&", "get_drive_delta.json"),
+            // real pagination continuation shape (OData function-call token, from this fixture's own @odata.nextLink)
+            InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta(token=1230919asd190410jlka)", "get_drive_delta.json"),
             // /v1.0/drives/{driveId}/items/{itemId}/activities - no query params allowed by rules
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/items/" + itemId + "/activities", "list_itemActivity.json"),
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/items/" + itemId + "/activities?$expand=driveItem", "list_itemActivity.json"),

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDriveTests.java
@@ -39,11 +39,13 @@ public class OneDriveTests extends JavaRulesTestBaseCase {
             InvocationExample.of(baseEndpoint + "/groups", "groups.json"),
             InvocationExample.of(baseEndpoint + "/groups?$top=999&$select=id,mail&$skiptoken=abcXYZ123&$orderby=id&$count=true", "groups.json"),
             // /v1.0/users/{userId}/drives - no query params, and with all allowed query params
-            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives", "list_drives.json"),
-            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_drives.json"),
+            // (with app ids visible, fixture's @odata.nextLink is passed through unmodified -- no
+            // pathParameterSchemas constraint on userId in this rule variant)
+            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives", "list_user_drives.json"),
+            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_user_drives.json"),
             // /v1.0/groups/{groupId}/drives - no query params, and with all allowed query params
-            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives", "list_drives.json"),
-            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_drives.json"),
+            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives", "list_groups_drives.json"),
+            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_groups_drives.json"),
             // /v1.0/drives/{driveId}/root/delta - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta", "get_drive_delta.json"),
             // real pagination continuation shape confirmed via live testing against the Graph API

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
@@ -48,8 +48,11 @@ public class OneDrive_NoAppIds_Tests extends JavaRulesTestBaseCase {
             InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_drives.json"),
             // /v1.0/drives/{driveId}/root/delta - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta", "get_drive_delta.json"),
+            // real pagination continuation shape confirmed via live testing against the Graph API
+            // (a "?token=..." query param, matching MSFT's own docs example)
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta?token=abcXYZ123&", "get_drive_delta.json"),
-            // real pagination continuation shape (OData function-call token, from this fixture's own @odata.nextLink)
+            // the OTHER real continuation shape, from this fixture's own captured @odata.nextLink
+            // (an OData function-call path segment -- rules must accept both)
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta(token=1230919asd190410jlka)", "get_drive_delta.json"),
             // /v1.0/drives/{driveId}/items/{itemId}/activities - no query params allowed by rules
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/items/" + itemId + "/activities", "list_itemActivity.json"),

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
@@ -49,6 +49,8 @@ public class OneDrive_NoAppIds_Tests extends JavaRulesTestBaseCase {
             // /v1.0/drives/{driveId}/root/delta - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta", "get_drive_delta.json"),
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta?token=abcXYZ123&", "get_drive_delta.json"),
+            // real pagination continuation shape (OData function-call token, from this fixture's own @odata.nextLink)
+            InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta(token=1230919asd190410jlka)", "get_drive_delta.json"),
             // /v1.0/drives/{driveId}/items/{itemId}/activities - no query params allowed by rules
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/items/" + itemId + "/activities", "list_itemActivity.json"),
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/items/" + itemId + "/activities?$expand=driveItem", "list_itemActivity.json"),

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/msft/OneDrive_NoAppIds_Tests.java
@@ -41,11 +41,14 @@ public class OneDrive_NoAppIds_Tests extends JavaRulesTestBaseCase {
             InvocationExample.of(baseEndpoint + "/groups", "groups.json"),
             InvocationExample.of(baseEndpoint + "/groups?$top=999&$select=id,mail&$skiptoken=abcXYZ123&$orderby=id&$count=true", "groups.json"),
             // /v1.0/users/{userId}/drives - no query params, and with all allowed query params
-            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives", "list_drives.json"),
-            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_drives.json"),
+            // (fixture's @odata.nextLink embeds the raw, un-pseudonymized AAD user id that Graph
+            // resolves the path to; it must be re-tokenized so a client following the link isn't
+            // blocked by pathParameterSchemas requiring a reversible-pseudonym userId)
+            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives", "list_user_drives.json"),
+            InvocationExample.of(baseEndpoint + "/users/" + userId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_user_drives.json"),
             // /v1.0/groups/{groupId}/drives - no query params, and with all allowed query params
-            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives", "list_drives.json"),
-            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_drives.json"),
+            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives", "list_groups_drives.json"),
+            InvocationExample.of(baseEndpoint + "/groups/" + groupId + "/drives?$select=id,driveType,system&$skiptoken=abcXYZ123&$top=999&$orderby=id&$expand=root", "list_groups_drives.json"),
             // /v1.0/drives/{driveId}/root/delta - no query params, and with all allowed query params
             InvocationExample.of(baseEndpoint + "/drives/" + driveId + "/root/delta", "get_drive_delta.json"),
             // real pagination continuation shape confirmed via live testing against the Graph API


### PR DESCRIPTION
From https://github.com/Worklytics/evalengin/pull/9014
- Support delta token in path, apart from query parameter
- Pseudonymizing delta link when listing user drives

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Psoxy update](https://app.asana.com/1/27145998307022/task/1217917147563451)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op?
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217917147563451