### PR TITLE
Bump json-schema-validator to 3.0.7 (CVE-2026-59889)

### DIFF
--- a/java/gateway-core/pom.xml
+++ b/java/gateway-core/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>3.0.6</version>
+            <version>3.0.7</version>
         </dependency>
 
         <!-- Guava for caching -->


### PR DESCRIPTION
## Summary
- Bump `com.networknt:json-schema-validator` from 3.0.6 to 3.0.7 so the transitive Jackson 3 dependency (`tools.jackson.core:jackson-databind`) moves from 3.1.4 to patched **3.2.1**.
- Closes [CVE-2026-59889](https://github.com/advisories/GHSA-5gvw-p9qm-jgwh) (`GHSA-5gvw-p9qm-jgwh`): `@JsonView` bypassed for `@JsonUnwrapped` container properties on deserialization.

This is the Jackson 3 line pulled in by json-schema-validator. Our first-party Jackson 2 usage (`com.fasterxml.jackson.core:jackson-databind` via `jackson-bom` 2.22.1) is already on a patched release.

### Dependabot alerts
These five alerts are the same CVE reported against each Maven module that inherits the vulnerable Jackson 3 jar:

| Alert | Manifest |
| --- | --- |
| [Dependabot alert 120](https://github.com/Worklytics/psoxy/security/dependabot/120) | `java/core/pom.xml` |
| [Dependabot alert 121](https://github.com/Worklytics/psoxy/security/dependabot/121) | `java/gateway-core/pom.xml` |
| [Dependabot alert 122](https://github.com/Worklytics/psoxy/security/dependabot/122) | `java/impl/aws/pom.xml` |
| [Dependabot alert 123](https://github.com/Worklytics/psoxy/security/dependabot/123) | `java/impl/cmd-line/pom.xml` |
| [Dependabot alert 124](https://github.com/Worklytics/psoxy/security/dependabot/124) | `java/impl/gcp/pom.xml` |

Alert numbers are Dependabot security alerts, not GitHub issue/PR numbers (those IDs already belong to older PRs).

## Test plan
- [x] `mvn -pl gateway-core -am dependency:tree` shows `tools.jackson.core:jackson-databind:3.2.1`
- [x] `JsonSchemaValidationUtilsTest` (34 tests) pass on 3.0.7
- [x] `gateway-core` + `psoxy-core` unit tests pass (OpenNLP model download skipped locally; two `SentenceMetadataProcessorTest` cases need models and are unrelated)
- [ ] Confirm Dependabot alerts 120–124 auto-dismiss after merge

Made with [Cursor](https://cursor.com)