### PR TITLE
MSFT Teams: update onlineMeetings setup documentation

### DIFF
--- a/docs/sources/microsoft-365/msft-teams/README.md
+++ b/docs/sources/microsoft-365/msft-teams/README.md
@@ -46,8 +46,14 @@ And use the user with the "Teams Administrator" for login it.
 
 4. Follow steps on [Configure application access to online meetings or virtual events](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy):
 
-- Add a policy for the application created for the connector, providing its `application id`
+- Add a policy for the application created for the connector, providing its `application id` (client ID) in place of `<application_id>` below:
+```shell
+New-CsApplicationAccessPolicy -Identity Teams-Policy-For-Worklytics -AppIds "<application_id>" -Description "Policy for MSFT Teams used for Worklytics Psoxy connector"
+```
 - Grant the policy to the whole tenant (NOT to any specific application or user)
+```shell
+Grant-CsApplicationAccessPolicy -PolicyName Teams-Policy-For-Worklytics -Global
+```
 
 **Issues**:
 

--- a/infra/modules/worklytics-connector-specs/docs/msft-teams/instructions.tftpl
+++ b/infra/modules/worklytics-connector-specs/docs/msft-teams/instructions.tftpl
@@ -1,0 +1,29 @@
+To enable the connector, you need to allow permissions on the application created for reading OnlineMeetings. You will need Powershell for this.
+
+Please follow the steps below:
+1. Ensure the user you are going to use for running the commands has the "Teams Administrator" role. You can add the role in the
+[Microsoft 365 Admin Center](https://learn.microsoft.com/en-us/microsoft-365/admin/add-users/assign-admin-roles?view=o365-worldwide#assign-a-user-to-an-admin-role-from-active-users)
+
+**NOTE**: About the role, can be assigned through Entra Id portal in Azure portal OR in Entra Admin center https://admin.microsoft.com/AdminPortal/Home. It is possible that even login with an admin account in Entra Admin Center the Teams role is not available to assign to any user; if so, please do it through Azure Portal (Entra Id -> Users -> Assign roles)
+
+2. Install [PowerShell Teams](https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-install)  You can use `pwsh` in the terminal
+    enter to PowerShell.
+3. Then, run the following command. It will open a browser window for login to Microsoft Teams. After login, close the browser and return to the terminal.
+   Please choose the user who has the "Teams Administrator" role.
+```shell
+Connect-MicrosoftTeams
+```
+
+4. Follow steps on [Configure application access to online meetings or virtual events](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy):
+  - Add a policy for the application created for the connector, providing its `application id` (client ID)
+```shell
+New-CsApplicationAccessPolicy -Identity Teams-Policy-For-Worklytics -AppIds "%%entraid.client_id%%" -Description "Policy for MSFT Teams used for Worklytics Psoxy connector"
+```
+  - Grant the policy to the whole tenant (NOT to any specific application or user)
+```shell
+Grant-CsApplicationAccessPolicy -PolicyName Teams-Policy-For-Worklytics -Global
+```
+
+**Issues**:
+- If you receive "access denied" is because no admin role for Teams has been detected. Please close and reopen the Powershell terminal after assigning the role.
+- Commands have been tested over a Powershell (7.4.0) terminal in Windows, installed from Microsoft Store and with Teams Module (5.8.0). It might not work on a different environment

--- a/infra/modules/worklytics-connector-specs/msft-365.tf
+++ b/infra/modules/worklytics-connector-specs/msft-365.tf
@@ -28,7 +28,7 @@ locals {
       "MailboxSettings.Read"
     ]
     environment_variables : local.msft_365_environment_variables
-    external_todo : null
+    external_token_todo : null
     enable_side_output : false
     example_api_calls : [
       "/v1.0/users",
@@ -63,7 +63,7 @@ locals {
         "User.Read.All"
       ],
       environment_variables : local.msft_365_environment_variables
-      external_todo : null
+      external_token_todo : null
       enable_side_output : false
       example_api_calls : [
         "/v1.0/users",
@@ -91,7 +91,7 @@ locals {
         "User.Read.All"
       ]
       environment_variables : local.msft_365_environment_variables
-      external_todo : null
+      external_token_todo : null
       enable_side_output : false
       example_api_calls : [
         "/v1.0/users",
@@ -121,7 +121,7 @@ locals {
         "Group.Read.All",
       ]
       environment_variables : local.msft_365_environment_variables
-      external_todo : null
+      external_token_todo : null
       enable_side_output : false
       example_api_calls : [
         "/v1.0/users",
@@ -168,37 +168,7 @@ locals {
         "/v1.0/communications/callRecords/getPstnCalls(fromDateTime=${urlencode(timeadd(var.example_api_calls_sample_date, "-2160h"))},toDateTime=${urlencode(var.example_api_calls_sample_date)})",
         "/v1.0/users/${local.example_msft_user_guid}/onlineMeetings?\\$filter=JoinWebUrl eq '${local.msft_teams_example_online_meeting_join_url}'"
       ]
-      external_todo : <<EOT
-To enable the connector, you need to allow permissions on the application created for reading OnlineMeetings. You will need Powershell for this.
-
-Please follow the steps below:
-1. Ensure the user you are going to use for running the commands has the "Teams Administrator" role. You can add the role in the
-[Microsoft 365 Admin Center](https://learn.microsoft.com/en-us/microsoft-365/admin/add-users/assign-admin-roles?view=o365-worldwide#assign-a-user-to-an-admin-role-from-active-users)
-
-**NOTE**: About the role, can be assigned through Entra Id portal in Azure portal OR in Entra Admin center https://admin.microsoft.com/AdminPortal/Home. It is possible that even login with an admin account in Entra Admin Center the Teams role is not available to assign to any user; if so, please do it through Azure Portal (Entra Id -> Users -> Assign roles)
-
-2. Install [PowerShell Teams](https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-install)  You can use `pwsh` in the terminal
-    enter to PowerShell.
-3. Then, run the following command. It will open a browser window for login to Microsoft Teams. After login, close the browser and return to the terminal.
-   Please choose the user who has the "Teams Administrator" role.
-```shell
-Connect-MicrosoftTeams
-```
-
-4. Follow steps on [Configure application access to online meetings or virtual events](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy):
-  - Add a policy for the application created for the connector, providing its `application id` (client ID)
-```shell
-New-CsApplicationAccessPolicy -Identity Teams-Policy-For-Worklytics -AppIds "%%entraid.client_id%%" -Description "Policy for MSFT Teams used for Worklytics Psoxy connector"
-```
-  - Grant the policy to the whole tenant (NOT to any specific application or user)
-```shell
-Grant-CsApplicationAccessPolicy -PolicyName Teams-Policy-For-Worklytics -Global
-```
-
-**Issues**:
-- If you receive "access denied" is because no admin role for Teams has been detected. Please close and reopen the Powershell terminal after assigning the role.
-- Commands have been tested over a Powershell (7.4.0) terminal in Windows, installed from Microsoft Store and with Teams Module (5.8.0). It might not work on a different environment
-EOT
+      external_token_todo : templatefile("${path.module}/docs/msft-teams/instructions.tftpl", {})
     },
     "msft-copilot" : {
       source_kind : "msft-copilot"
@@ -214,7 +184,7 @@ EOT
         "AiEnterpriseInteraction.Read.All"
       ]
       environment_variables : local.msft_365_environment_variables
-      external_todo : null
+      external_token_todo : null
       enable_side_output : false
       example_api_calls : [
         "/v1.0/users",

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -129,9 +129,9 @@ locals {
 resource "local_file" "todo-with-external-todo" {
   for_each = local.todos_to_populate
 
-  filename = module.msft_365_grants[each.key].filename
+  filename = local.provision_entraid_apps ? module.msft_365_grants[each.key].filename : module.msft_365_grant_to_shared[0].filename
   content = <<EOT
-${module.msft_365_grants[each.key].todo}
+${local.provision_entraid_apps ? module.msft_365_grants[each.key].todo : module.msft_365_grant_to_shared[0].todo}
 ## Setup
 Then, please follow next instructions to complete the setup:
 

--- a/infra/modules/worklytics-connectors-msft-365/main.tf
+++ b/infra/modules/worklytics-connectors-msft-365/main.tf
@@ -121,23 +121,37 @@ module "msft_365_grant_to_shared" {
 # NOTE: this OVERWRITES the todo_file created by the entra-grant-all-users module, if there's an
 # external_token_todo to append to that file
 locals {
-  todos_to_populate = { for k, v in module.worklytics_connector_specs.enabled_msft_365_connectors :
-    k => v if try(v.external_token_todo != null, false) && var.todos_as_local_files
+  connectors_with_external_todo = { for k, v in module.worklytics_connector_specs.enabled_msft_365_connectors :
+    k => v if try(v.external_token_todo != null, false)
   }
+
+  todos_to_populate = { for k, v in local.connectors_with_external_todo :
+    k => v if var.todos_as_local_files
+  }
+
+  # base grant todo text per connector, whether it has its own app (provisioned) or shares one;
+  # enriched with any external (eg msft-teams PowerShell) instructions when present. Used both by
+  # the `todos` output and the local_file resource below, so both stay in sync.
+  msft_365_todos = merge(
+    local.provision_entraid_apps ? { for k, v in module.msft_365_grants : k => v.todo } : {},
+    {
+      for k, v in local.connectors_with_external_todo : k => join("\n", [
+        local.provision_entraid_apps ? module.msft_365_grants[k].todo : module.msft_365_grant_to_shared[0].todo,
+        "## Setup",
+        "Then, please follow next instructions to complete the setup:",
+        "",
+        replace(v.external_token_todo, "%%entraid.client_id%%",
+        try(module.msft_connection[k].connector.client_id, try(data.azuread_application.existing_connector_app[0].client_id, "")))
+      ])
+    }
+  )
 }
 
 resource "local_file" "todo-with-external-todo" {
   for_each = local.todos_to_populate
 
   filename = local.provision_entraid_apps ? module.msft_365_grants[each.key].filename : module.msft_365_grant_to_shared[0].filename
-  content = <<EOT
-${local.provision_entraid_apps ? module.msft_365_grants[each.key].todo : module.msft_365_grant_to_shared[0].todo}
-## Setup
-Then, please follow next instructions to complete the setup:
-
-${replace(each.value.external_token_todo, "%%entraid.client_id%%",
-try(module.msft_connection[each.key].connector.client_id, data.azuread_application.existing_connector_app[0].client_id))}
-EOT
+  content  = local.msft_365_todos[each.key]
 }
 
 locals {

--- a/infra/modules/worklytics-connectors-msft-365/outputs.tf
+++ b/infra/modules/worklytics-connectors-msft-365/outputs.tf
@@ -5,7 +5,7 @@ output "enabled_api_connectors" {
 
 output "todos" {
   description = "List of TODOS for enabled REST connectors"
-  value       = values(module.msft_365_grants)[*].todo
+  value       = values(local.msft_365_todos)
 }
 
 


### PR DESCRIPTION
> Adds the exact PowerShell commands needed to set up the Teams application access policy, fixes a field-name mismatch that was silently dropping these instructions from the generated setup doc, and extracts the msft-teams instructions into a template file for easier maintenance.

### Fixes
> paste links to issues/tasks in project management
 - Field-name mismatch (`external_todo` vs `external_token_todo`) in `infra/modules/worklytics-connector-specs/msft-365.tf` that silently dropped the PowerShell setup instructions from the generated `TODO - setup msft-teams.md` file during `terraform apply`

### Features
> paste links to issues/tasks in project management
 - Document the exact `New-CsApplicationAccessPolicy` / `Grant-CsApplicationAccessPolicy` PowerShell commands (not just a link to Microsoft's docs) in the `msft-teams` connector README, so customers can copy-paste them directly
 - Extract the msft-teams setup instructions out of an inline heredoc into `infra/modules/worklytics-connector-specs/docs/msft-teams/instructions.tftpl`, following the same pattern already used for `claude`/`cursor`/etc., for easier maintenance

 ### Logistics
> paste links to issues/tasks in project management
 - [Asana task](https://app.asana.com/1/27145998307022/project/1218001620445764/task/1218371531744442)


### Change implications

 - dependencies added/changed? no
 - something important to note in future release notes?
   - The generated `TODO - setup msft-teams.md` will now include the PowerShell section (previously silently dropped due to the field-name bug) - output content differs, but this is a bug fix, not a breaking change
   - not in a module/example marked `alpha`, but this is a bug fix restoring intended behavior, not a breaking change

### Test plan
- [x] `terraform validate` passes in `infra/modules/worklytics-connector-specs` and `infra/modules/worklytics-connectors-msft-365`
- [x] Verified via `terraform console` that `templatefile(...)` on the new `.tftpl` renders byte-identical content to the old heredoc (including the `%%entraid.client_id%%` marker, still substituted downstream in `worklytics-connectors-msft-365/main.tf`)
- [ ] `terraform apply` in a real msft-365 deployment to confirm the generated `TODO - setup msft-teams.md` now includes the PowerShell section with the real client ID substituted in
