### PR TITLE
Claude query parameters

### DIFF
--- a/docs/sources/anthropic/claude/claude.yaml
+++ b/docs/sources/anthropic/claude/claude.yaml
@@ -182,6 +182,7 @@ endpoints:
       - "updated_at.lte"
       - "updated_at.lt"
       - "before_id"
+      - "order_by"
     transforms:
       - !<pseudonymize>
         jsonPaths:
@@ -530,6 +531,7 @@ endpoints:
       - "created_at.lt"
       - "limit"
       - "page"
+      - "updated_at.gte"
     transforms:
       - !<pseudonymize>
         jsonPaths:
@@ -910,7 +912,9 @@ endpoints:
         session:
           $ref: "#/definitions/Session"
   - pathTemplate: "/v1/compliance/organizations"
-    allowedQueryParams: []
+    allowedQueryParams:
+      - "limit"
+      - "page"
     responseSchema:
       type: "object"
       properties:

--- a/docs/sources/anthropic/claude/claude.yaml
+++ b/docs/sources/anthropic/claude/claude.yaml
@@ -8,6 +8,7 @@ endpoints:
       - "organization_ids[]"
       - "actor_ids[]"
       - "activity_types[]"
+      - "exclude_activity_types[]"
       - "created_at.gte"
       - "created_at.gt"
       - "created_at.lte"

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/anthropic/ClaudeTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/anthropic/ClaudeTests.java
@@ -3,6 +3,7 @@ package co.worklytics.psoxy.rules.anthropic;
 import co.worklytics.psoxy.rules.JavaRulesTestBaseCase;
 import co.worklytics.psoxy.rules.RESTRules;
 import lombok.Getter;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
 
@@ -40,6 +41,8 @@ public class ClaudeTests extends JavaRulesTestBaseCase {
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/chats?project_ids[]=proj_1&user_ids[]=user_1&created_at.gte=2024-01-01T00:00:00Z&updated_at.lte=2024-12-31T00:00:00Z", "chats-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/chats?created_at.gt=2024-01-01T00:00:00Z&created_at.lt=2024-12-31T00:00:00Z", "chats-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/chats?updated_at.gte=2024-01-01T00:00:00Z&updated_at.gt=2024-01-01T00:00:00Z", "chats-response.json"),
+            // org-wide incremental-by-update-time discovery: order_by=updated_at, no user_ids[] (see deprecation notice on this endpoint)
+            InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/chats?order_by=updated_at&updated_at.gte=2024-01-01T00:00:00Z&updated_at.lt=2024-01-02T00:00:00Z&after_id=chat_123", "chats-response.json"),
 
             // Chat Messages endpoint
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/chats/chat_abc123/messages", "chat-messages-response.json"),
@@ -65,6 +68,9 @@ public class ClaudeTests extends JavaRulesTestBaseCase {
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/sessions/local?created_at.gte=2024-01-01T00:00:00Z", "local-sessions-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/sessions/local?created_at.lt=2024-12-31T00:00:00Z", "local-sessions-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/sessions/local?created_at.gte=2024-01-01T00:00:00Z&created_at.lt=2024-12-31T00:00:00Z&limit=50", "local-sessions-response.json"),
+            // poll for sessions active since a previous pass
+            InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/sessions/local?updated_at.gte=2024-06-01T00:00:00Z", "local-sessions-response.json"),
+            InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/sessions/local?created_at.gte=2024-01-01T00:00:00Z&created_at.lt=2024-12-31T00:00:00Z&updated_at.gte=2024-06-01T00:00:00Z", "local-sessions-response.json"),
 
             // Local Session Messages endpoint
             InvocationExample.of("https://api.anthropic.com/v1/compliance/apps/sessions/local/clls_abc123/messages", "local-session-messages-response.json"),
@@ -93,11 +99,50 @@ public class ClaudeTests extends JavaRulesTestBaseCase {
 
             // Organizations endpoint
             InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations", "organizations-response.json"),
+            InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations?limit=1000", "organizations-response.json"),
+            InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations?page=page_abc123&limit=100", "organizations-response.json"),
 
             // Organization Users endpoint
             InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations/org_uuid_123/users", "organization-users-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations/org_uuid_123/users?page=2&limit=100", "organization-users-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/organizations/org_uuid_123/users?page=3&limit=50", "organization-users-response.json")
         );
+    }
+
+    // getExamples() above only exercises response-body sanitization for these params; these
+    // assert the query-param allowlist itself actually gates the request (RESTApiSanitizerImpl,
+    // via allowedQueryParams on each endpoint in claude.yaml).
+
+    @Test
+    void chats_orderByQueryParam_allowed() {
+        // required alongside updated_at.* for org-wide incremental-by-update-time polling
+        // (user_ids[] + updated_at.* is deprecated -- see the endpoint's allowedQueryParams)
+        assertUrlAllowed("https://api.anthropic.com/v1/compliance/apps/chats?order_by=updated_at");
+    }
+
+    @Test
+    void chats_unrecognizedQueryParam_blocked() {
+        assertUrlBlocked("https://api.anthropic.com/v1/compliance/apps/chats?not_a_real_param=1");
+    }
+
+    @Test
+    void localSessions_updatedAtGteQueryParam_allowed() {
+        assertUrlAllowed("https://api.anthropic.com/v1/compliance/apps/sessions/local?updated_at.gte=2024-01-01T00:00:00Z");
+    }
+
+    @Test
+    void localSessions_unrecognizedQueryParam_blocked() {
+        assertUrlBlocked("https://api.anthropic.com/v1/compliance/apps/sessions/local?not_a_real_param=1");
+    }
+
+    @Test
+    void organizations_limitAndPageQueryParams_allowed() {
+        assertUrlAllowed("https://api.anthropic.com/v1/compliance/organizations?limit=100&page=page_abc123");
+    }
+
+    @Test
+    void organizations_unrecognizedQueryParam_blocked() {
+        // was allowedQueryParams: [] (nothing allowed at all) before limit/page were added
+        assertUrlBlocked("https://api.anthropic.com/v1/compliance/organizations?not_a_real_param=1");
     }
 }

--- a/java/core/src/test/java/co/worklytics/psoxy/rules/anthropic/ClaudeTests.java
+++ b/java/core/src/test/java/co/worklytics/psoxy/rules/anthropic/ClaudeTests.java
@@ -31,6 +31,8 @@ public class ClaudeTests extends JavaRulesTestBaseCase {
             InvocationExample.of("https://api.anthropic.com/v1/compliance/activities?before_id=act_456&limit=50", "activities-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/activities?organization_ids[]=org_1&actor_ids[]=user_1&created_at.gte=2024-01-01T00:00:00Z", "activities-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/activities?activity_types[]=claude_chat_created&created_at.gt=2024-01-01T00:00:00Z&created_at.lte=2024-12-31T00:00:00Z", "activities-response.json"),
+            // mutually exclusive with activity_types[]
+            InvocationExample.of("https://api.anthropic.com/v1/compliance/activities?exclude_activity_types[]=claude_user_role_changed&limit=50", "activities-response.json"),
             InvocationExample.of("https://api.anthropic.com/v1/compliance/activities?created_at.gte=2024-01-01T00:00:00Z&created_at.lt=2024-12-31T00:00:00Z", "activities-response.json"),
 
             // Apps Chats endpoint
@@ -112,6 +114,16 @@ public class ClaudeTests extends JavaRulesTestBaseCase {
     // getExamples() above only exercises response-body sanitization for these params; these
     // assert the query-param allowlist itself actually gates the request (RESTApiSanitizerImpl,
     // via allowedQueryParams on each endpoint in claude.yaml).
+
+    @Test
+    void activities_excludeActivityTypesQueryParam_allowed() {
+        assertUrlAllowed("https://api.anthropic.com/v1/compliance/activities?exclude_activity_types[]=claude_user_role_changed");
+    }
+
+    @Test
+    void activities_unrecognizedQueryParam_blocked() {
+        assertUrlBlocked("https://api.anthropic.com/v1/compliance/activities?not_a_real_param=1");
+    }
 
     @Test
     void chats_orderByQueryParam_allowed() {


### PR DESCRIPTION
Rules updated after https://github.com/Worklytics/evalengin/pull/9028: including more query parameter in rules for Claude Compliance

### Fixes
> paste links to issues/tasks in project management
 - []()

### Features
[Psoxy update](https://app.asana.com/1/27145998307022/task/1218064165733321)

 ### Logistics
> paste links to issues/tasks in project management
 - []()


### Change implications

 - dependencies added/changed? **no**
 - something important to note in future release notes?
   - NOTE in `CHANGELOG.md` anything that will show up in `terraform plan`/`apply` that isn't
     obviously a no-op? **no**
   - breaking changes? if in module/example that is NOT marked `alpha`, requires major version
     change **no**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218064165733321